### PR TITLE
chemistry reordering to increase cache performance

### DIFF
--- a/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/c/CPickler.py
+++ b/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/c/CPickler.py
@@ -325,7 +325,7 @@ class CPickler(CMill):
 
     def _renderDocument(self, mechanism, options=None):
 
-        reorder_reactions=True
+        reorder_reactions=False
 
         if(reorder_reactions):
 

--- a/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/c/CPickler.py
+++ b/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/c/CPickler.py
@@ -325,10 +325,12 @@ class CPickler(CMill):
 
     def _renderDocument(self, mechanism, options=None):
 
-        plot_react_matrix=True
         reorder_reactions=True
 
         if(reorder_reactions):
+
+            plot_react_matrix = True
+            use_tsp = True #traveling salesman reordering
 
             if(plot_react_matrix):
                 import matplotlib.pyplot as mplt
@@ -342,20 +344,26 @@ class CPickler(CMill):
                 rmat=mechanism._get_reaction_matrix()
                 ax[1].matshow(rmat)
 
-            #mechanism._sort_reactions_within_type_tsp(self.reactionIndex)
-            mechanism._sort_reactions_within_type_random(self.reactionIndex)
+            #reorder reactions
+            if(use_tsp):
+                mechanism._sort_reactions_within_type_tsp(self.reactionIndex)
+            else:
+                mechanism._sort_reactions_within_type_random(self.reactionIndex)
             if(plot_react_matrix):
                 rmat=mechanism._get_reaction_matrix()
                 ax[2].matshow(rmat)
 
-            #mechanism._sort_species_ids_tsp()
-            mechanism._sort_species_ids_random()
+            #reorder species
+            if(use_tsp):
+                mechanism._sort_species_ids_tsp()
+            else:
+                mechanism._sort_species_ids_random()
             if(plot_react_matrix):
                 rmat=mechanism._get_reaction_matrix()
                 ax[3].matshow(rmat)
                 mplt.savefig("rmat_all.pdf")
 
-            #set species in cpickler    
+            #set species after reordering    
             self._setSpecies(mechanism)
 
         else:

--- a/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/c/CPickler.py
+++ b/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/c/CPickler.py
@@ -325,9 +325,42 @@ class CPickler(CMill):
 
     def _renderDocument(self, mechanism, options=None):
 
-        self._setSpecies(mechanism)
+        plot_react_matrix=True
+        reorder_reactions=True
 
-        self.reactionIndex = mechanism._sort_reactions()
+        if(reorder_reactions):
+
+            if(plot_react_matrix):
+                import matplotlib.pyplot as mplt
+                (fig,ax)=mplt.subplots(1,4,figsize=(20,5))
+                rmat=mechanism._get_reaction_matrix()
+                ax[0].matshow(rmat)
+
+            #sort reactions by type
+            self.reactionIndex = mechanism._sort_reactions()
+            if(plot_react_matrix):
+                rmat=mechanism._get_reaction_matrix()
+                ax[1].matshow(rmat)
+
+            #mechanism._sort_reactions_within_type_tsp(self.reactionIndex)
+            mechanism._sort_reactions_within_type_random(self.reactionIndex)
+            if(plot_react_matrix):
+                rmat=mechanism._get_reaction_matrix()
+                ax[2].matshow(rmat)
+
+            #mechanism._sort_species_ids_tsp()
+            mechanism._sort_species_ids_random()
+            if(plot_react_matrix):
+                rmat=mechanism._get_reaction_matrix()
+                ax[3].matshow(rmat)
+                mplt.savefig("rmat_all.pdf")
+
+            #set species in cpickler    
+            self._setSpecies(mechanism)
+
+        else:
+            self._setSpecies(mechanism)
+            self.reactionIndex = mechanism._sort_reactions()
 
         self._includes()
         self._declarations(mechanism)

--- a/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/mechanisms/Mechanism.py
+++ b/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/mechanisms/Mechanism.py
@@ -220,6 +220,9 @@ class Mechanism(object):
                 reactionmat[i][self.species(symbol).id]=coefficient
         
         new_to_old_map=self._tsp_solve(reactionmat,0.001)
+        #new_to_old_map=self._cluster_solve(reactionmat)
+
+        print(new_to_old_map)
 
         return(new_to_old_map)
 
@@ -366,20 +369,28 @@ class Mechanism(object):
     def _cluster_solve(self,mat):
 
         from sklearn.cluster import AgglomerativeClustering
+        import numpy as npy
 
-        #do reaction reordering
-        nclus=mat.shape[0]/2
+        new_to_old_map=npy.array([])
 
-        clustering = AgglomerativeClustering(n_clusters=nclus, compute_full_tree=True,
-                            affinity='euclidean', linkage='ward')
-        y=clustering.fit_predict(reactionmat)
-        print(y)
+        if(mat.shape[0] > 1):
 
-        new_to_old_map=[]
-        for i in range(nclus):
-            for j in range(len(y)):
-                if(y[j]==i):
-                    new_to_old_map.append(j)
+            nclus=mat.shape[0]/4
+            #nclus=2
+
+            clustering = AgglomerativeClustering(n_clusters=nclus, compute_full_tree=True, affinity='l1', linkage='average')
+            y=clustering.fit_predict(mat)
+
+            for i in range(nclus):
+                for j in range(len(y)):
+                    if(y[j]==i):
+                        new_to_old_map = npy.append(new_to_old_map,j)
+
+            new_to_old_map=new_to_old_map.astype(int)
+
+
+        else:
+            new_to_old_map=npy.arange(mat.shape[0])
 
         return(new_to_old_map)
 
@@ -418,7 +429,6 @@ class Mechanism(object):
             newmat=npy.zeros((nrows+1,ncols))
             newmat[1:(nrows+1),:]=mat
             order=two_opt(newmat,improvement_threshold)
-            print(order[1:(nrows+1)]-1)
             return(order[1:(nrows+1)]-1)
         else:
             return(npy.array([]))
@@ -443,6 +453,8 @@ class Mechanism(object):
         new_to_old_map = npy.random.permutation(nSpecies)
 
         self._reorder_species_from_map(new_to_old_map)
+
+    #===================================================================
 
 
     # other methods  


### PR DESCRIPTION
Some new functions are added in fuego to reorder chemistry so that the memory performance can be improved. Reactions are clustered in a way that the production rate calculation reuses the same/similar species data. The species are reordered in a way that reactions tend to use species ordered continuously in memory. 

We achieve this by constructing a reaction - species matrix and using a traveling salesman reorodering of the rows and columns.

Right now, this reordering has not been turned off in the cpickler (there is a flag that can be used to turn it on) by default and the fuego generated files in Mechanism/models have not been changed.

Also adding a picture to explain this. see pdf below
[rmat_all.pdf](https://github.com/AMReX-Combustion/PelePhysics/files/3040360/rmat_all.pdf)

This shows a matrix representation of the LuDME chemistry (39 spec, 169 reactions). Each row is a reaction and the non-zero (colored) entries are the corresponding species. I have also added all 3rd bodies involved also as a participating specie in a reaction.

Fig 1 from left: the matrix straight out of chemkin
Fig 2 from left: after fuego sorts by reaction type (troe,sri etc..) - this is the DEFAULT
Fig3 from left: after the rows are reordered
Fig4 from left: after columns are reordered
