### PR TITLE
Remove AMReX F_interfaces and amrex_parallel_module from PelePhysics.

### DIFF
--- a/Eos/Fuego/eos.F90
+++ b/Eos/Fuego/eos.F90
@@ -36,7 +36,6 @@ contains
   subroutine eos_init(small_temp, small_dens)
 
     use extern_probin_module
-    use amrex_parallel_module
     use iso_c_binding, only : c_double, c_size_t
 
     implicit none


### PR DESCRIPTION
This allows me to build with the Intel compiler.