### PR TITLE
Trivial fix to warning from Intel compiler

### DIFF
--- a/Reactions/Fuego/actual_reactor.F90
+++ b/Reactions/Fuego/actual_reactor.F90
@@ -381,7 +381,7 @@ contains
 
     integer,        intent(in)  :: neq, npt
     real(amrex_real),intent(in)  :: y(neq,npt), t
-    real(amrex_real),intent(out) :: pd(neq,neq)
+    real(amrex_real),intent(inout) :: pd(neq,neq)
 
     call amrex_error('DVODE version: Analytic Jacobian not yet implemented')
 


### PR DESCRIPTION
Set as `intent(out)` and currently isn't being set.