### PR TITLE
OMP fixes for PeleC

### DIFF
--- a/Reactions/Fuego/actual_reactor.F90
+++ b/Reactions/Fuego/actual_reactor.F90
@@ -16,7 +16,7 @@ module reactor_module
 
   logical, save, private :: reactor_initialized = .false.
 
-  !$omp threadprivate(vodeVec,cdot,rhoydot_ext,ydot_ext,rhoedot_ext,rhoe_init,time_init,rhohdot_ext,rhoh_init,hdot_ext,h_init,time_old,iloc,jloc,kloc,eos_state)
+  !$omp threadprivate(vodeVec,cdot,rhoydot_ext,ydot_ext,rhoedot_ext,rhoe_init,time_init,rhohdot_ext,rhoh_init,hdot_ext,h_init,pressureInit,time_old,iloc,jloc,kloc,ie,eos_state,reactor_initialized)
 
 contains
 

--- a/Support/Fuego/Evaluation/vode_module.f90
+++ b/Support/Fuego/Evaluation/vode_module.f90
@@ -14,7 +14,7 @@ module vode_module
   integer, allocatable, save :: vodeiwork(:), vodeipar(:)
   integer, save :: lvoderwork, lvodeiwork
 
-!$omp threadprivate(voderwork,vodeiwork,voderpar,vodeipar)
+  !$omp threadprivate(verbose,itol,order,maxstep,mf,use_ajac,save_ajac,always_new_j,stiff,neq,voderwork,vodeiwork,voderpar,vodeipar,lvoderwork,lvodeiwork,rtol,atol)
 
 contains
 
@@ -63,7 +63,6 @@ contains
 
     end if
 
-    !$omp parallel
     allocate(voderwork(lvoderwork))
     allocate(vodeiwork(lvodeiwork))
 
@@ -76,7 +75,6 @@ contains
     allocate(vodeipar(1))
 
     call setfirst(.true.)
-    !$omp end parallel
 
   end subroutine vode_init
 


### PR DESCRIPTION
Some variables were missing in `threadprivate` and since in PeleC we are/will be calling vode in an OMP parallel region, we can't do so in vode as well.