### PR TITLE
Changes to nspecies and nreactions parameter checks to allow for Null Reactions_dir

### DIFF
--- a/Reactions/network.f90
+++ b/Reactions/network.f90
@@ -35,12 +35,12 @@ contains
 
     ! Check to make sure, and if not, throw an error.
 
-    if ( nspecies .le. 1 ) then
-       call bl_error("Network cannot have a nonpositive number of species.")
+    if ( nspecies .lt. 1 ) then
+       call bl_error("Network cannot have less than one species.")
     endif
 
-    if ( nreactions .le. 0 ) then
-       call bl_error("Network cannot have a negative number of reactions.")
+    if ( nreactions .lt. 0 ) then
+       call bl_error("Network cannot have less than zero reactions.")
     endif
 
     if ( naux .lt. 0 ) then


### PR DESCRIPTION
Maybe I'm doing something wrong, but the PeleC HIT case uses the `Reactions_dir=Null`, which sets these parameters:
```
  integer, parameter :: nspecies    = 1 ! number of species
  integer, parameter :: nreactions  = 0 ! number of reactions
```
which seem valid but they don't currently pass the error checks on the `nspecies` and `nreactions` parameters without these changes.