### PR TITLE
Add missing implicit none statements on subroutines

### DIFF
--- a/Eos/Fuego/eos.F90
+++ b/Eos/Fuego/eos.F90
@@ -27,6 +27,7 @@ module eos_module
   interface
      subroutine amrex_array_init_snan (p, nelem) bind(C,name="amrex_array_init_snan")
        use iso_c_binding, only : c_double, c_size_t
+       implicit none
        real(c_double),intent(inout) :: p
        integer (kind=c_size_t),intent(in),value :: nelem
      end subroutine amrex_array_init_snan

--- a/Eos/Soave-Redlich-Kwong/eos.F90
+++ b/Eos/Soave-Redlich-Kwong/eos.F90
@@ -42,6 +42,7 @@ module eos_module
   interface
      subroutine amrex_array_init_snan (p, nelem) bind(C,name="amrex_array_init_snan")
        use iso_c_binding, only : c_double, c_size_t
+       implicit none
        real(c_double),intent(inout) :: p
        integer (kind=c_size_t),intent(in),value :: nelem
      end subroutine amrex_array_init_snan
@@ -1592,6 +1593,7 @@ end subroutine SRK_EOS_GetMixtureCp
 ! Given a mixture composition calculate mixture enthalpy using SRK EOS  !  
 !=======================================================================!
 subroutine SRK_EOS_GetMixture_H(state)
+  implicit none
   type (eos_t), intent(inout) :: state
   real(amrex_real) :: tau, K1
   real(amrex_real) :: eosT1Denom, eosT3Denom 
@@ -1876,6 +1878,7 @@ end subroutine SRK_EOS_GetSpeciesE
 !  the following derivatives for testing, dP/dT, dP/dtau, dH/dtau !
 !=================================================================!
 subroutine  SRK_EOS_GetDerivative(state)
+  implicit none
   type (eos_t), intent(inout) :: state
   integer :: i,j
   real(amrex_real) :: tau, K1

--- a/Reactions/Fuego/actual_reactor.F90
+++ b/Reactions/Fuego/actual_reactor.F90
@@ -31,6 +31,7 @@ contains
     use extern_probin_module, only : new_Jacobian_each_cell
     use amrex_omp_module
 
+    implicit none
     integer(c_int),  intent(in   ) :: iE_in
     integer(c_int),  intent(in   ), optional :: Ncells
     integer :: verbose, itol, order, maxstep
@@ -86,6 +87,7 @@ contains
          voderwork, vodeiwork, lvoderwork, lvodeiwork, voderpar, vodeipar
     use eos_module
 
+    implicit none
     real(amrex_real),   intent(inout) :: rY_in(nspecies+1),rY_src_in(nspecies)
     real(amrex_real),   intent(inout) :: rX_in,rX_src_in,P_in
     real(amrex_real),   intent(inout) :: dt_react, time
@@ -316,6 +318,7 @@ contains
     use chemistry_module, only : molecular_weight
     use eos_module
 
+    implicit none
     integer,         intent(in)   :: neq, ipar(*)
     real(amrex_real), intent(in)  :: y(neq), time, rpar(*)
     real(amrex_real), intent(out) :: ydot(neq)
@@ -379,6 +382,7 @@ contains
   subroutine f_jac(neq, npt, y, t, pd)
     use amrex_error_module
 
+    implicit none
     integer,        intent(in)  :: neq, npt
     real(amrex_real),intent(in)  :: y(neq,npt), t
     real(amrex_real),intent(inout) :: pd(neq,neq)
@@ -390,6 +394,7 @@ contains
 !*** FINALIZE ROUTINES ***!
   subroutine reactor_close() bind(C, name="reactor_close")
 
+    implicit none
     call destroy(eos_state)
 
     reactor_initialized = .false.

--- a/Reactions/Fuego/react_type.F90
+++ b/Reactions/Fuego/react_type.F90
@@ -35,10 +35,12 @@ module react_type_module
 contains
 
   subroutine react_build(r)
+    implicit none
     type(react_t), intent(inout) :: r
   end subroutine react_build
 
   subroutine react_destroy(r)
+    implicit none
     type(react_t), intent(inout) :: r
   end subroutine react_destroy
   

--- a/Reactions/Null_air/actual_reactor.F90
+++ b/Reactions/Null_air/actual_reactor.F90
@@ -11,6 +11,7 @@ contains
 
     use, intrinsic :: iso_c_binding
 
+    implicit none
     integer(c_int),  intent(in   ) :: iE_in
 
     !nothing needed here
@@ -28,6 +29,7 @@ contains
     
     use eos_module
 
+    implicit none
     real(amrex_real),   intent(inout) :: rY_in(nspec+1),rY_src_in(nspec)
     real(amrex_real),   intent(inout) :: rX_in,rX_src_in,P_in
     real(amrex_real),   intent(inout) :: dt_react, time

--- a/Testing/Exec/EosEval/main_nd.F90
+++ b/Testing/Exec/EosEval/main_nd.F90
@@ -12,6 +12,7 @@ contains
     use eos_module
     use transport_module
 
+    implicit none
     integer :: namlen
     integer :: name(namlen)
 
@@ -34,6 +35,7 @@ contains
   subroutine extern_close() bind(C, name="extern_close")
 
     use transport_module
+    implicit none
 
     call transport_close()
 

--- a/Testing/Exec/ReactEval/main_nd.F90
+++ b/Testing/Exec/ReactEval/main_nd.F90
@@ -12,6 +12,7 @@ contains
     use eos_module
     use transport_module
 
+    implicit none
     integer :: namlen
     integer :: name(namlen)
 
@@ -33,6 +34,7 @@ contains
   subroutine extern_init_reactor() bind(C, name="extern_init_reactor")
 
     use reactor_module
+    implicit none
 
     call reactor_init(1)
 
@@ -42,6 +44,7 @@ contains
   subroutine extern_close() bind(C, name="extern_close")
 
     use transport_module
+    implicit none
 
     call transport_close()
 

--- a/Testing/Exec/ReactEvalCVODE/main_nd.F90
+++ b/Testing/Exec/ReactEvalCVODE/main_nd.F90
@@ -15,6 +15,7 @@ contains
     use eos_module
     use transport_module
 
+    implicit none
     integer :: namlen
     integer :: name(namlen)
 
@@ -41,6 +42,7 @@ contains
   subroutine extern_close() bind(C, name="extern_close")
 
     use transport_module
+    implicit none
 
     call transport_close()
 

--- a/Testing/Exec/ReactEvalCVODE_regTest/main_nd.F90
+++ b/Testing/Exec/ReactEvalCVODE_regTest/main_nd.F90
@@ -15,6 +15,7 @@ contains
     use eos_module
     use transport_module
 
+    implicit none
     integer :: namlen
     integer :: name(namlen)
 
@@ -41,6 +42,7 @@ contains
   subroutine extern_close() bind(C, name="extern_close")
 
     use transport_module
+    implicit none
 
     call transport_close()
 

--- a/Testing/Exec/TranEval/main_nd.F90
+++ b/Testing/Exec/TranEval/main_nd.F90
@@ -12,6 +12,7 @@ contains
     use eos_module
     use transport_module
 
+    implicit none
     integer :: namlen
     integer :: name(namlen)
 
@@ -34,6 +35,7 @@ contains
   subroutine extern_close() bind(C, name="extern_close")
 
     use transport_module
+    implicit none
 
     call transport_close()
 

--- a/Transport/EGLib/actual_transport.f90
+++ b/Transport/EGLib/actual_transport.f90
@@ -44,6 +44,7 @@ contains
 
 
   subroutine build_internal(npts)
+    implicit none
     integer, intent(in) :: npts
 
     call egzini(npts)
@@ -65,6 +66,8 @@ contains
 
   subroutine destroy_internal
 
+    implicit none
+
     deallocate(Tp)
     deallocate(L1)
     deallocate(L2)
@@ -81,6 +84,7 @@ contains
 
     use amrex_error_module
     
+    implicit none
     type (wtr_t), intent(in   ) :: which
     type (trv_t), intent(inout) :: coeff
     integer :: i

--- a/Transport/Simple/actual_transport.f90
+++ b/Transport/Simple/actual_transport.f90
@@ -82,6 +82,7 @@ contains
 
 
   subroutine build_internal(npts)
+    implicit none
     integer, intent(in) :: npts
 
     if (npts_smp .ne. npts .and. npts.gt.0) then
@@ -108,6 +109,8 @@ contains
 
   subroutine destroy_internal
 
+    implicit none
+
     deallocate(Tloc)
     deallocate(rholoc)
     deallocate(Yloc)
@@ -130,6 +133,7 @@ contains
 
     use amrex_error_module
     
+    implicit none
     type (wtr_t), intent(in   ) :: which
     type (trv_t), intent(inout) :: coeff
     integer :: i, n, nn

--- a/Transport/Simple/actual_transport_nonideal.f90
+++ b/Transport/Simple/actual_transport_nonideal.f90
@@ -173,6 +173,7 @@ contains
 
 
   subroutine build_internal(npts)
+    implicit none
     integer, intent(in) :: npts
 
     if (npts_smp .ne. npts .and. npts.gt.0) then
@@ -198,6 +199,8 @@ contains
 
   subroutine destroy_internal
 
+    implicit none
+
     deallocate(Tloc)
     deallocate(rholoc)
     deallocate(Yloc)
@@ -218,6 +221,8 @@ contains
   subroutine actual_transport(which, coeff)
 
     use amrex_error_module
+
+    implicit none
 
     type (wtr_t), intent(in   ) :: which
     type (trv_t), intent(inout) :: coeff

--- a/Transport/Sutherland/actual_transport.f90
+++ b/Transport/Sutherland/actual_transport.f90
@@ -38,6 +38,7 @@ contains
 
 
   subroutine build_internal(npts)
+    implicit none
     integer, intent(in) :: npts
 
     if (npts_suth .ne. npts .and. npts.gt.0) then
@@ -53,6 +54,8 @@ contains
 
 
   subroutine destroy_internal
+
+    implicit none
 
     deallocate(Tp)
     deallocate(Cpp)

--- a/Transport/transport_type.f90
+++ b/Transport/transport_type.f90
@@ -36,6 +36,7 @@ module transport_type_module
 contains
 
   subroutine trv_build(trv,n)    
+    implicit none
     type(trv_t), intent(inout) :: trv
     integer, intent(in) :: n
     integer :: i
@@ -54,6 +55,7 @@ contains
   end subroutine trv_build
   
   subroutine trv_destroy(trv)
+    implicit none
     type(trv_t), intent(inout) :: trv
     integer :: i
     if (trv%npts .gt. 0) then


### PR DESCRIPTION
I noticed some inconsistencies between compilers with PeleC and it looked like it was caused by some missing `implicit none`s so I tried to catch them all in PelePhysics here first.