### PR TITLE
Fix preprocessor defines for ionic species

### DIFF
--- a/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/c/CPickler.py
+++ b/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/c/CPickler.py
@@ -853,7 +853,15 @@ class CPickler(CMill):
         self._write('/* Species */')
         nb_spec = 0
         for species in mechanism.species():
-            self._write('#define %s_ID %d' % ((species.symbol).replace("*","D").replace("-","").replace(")","").replace("(",""), species.id) )
+            s = species.symbol.strip()
+            # Ionic species
+            if s[-1] == '-': s = s[:-1] + 'm'
+            if s[-1] == '+': s = s[:-1] + 'p'
+            # Excited species
+            s = s.replace('*', 's')
+            # Remove other characters not allowed in preprocessor defines
+            s = s.replace('-', '').replace('(','').replace(')','')
+            self._write('#define %s_ID %d' % (s, species.id))
             nb_spec += 1
         self._write()
         self._write("#define NUM_ELEMENTS %d" % (nb_elem))


### PR DESCRIPTION
This pull request fixes the preprocessor defines for ionic species, i.e. species names with trailing '-' and '+'.
Also, excited species are now denoted by a lower-case 's' (= star). I can change this to, e.g. 'star', to be more clear or revert it back to 'D', if you think that’s better.

This fixes #39 .
