### PR TITLE
Hari/gpu

### DIFF
--- a/Docs/cvode/source/CvodeInPP.rst
+++ b/Docs/cvode/source/CvodeInPP.rst
@@ -570,7 +570,7 @@ To run on GPUs, `AMREX` should be build with CUDA enabled. To do so, add this li
 
     USE_CUDA   = TRUE
 
-Then, the CUDA features of CVODE are enabled in `PelePhysics` via a specific ``USE_CUDA_CVODE`` flag:
+Then, the CUDA features of CVODE are enabled in `PelePhysics` via a specific ``USE_CUDA_SUNDIALS_PP`` flag:
 
 .. code-block:: c++
 
@@ -580,9 +580,20 @@ Then, the CUDA features of CVODE are enabled in `PelePhysics` via a specific ``U
     #######################
     # Activates use of SUNDIALS: CVODE (default)
     USE_SUNDIALS_PP = TRUE
-    
-    USE_CUDA_CVODE = TRUE 
-    
+    ifeq ($(USE_SUNDIALS_PP), TRUE)  
+        # provide location of sundials lib if needed 
+        #SUNDIALS_LIB_DIR=$(PELE_PHYSICS_HOME)/ThirdParty/sundials/instdir/lib/
+        # use ARKODE: if FALSE then CVODE is used
+        USE_ARKODE_PP = FALSE
+        # use KLU sparse features -- only useful if CVODE is used on CPU
+        USE_KLU_PP = FALSE
+        # Activates GPU version
+        USE_CUDA_SUNDIALS_PP = TRUE
+    else
+      # Activates use of Hari explicit RK
+      # will only work if USE_SUNDIALS_PP = FALSE
+      USE_RK64_PP = FALSE
+    endif
     #######################
     ...
 

--- a/Reactions/Fuego/GPU/actual_CARKODE_GPU.cpp
+++ b/Reactions/Fuego/GPU/actual_CARKODE_GPU.cpp
@@ -1,0 +1,253 @@
+#include <GPU/actual_CARKODE_GPU.h> 
+#include <AMReX_ParmParse.H>
+#include <chemistry_file.H>
+#include "mechanism.h"
+#include <Fuego_EOS.H>
+#include <AMReX_Gpu.H>
+
+AMREX_GPU_DEVICE_MANAGED  int eint_rho = 1; // in/out = rhoE/rhoY
+AMREX_GPU_DEVICE_MANAGED  int enth_rho = 2; // in/out = rhoH/rhoY 
+AMREX_GPU_DEVICE_MANAGED int use_erkode=0;
+
+/******************************************************************************************/
+/* Initialization routine, called once at the begining of the problem */
+int reactor_info(const int* reactor_type, const int* Ncells)
+{
+    amrex::ParmParse pp("ode");
+    pp.query("use_erkode", use_erkode);
+    if(use_erkode==1)
+    {
+        amrex::Print()<<"Using ERK ODE\n";
+    }
+    else
+    {
+        amrex::Print()<<"Using ARK ODE\n";
+    }
+    return(0);
+}
+/******************************************************************************************/
+/* Main call routine */
+int react(realtype *rY_in, realtype *rY_src_in, 
+        realtype *rX_in, realtype *rX_src_in,
+        realtype *dt_react, realtype *time,
+        const int* reactor_type,const int* Ncells, cudaStream_t stream,
+        double reltol,double abstol)
+{
+
+    int NCELLS, NEQ, neq_tot,flag;
+    realtype time_init, time_out;
+    void *arkode_mem    = NULL;
+    N_Vector y         = NULL;
+
+    NEQ = NUM_SPECIES;
+    NCELLS         = *Ncells;
+    neq_tot        = (NEQ + 1) * NCELLS;
+
+    /* User data */
+    UserData user_data;
+    BL_PROFILE_VAR("AllocsInARKODE", AllocsARKODE);
+    cudaMallocManaged(&user_data, sizeof(struct ARKODEUserData));
+    BL_PROFILE_VAR_STOP(AllocsARKODE);
+    user_data->ncells_d[0]             = NCELLS;
+    user_data->neqs_per_cell[0]        = NEQ;
+    user_data->ireactor_type           = *reactor_type; 
+    user_data->iverbose                = 1;
+    user_data->stream                  = stream;
+    user_data->nbBlocks                = NCELLS/32;
+    user_data->nbThreads               = 32;
+
+    y = N_VNewManaged_Cuda(neq_tot);
+    N_VSetCudaStream_Cuda(y, &stream);
+
+
+    BL_PROFILE_VAR_START(AllocsARKODE);
+    /* Define vectors to be used later in creact */
+    cudaMalloc(&(user_data->rhoe_init), NCELLS*sizeof(double));
+    cudaMalloc(&(user_data->rhoesrc_ext), NCELLS*sizeof(double));
+    cudaMalloc(&(user_data->rYsrc), (NCELLS*NEQ)*sizeof(double));
+    BL_PROFILE_VAR_STOP(AllocsARKODE);
+
+    /* Get Device MemCpy of in arrays */
+    /* Get Device pointer of solution vector */
+    realtype *yvec_d      = N_VGetDeviceArrayPointer_Cuda(y);
+    BL_PROFILE_VAR("AsyncCpy", AsyncCpy);
+    // rhoY,T
+    cudaMemcpy(yvec_d, rY_in, sizeof(realtype) * ((NEQ+1)*NCELLS), cudaMemcpyHostToDevice);
+    // rhoY_src_ext
+    cudaMemcpy(user_data->rYsrc, rY_src_in, (NEQ*NCELLS)*sizeof(double), cudaMemcpyHostToDevice);
+    // rhoE/rhoH
+    cudaMemcpy(user_data->rhoe_init, rX_in, sizeof(realtype) * NCELLS, cudaMemcpyHostToDevice);
+    cudaMemcpy(user_data->rhoesrc_ext, rX_src_in, sizeof(realtype) * NCELLS, cudaMemcpyHostToDevice);
+    BL_PROFILE_VAR_STOP(AsyncCpy)
+
+    /* Initial time and time to reach after integration */
+    time_init = *time;
+    time_out  = *time + (*dt_react);
+    
+    if(use_erkode == 0)
+    {
+       arkode_mem = ARKStepCreate(cF_RHS, NULL, *time, y);
+        flag = ARKStepSetUserData(arkode_mem, static_cast<void*>(user_data));
+        flag = ARKStepSStolerances(arkode_mem, reltol, abstol); 
+        flag = ARKStepResStolerance(arkode_mem, abstol);
+        flag = ARKStepEvolve(arkode_mem, time_out, y, &time_init, ARK_NORMAL);      /* call integrator */
+    }
+    else
+    {
+       arkode_mem = ERKStepCreate(cF_RHS, *time, y);
+       flag = ERKStepSetUserData(arkode_mem, static_cast<void*>(user_data));
+       flag = ERKStepSStolerances(arkode_mem, reltol, abstol); 
+       flag = ERKStepEvolve(arkode_mem, time_out, y, &time_init, ARK_NORMAL);      /* call integrator */
+    }
+
+#ifdef MOD_REACTOR
+    /* If reactor mode is activated, update time */
+    *dt_react = time_init - *time;
+    *time  = time_init + (*dt_react);
+#endif
+    /* Pack data to return in main routine external */
+    BL_PROFILE_VAR_START(AsyncCpy);
+    cudaMemcpy(rY_in, yvec_d, ((NEQ+1)*NCELLS)*sizeof(realtype), cudaMemcpyDeviceToHost);
+
+    for  (int i = 0; i < NCELLS; i++) {
+        rX_in[i] = rX_in[i] + (*dt_react) * rX_src_in[i];
+    }
+    BL_PROFILE_VAR_STOP(AsyncCpy);
+
+
+    /* Get estimate of how hard the integration process was */
+    long int nfe,nfi;
+    if(use_erkode==0)
+    {
+        flag = ARKStepGetNumRhsEvals(arkode_mem, &nfe, &nfi);
+    }
+    else
+    {
+        flag = ERKStepGetNumRhsEvals(arkode_mem, &nfe);
+    }
+
+    //cleanup
+    N_VDestroy(y);          /* Free the y vector */
+    if(use_erkode==0)
+    {
+        ARKStepFree(&arkode_mem);
+    }
+    else
+    {
+        ERKStepFree(&arkode_mem);
+    }
+
+    cudaFree(user_data->rhoe_init);
+    cudaFree(user_data->rhoesrc_ext);
+    cudaFree(user_data->rYsrc);
+    cudaFree(user_data);
+
+    return nfe;
+}
+/******************************************************************************************/
+static int cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, 
+        void *user_data)
+{
+
+    BL_PROFILE_VAR("fKernelSpec()", fKernelSpec);
+
+    cudaError_t cuda_status = cudaSuccess;
+
+    /* Get Device pointers for Kernel call */
+    realtype *yvec_d      = N_VGetDeviceArrayPointer_Cuda(y_in);
+    realtype *ydot_d      = N_VGetDeviceArrayPointer_Cuda(ydot_in);
+
+    // allocate working space 
+    UserData udata = static_cast<ARKODEUserData*>(user_data);
+    udata->dt_save = t;
+
+    const auto ec = Gpu::ExecutionConfig(udata->ncells_d[0]);   
+    //amrex::launch_global<<<ec.numBlocks, ec.numThreads, ec.sharedMem, udata->stream>>>(
+    amrex::launch_global<<<udata->nbBlocks, udata->nbThreads, ec.sharedMem, udata->stream>>>(
+            [=] AMREX_GPU_DEVICE () noexcept {
+            for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
+                    icell < udata->ncells_d[0]; icell += stride) {
+            fKernelSpec(icell, user_data, yvec_d, ydot_d, udata->rhoe_init, 
+                    udata->rhoesrc_ext, udata->rYsrc);    
+            }
+            }); 
+
+    cuda_status = cudaStreamSynchronize(udata->stream);  
+    assert(cuda_status == cudaSuccess);
+
+    BL_PROFILE_VAR_STOP(fKernelSpec);
+
+    return(0);
+}
+/******************************************************************************************/
+/**********************************/
+/*
+ * CUDA kernels
+ */
+AMREX_GPU_DEVICE
+inline void 
+fKernelSpec(int icell, void *user_data, 
+        realtype *yvec_d, realtype *ydot_d,  
+        double *rhoe_init, double *rhoesrc_ext, double *rYs)
+{
+    UserData udata = static_cast<ARKODEUserData*>(user_data);
+
+    EOS eos;
+
+    amrex::GpuArray<amrex::Real,NUM_SPECIES> mw;
+    amrex::GpuArray<amrex::Real,NUM_SPECIES> massfrac;
+    amrex::GpuArray<amrex::Real,NUM_SPECIES> ei_pt;
+    amrex::GpuArray<amrex::Real,NUM_SPECIES> cdots_pt;
+    amrex::Real Cv_pt, rho_pt, temp_pt, nrg_pt;
+
+    int offset = icell * (NUM_SPECIES + 1); 
+
+    /* MW CGS */
+    get_mw(mw.arr);
+
+    /* rho */ 
+    rho_pt = 0.0;
+    for (int n = 0; n < NUM_SPECIES; n++) {
+        rho_pt = rho_pt + yvec_d[offset + n];
+    }
+
+    /* Yks, C CGS*/
+    for (int i = 0; i < NUM_SPECIES; i++){
+        massfrac[i] = yvec_d[offset + i] / rho_pt;
+    }
+
+    /* NRG CGS */
+    nrg_pt = (rhoe_init[icell] + rhoesrc_ext[icell]*(udata->dt_save)) /rho_pt;
+
+    /* temp */
+    temp_pt = yvec_d[offset + NUM_SPECIES];
+
+    /* Additional var needed */
+    if (udata->ireactor_type == 1){
+        /* UV REACTOR */
+        eos.eos_EY2T(massfrac.arr, nrg_pt, temp_pt);
+        eos.eos_T2EI(temp_pt, ei_pt.arr);
+        eos.eos_TY2Cv(temp_pt, massfrac.arr, Cv_pt);
+    }else {
+        /* HP REACTOR */
+        eos.eos_HY2T(massfrac.arr, nrg_pt, temp_pt);
+        eos.eos_TY2Cp(temp_pt, massfrac.arr, Cv_pt);
+        eos.eos_T2HI(temp_pt, ei_pt.arr);
+    }
+
+    eos.eos_RTY2W(rho_pt, temp_pt, massfrac.arr, cdots_pt.arr);
+
+    /* Fill ydot vect */
+    ydot_d[offset + NUM_SPECIES] = rhoesrc_ext[icell];
+    for (int i = 0; i < NUM_SPECIES; i++){
+        ydot_d[offset + i]           = cdots_pt[i] * mw[i] + rYs[icell * NUM_SPECIES + i];
+        ydot_d[offset + NUM_SPECIES] = ydot_d[offset + NUM_SPECIES]  - ydot_d[offset + i] * ei_pt[i];
+    }
+    ydot_d[offset + NUM_SPECIES] = ydot_d[offset + NUM_SPECIES] /(rho_pt * Cv_pt);
+    
+    /* Fill ydot vect */
+    /*ydot_d[offset + NUM_SPECIES] = 1e6;
+    for (int i = 0; i < NUM_SPECIES; i++){
+        ydot_d[offset + i]           = 0.0;
+    }*/
+}

--- a/Reactions/Fuego/GPU/actual_CARKODE_GPU.h
+++ b/Reactions/Fuego/GPU/actual_CARKODE_GPU.h
@@ -1,0 +1,57 @@
+#include <math.h>
+#include <iostream>
+#include <cstring>
+#include <chrono>
+#include <cassert>
+#include <assert.h>
+
+#include <arkode/arkode_arkstep.h>
+#include <arkode/arkode_erkstep.h>
+
+#include <nvector/nvector_cuda.h>
+#include <nvector/nvector_serial.h>    /* access to serial N_Vector            */
+
+#include <cuda_runtime.h>
+#include <cublas_v2.h>
+#include <cusolverSp.h>
+#include <cusparse.h>
+#include <cuda_runtime_api.h>
+
+#include <AMReX_Print.H>
+/**********************************/
+
+typedef struct ARKODEUserData {
+    /* Checks */
+    bool reactor_arkode_initialized;
+    /* Base items */
+    int ncells_d[1];
+    int neqs_per_cell[1];
+    int iverbose;
+    int ireactor_type;
+    double dt_save;
+
+    double *rhoe_init = NULL;
+    double *rhoesrc_ext = NULL;
+    double *rYsrc = NULL;
+    cudaStream_t stream;
+    int nbBlocks;
+    int nbThreads;
+} *UserData;
+
+int reactor_info(const int* cvode_iE, const int* Ncells);
+
+static int cF_RHS(realtype t, N_Vector y_in, N_Vector ydot, void *user_data);
+
+void reactor_close();
+    
+int react(realtype *rY_in, realtype *rY_src_in, 
+            realtype *rX_in, realtype *rX_src_in, 
+            realtype *dt_react, realtype *time,
+            const int* cvode_iE, const int* Ncells, cudaStream_t stream,double reltol=1e-6,double abstol=1e-10);
+
+AMREX_GPU_DEVICE
+inline
+void
+fKernelSpec(int ncells, void *user_data, 
+		            realtype *yvec_d, realtype *ydot_d,  
+		            double *rhoX_init, double *rhoXsrc_ext, double *rYs);

--- a/Reactions/Fuego/Make.package
+++ b/Reactions/Fuego/Make.package
@@ -1,8 +1,14 @@
 f90EXE_sources += actual_network.f90
 ifeq ($(USE_CUDA_CVODE), TRUE)
-    Blocs   += $(PELE_PHYSICS_HOME)/Reactions/Fuego/GPU
-    CEXE_headers += actual_Creactor_GPU.h
-    CEXE_sources += actual_Creactor_GPU.cpp
+    ifeq ($(USE_ARKODE_PP), TRUE)
+        Blocs   += $(PELE_PHYSICS_HOME)/Reactions/Fuego/GPU
+        CEXE_headers +=actual_CARKODE_GPU.h  
+        CEXE_sources += actual_CARKODE_GPU.cpp
+    else
+        Blocs   += $(PELE_PHYSICS_HOME)/Reactions/Fuego/GPU
+        CEXE_headers += actual_Creactor_GPU.h
+        CEXE_sources += actual_Creactor_GPU.cpp
+    endif
 else
     ifeq ($(USE_SUNDIALS_PP), TRUE)
         ifeq ($(USE_ARKODE_PP), TRUE)

--- a/Reactions/Fuego/Make.package
+++ b/Reactions/Fuego/Make.package
@@ -1,30 +1,31 @@
 f90EXE_sources += actual_network.f90
-ifeq ($(USE_CUDA_CVODE), TRUE)
-    ifeq ($(USE_ARKODE_PP), TRUE)
+
+ifeq ($(USE_SUNDIALS_PP), TRUE)
+    ifeq ($(USE_CUDA_SUNDIALS_PP), TRUE)
         Blocs   += $(PELE_PHYSICS_HOME)/Reactions/Fuego/GPU
-        CEXE_headers +=actual_CARKODE_GPU.h  
-        CEXE_sources += actual_CARKODE_GPU.cpp
-    else
-        Blocs   += $(PELE_PHYSICS_HOME)/Reactions/Fuego/GPU
-        CEXE_headers += actual_Creactor_GPU.h
-        CEXE_sources += actual_Creactor_GPU.cpp
-    endif
-else
-    ifeq ($(USE_SUNDIALS_PP), TRUE)
         ifeq ($(USE_ARKODE_PP), TRUE)
-            Blocs   += $(PELE_PHYSICS_HOME)/Reactions/Fuego/CPU
-            CEXE_headers +=actual_CARKODE.h  
-            CEXE_sources +=actual_CARKODE.cpp
+            CEXE_headers += actual_CARKODE_GPU.h  
+            CEXE_sources += actual_CARKODE_GPU.cpp
         else
-            Blocs   += $(PELE_PHYSICS_HOME)/Reactions/Fuego/CPU
-            CEXE_headers +=actual_Creactor.h  
-            CEXE_sources +=actual_Creactor.cpp
+            CEXE_headers += actual_Creactor_GPU.h
+            CEXE_sources += actual_Creactor_GPU.cpp
+        endif
+    else
+        Blocs   += $(PELE_PHYSICS_HOME)/Reactions/Fuego/CPU
+        ifeq ($(USE_ARKODE_PP), TRUE)
+            CEXE_headers += actual_CARKODE.h  
+            CEXE_sources += actual_CARKODE.cpp
+        else
+            CEXE_headers += actual_Creactor.h  
+            CEXE_sources += actual_Creactor.cpp
             f90EXE_sources += mod_cvode.f90
         endif
-    else ifeq ($(USE_RK64_PP), TRUE)
+    endif
+else 
+    ifeq ($(USE_RK64_PP), TRUE)
         Blocs   += $(PELE_PHYSICS_HOME)/Reactions/Fuego/CPU
-        CEXE_headers +=actual_CRK64.h  
-        CEXE_sources +=actual_CRK64.cpp
+        CEXE_headers += actual_CRK64.h  
+        CEXE_sources += actual_CRK64.cpp
     else
         F90EXE_sources += react_type.F90
         F90EXE_sources += actual_reactor.F90

--- a/Testing/Exec/ReactEvalCVODE_GPU/GNUmakefile
+++ b/Testing/Exec/ReactEvalCVODE_GPU/GNUmakefile
@@ -24,13 +24,22 @@ PELE_PHYSICS_HOME    := ../../..
 # this flag activates the subcycling mode in the D/Cvode routines
 DEFINES  += -DMOD_REACTOR
 
-# use CVODE
-#CVODE_LIB_DIR=$(PELE_PHYSICS_HOME)/ThirdParty/sundials/instdir/lib/
+# use SUNDIALS
 USE_SUNDIALS_PP = TRUE
-
-USE_CUDA_CVODE = TRUE
-USE_ARKODE_PP = TRUE
-
+ifeq ($(USE_SUNDIALS_PP), TRUE)  
+    # provide location of sundials lib if needed 
+    #SUNDIALS_LIB_DIR=$(PELE_PHYSICS_HOME)/ThirdParty/sundials/instdir/lib/
+    # use ARKODE: if FALSE then CVODE is used
+    USE_ARKODE_PP = FALSE
+    # use KLU sparse features -- only useful if CVODE is used on CPU
+    USE_KLU_PP = FALSE
+    # Activates GPU version
+    USE_CUDA_SUNDIALS_PP = TRUE
+else
+  # Activates use of Hari explicit RK
+  # will only work if USE_SUNDIALS_PP = FALSE
+  USE_RK64_PP = FALSE
+endif
 #######################
 ifeq ($(FUEGO_GAS), TRUE)
   Eos_dir         = Fuego

--- a/Testing/Exec/ReactEvalCVODE_GPU/GNUmakefile
+++ b/Testing/Exec/ReactEvalCVODE_GPU/GNUmakefile
@@ -15,7 +15,7 @@ FUEGO_GAS  = TRUE
 
 USE_CUDA   = TRUE
 
-TINY_PROFILE = TRUE
+TINY_PROFILE = FALSE
 
 # define the location of the PELE_PHYSICS top directory
 PELE_PHYSICS_HOME    := ../../..
@@ -29,6 +29,7 @@ DEFINES  += -DMOD_REACTOR
 USE_SUNDIALS_PP = TRUE
 
 USE_CUDA_CVODE = TRUE
+USE_ARKODE_PP = TRUE
 
 #######################
 ifeq ($(FUEGO_GAS), TRUE)

--- a/Testing/Exec/ReactEvalCVODE_GPU/inputs.3d
+++ b/Testing/Exec/ReactEvalCVODE_GPU/inputs.3d
@@ -1,4 +1,4 @@
-dt = 1.e-06
+dt = 1.e-05
 ndt = 10
 
 # Select CVODE Jacobian eval: 0=FD 1=AJ
@@ -19,3 +19,5 @@ amr.plot_file = plt
 fuel_name = CH4
 
 third_dim = 128
+
+ode.use_erkode=0

--- a/Testing/Exec/ReactEvalCVODE_GPU/main.cpp
+++ b/Testing/Exec/ReactEvalCVODE_GPU/main.cpp
@@ -15,7 +15,14 @@ using namespace amrex;
 #include <Transport_F.H>
 #include <main_F.H>
 #include <PlotFileFromMF.H>
-#include <actual_Creactor_GPU.h>
+#if defined(USE_SUNDIALS_PP)
+// ARKODE or CVODE
+  #ifdef USE_ARKODE_PP
+    #include <actual_CARKODE_GPU.h>
+  #else
+    #include <actual_Creactor_GPU.h>
+  #endif
+#endif
 
 /**********************************/
 int
@@ -44,7 +51,7 @@ main (int   argc,
 
     int max_grid_size = 16;
     std::string probin_file="probin";
-    std::string fuel_name="none";
+    std::string fuel_name="CH4";
     std::string pltfile("plt");
     /* CVODE inputs */
     int cvode_ncells = 1;
@@ -85,7 +92,7 @@ main (int   argc,
       pp.query("cvode_ncells",cvode_ncells);
 
       // Get name of fuel 
-      pp.get("fuel_name", fuel_name);
+      pp.query("fuel_name", fuel_name);
 
     }
 
@@ -99,12 +106,17 @@ main (int   argc,
     //}
 
     amrex::Print() << "Integration method: ";
+  #ifdef USE_ARKODE_PP
+        amrex::Print() << "using arkode";
+        amrex::Print() << std::endl;
+  #else
         amrex::Print() << "BDF (stiff)";
-    amrex::Print() << std::endl;
-
-    amrex::Print() << "Integration iteration method: ";
+        amrex::Print() << std::endl;
+        amrex::Print() << "Integration iteration method: ";
         amrex::Print() << "Newton";
-    amrex::Print() << std::endl;
+        amrex::Print() << std::endl;
+   #endif
+
 
     amrex::Print() << "Type of reactor: ";
         amrex::Print() << cvode_iE;

--- a/ThirdParty/Make.ThirdParty
+++ b/ThirdParty/Make.ThirdParty
@@ -20,8 +20,7 @@ ifeq ($(USE_SUNDIALS_PP),TRUE)
           LIBRARIES += -L$(SUNDIALS_LIB_DIR) -lsundials_nveccuda
       else
           DEFINES  += -DUSE_CUDA_CVODE
-          #LIBRARIES += -L$(SUNDIALS_LIB_DIR) -lsundials_nveccuda -lsundials_sunlinsolcusolversp
-          LIBRARIES += -L$(SUNDIALS_LIB_DIR) -lsundials_nveccuda
+          LIBRARIES += -L$(SUNDIALS_LIB_DIR) -lsundials_nveccuda -lsundials_sunlinsolcusolversp
           LIBRARIES += -lcusolver -lcusparse
       endif
   endif

--- a/ThirdParty/Make.ThirdParty
+++ b/ThirdParty/Make.ThirdParty
@@ -15,9 +15,15 @@ ifeq ($(USE_SUNDIALS_PP),TRUE)
     LIBRARIES += -L$(SUNDIALS_LIB_DIR) -lsundials_nvecopenmp
   endif
   ifeq ($(USE_CUDA_CVODE),TRUE)
-    DEFINES  += -DUSE_CUDA_CVODE
-    LIBRARIES += -L$(SUNDIALS_LIB_DIR) -lsundials_nveccuda -lsundials_sunlinsolcusolversp
-    LIBRARIES += -lcusolver -lcusparse
+      ifeq ($(USE_ARKODE_PP),TRUE)
+          DEFINES  += -DUSE_CUDA_CVODE
+          LIBRARIES += -L$(SUNDIALS_LIB_DIR) -lsundials_nveccuda
+      else
+          DEFINES  += -DUSE_CUDA_CVODE
+          #LIBRARIES += -L$(SUNDIALS_LIB_DIR) -lsundials_nveccuda -lsundials_sunlinsolcusolversp
+          LIBRARIES += -L$(SUNDIALS_LIB_DIR) -lsundials_nveccuda
+          LIBRARIES += -lcusolver -lcusparse
+      endif
   endif
   ifneq ($(shell uname),Darwin)
     LIBRARIES += -Wl,-rpath=${SUNDIALS_LIB_DIR}

--- a/ThirdParty/Make.ThirdParty
+++ b/ThirdParty/Make.ThirdParty
@@ -14,12 +14,11 @@ ifeq ($(USE_SUNDIALS_PP),TRUE)
   ifeq ($(USE_OMP),TRUE)
     LIBRARIES += -L$(SUNDIALS_LIB_DIR) -lsundials_nvecopenmp
   endif
-  ifeq ($(USE_CUDA_CVODE),TRUE)
+  ifeq ($(USE_CUDA_SUNDIALS_PP),TRUE)
+      DEFINES  += -DUSE_CUDA_SUNDIALS_PP
       ifeq ($(USE_ARKODE_PP),TRUE)
-          DEFINES  += -DUSE_CUDA_CVODE
           LIBRARIES += -L$(SUNDIALS_LIB_DIR) -lsundials_nveccuda
       else
-          DEFINES  += -DUSE_CUDA_CVODE
           LIBRARIES += -L$(SUNDIALS_LIB_DIR) -lsundials_nveccuda -lsundials_sunlinsolcusolversp
           LIBRARIES += -lcusolver -lcusparse
       endif


### PR DESCRIPTION
This PR adds capability to use SUNDIALS ARKODE integrator for chemistry on GPU. To use, one needs to turn on CUDA (USE_CUDA=TRUE) and turn on ARKODE (USE_ARKODE_PP=TRUE) during build. Current implementation uses a pure explicit source term, there are no linear solves involved. You can also turn explicit RK (ERKStep) by using flag ode.use_erkode=1. 

Preliminary testing on a 16x16x16 grid using drm19 mechanism and the initial conditions from reactval_C test case indicates ~ 40X speed-up (CPU vs GPU). I have verified the results also match for the reacteval_C test case.
![cpu_gpu_compare](https://user-images.githubusercontent.com/7399475/77791760-d6a17980-702c-11ea-9917-57fa93e4c46a.png)
