### PR TITLE
Feature transport cpp unif

### DIFF
--- a/Transport/Constant/Transport.H
+++ b/Transport/Constant/Transport.H
@@ -11,7 +11,6 @@
 
 #include "mechanism.h"
 #include "chemistry_file.H"
-#include "IndexDefines.H"
 #include "TransportParams.H"
 
 void transport_init();
@@ -20,8 +19,13 @@ void transport_close();
 AMREX_GPU_DEVICE
 void get_transport_coeffs(
   amrex::Box const& bx,
-  amrex::Array4<const amrex::Real> const& q,
-  amrex::Array4<amrex::Real> const& D);
+  amrex::Array4<const amrex::Real> const& Y_in,
+  amrex::Array4<const amrex::Real> const& T_in,
+  amrex::Array4<const amrex::Real> const& Rho_in,
+  amrex::Array4<amrex::Real> const& D_out,
+  amrex::Array4<amrex::Real> const& mu_out,
+  amrex::Array4<amrex::Real> const& xi_out,
+  amrex::Array4<amrex::Real> const& lam_out);
 
 using namespace transport_params;
 

--- a/Transport/Constant/Transport.cpp
+++ b/Transport/Constant/Transport.cpp
@@ -16,8 +16,13 @@ AMREX_GPU_DEVICE
 void
 get_transport_coeffs(
   amrex::Box const& bx,
-  amrex::Array4<const amrex::Real> const& q,
-  amrex::Array4<amrex::Real> const& D)
+  amrex::Array4<const amrex::Real> const& Y_in,
+  amrex::Array4<const amrex::Real> const& T_in,
+  amrex::Array4<const amrex::Real> const& Rho_in,
+  amrex::Array4<amrex::Real> const& D_out,
+  amrex::Array4<amrex::Real> const& mu_out,
+  amrex::Array4<amrex::Real> const& xi_out,
+  amrex::Array4<amrex::Real> const& lam_out)
 {
 
   const auto lo = amrex::lbound(bx);
@@ -41,10 +46,10 @@ get_transport_coeffs(
     for (int j = lo.y; j <= hi.y; ++j) {
       for (int i = lo.x; i <= hi.x; ++i) {
 
-        T = q(i, j, k, QTEMP);
-        rho = q(i, j, k, QRHO);
+        T = T_in(i, j, k);
+        rho = Rho_in(i, j, k);
         for (int n = 0; n < NUM_SPECIES; ++n) {
-          massloc[n] = q(i, j, k, QFS + n);
+          massloc[n] = Y_in(i, j, k, n);
         }
 
         transport(
@@ -53,12 +58,12 @@ get_transport_coeffs(
 
         //   mu, xi and lambda are stored after D in the diffusion multifab
         for (int n = 0; n < NUM_SPECIES; ++n) {
-          D(i, j, k, n) = Ddiag[n];
+          D_out(i, j, k, n) = Ddiag[n];
         }
 
-        D(i, j, k, dComp_mu) = muloc;
-        D(i, j, k, dComp_xi) = xiloc;
-        D(i, j, k, dComp_lambda) = lamloc;
+        mu_out(i, j, k)  = muloc;
+        xi_out(i, j, k)  = xiloc;
+        lam_out(i, j, k) = lamloc;
       }
     }
   }

--- a/Transport/Simple/Transport.H
+++ b/Transport/Simple/Transport.H
@@ -13,7 +13,6 @@
 
 #include "mechanism.h"
 #include "chemistry_file.H"
-#include "IndexDefines.H"
 #include "TransportParams.H"
 
 void transport_init();
@@ -22,8 +21,13 @@ void transport_close();
 AMREX_GPU_DEVICE
 void get_transport_coeffs(
   amrex::Box const& bx,
-  amrex::Array4<const amrex::Real> const& q,
-  amrex::Array4<amrex::Real> const& D);
+  amrex::Array4<const amrex::Real> const& Y_in,
+  amrex::Array4<const amrex::Real> const& T_in,
+  amrex::Array4<const amrex::Real> const& Rho_in,
+  amrex::Array4<amrex::Real> const& D_out,
+  amrex::Array4<amrex::Real> const& mu_out,
+  amrex::Array4<amrex::Real> const& xi_out,
+  amrex::Array4<amrex::Real> const& lam_out);
 
 using namespace transport_params;
 
@@ -40,6 +44,7 @@ comp_pure_bulk(amrex::Real Tloc, amrex::Real* muloc, amrex::Real* xiloc)
   amrex::Real epskoverT, epskoverTstd;
   amrex::Real pi = 3.141592653589793238;
   amrex::Real pi3_2 = 5.56832799683171;
+  // Call CKRP ?
   amrex::Real Ru = 8.31446261815324e7;;
 
   CKCVMS(&Tloc, cvk);
@@ -103,6 +108,7 @@ transport(
   //  need to set Ru
 
   amrex::Real trace = 1.e-15;
+  // Call CKRP ?
   amrex::Real Patm = 1.01325e6;
   amrex::Real wbar, pscale;
   amrex::Real Xloc[NUM_SPECIES];
@@ -216,6 +222,7 @@ transport(
       Ddiag[i] = trans_wt[i] * term1 / term2 / wbar;
     }
 
+    // Call CKRP ?
     amrex::Real Ru = 8.31446261815324e7;;
     pscale = Patm * wbar / (Ru * Tloc * rholoc);
 

--- a/Transport/Simple/Transport.cpp
+++ b/Transport/Simple/Transport.cpp
@@ -16,8 +16,13 @@ AMREX_GPU_DEVICE
 void
 get_transport_coeffs(
   amrex::Box const& bx,
-  amrex::Array4<const amrex::Real> const& q,
-  amrex::Array4<amrex::Real> const& D)
+  amrex::Array4<const amrex::Real> const& Y_in,
+  amrex::Array4<const amrex::Real> const& T_in,
+  amrex::Array4<const amrex::Real> const& Rho_in,
+  amrex::Array4<amrex::Real> const& D_out,
+  amrex::Array4<amrex::Real> const& mu_out,
+  amrex::Array4<amrex::Real> const& xi_out,
+  amrex::Array4<amrex::Real> const& lam_out)
 {
 
   const auto lo = amrex::lbound(bx);
@@ -41,10 +46,10 @@ get_transport_coeffs(
     for (int j = lo.y; j <= hi.y; ++j) {
       for (int i = lo.x; i <= hi.x; ++i) {
 
-        T = q(i, j, k, QTEMP);
-        rho = q(i, j, k, QRHO);
+        T = T_in(i, j, k);
+        rho = Rho_in(i, j, k);
         for (int n = 0; n < NUM_SPECIES; ++n) {
-          massloc[n] = q(i, j, k, QFS + n);
+          massloc[n] = Y_in(i, j, k, n);
         }
 
         transport(
@@ -53,12 +58,12 @@ get_transport_coeffs(
 
         //   mu, xi and lambda are stored after D in the diffusion multifab
         for (int n = 0; n < NUM_SPECIES; ++n) {
-          D(i, j, k, n) = Ddiag[n];
+          D_out(i, j, k, n) = Ddiag[n];
         }
 
-        D(i, j, k, dComp_mu) = muloc;
-        D(i, j, k, dComp_xi) = xiloc;
-        D(i, j, k, dComp_lambda) = lamloc;
+        mu_out(i, j, k) = muloc;
+        xi_out(i, j, k) = xiloc;
+        lam_out(i, j, k) = lamloc;
       }
     }
   }


### PR DESCRIPTION
This only addresses the in/ou in the cpp version of "Simple" and "Constant" transport. It should make it consistent with the F90 versions.
It will affect PeleC 