### PR TITLE
Feature tolerances

### DIFF
--- a/Reactions/Fuego/CPU/actual_CARKODE.cpp
+++ b/Reactions/Fuego/CPU/actual_CARKODE.cpp
@@ -123,8 +123,13 @@ int reactor_init(const int* reactor_type, const int* Ncells,
         atol  = N_VNew_Serial(neq_tot);
 	ratol = N_VGetArrayPointer(atol);
 	if (typVals) { 
-	    printf("Using typical values\n");
-	    printf("rtol = %14.8e atolfact = %14.8e \n",relative_tol, absolute_tol);
+#ifdef _OPENMP
+            if ((data->iverbose > 0) && (omp_thread == 0)) {
+#else
+            if (data->iverbose > 0) {
+#endif
+	        printf("rtol = %14.8e atolfact = %14.8e \n",relative_tol, absolute_tol);
+	    }
 	    for  (int i = 0; i < data->ncells; i++) {
 	        offset = i * (NUM_SPECIES + 1);
 		for  (int k = 0; k < NUM_SPECIES + 1; k++) {
@@ -132,7 +137,13 @@ int reactor_init(const int* reactor_type, const int* Ncells,
 		}
 	    }
 	} else {
-	    printf("rtol = %14.8e atol = %14.8e \n",relative_tol, absolute_tol);
+#ifdef _OPENMP
+            if ((data->iverbose > 0) && (omp_thread == 0)) {
+#else
+            if (data->iverbose > 0) {
+#endif
+	        printf("rtol = %14.8e atol = %14.8e \n",relative_tol, absolute_tol);
+	    }
             for (int i=0; i<neq_tot; i++) {
                 ratol[i] = absolute_tol;
             }

--- a/Reactions/Fuego/CPU/actual_CARKODE.cpp
+++ b/Reactions/Fuego/CPU/actual_CARKODE.cpp
@@ -19,7 +19,7 @@
   double *rhoXsrc_ext = NULL;
   double *rYsrc       = NULL;
   double *typVals     = NULL;
-  double relTol       = 1.0e-10
+  double relTol       = 1.0e-10;
   double absTol       = 1.0e-10;
 /* REMOVE MAYBE LATER */
   int dense_solve           = 1;
@@ -106,11 +106,11 @@ void ReSetTolODE() {
             }
 	}
         if (data->iuse_erkode == 1) {
-	    flag = ERKStepSVtolerances(arkode_mem, relTol, atol); 
-	    if (check_flag(&flag, "ERKStepSVtolerances", 1)) return 1;
+	    int flag = ERKStepSVtolerances(arkode_mem, relTol, atol); 
+	    if (check_flag(&flag, "ERKStepSVtolerances", 1)) amrex::Abort("Problem in ReSetTolODE");
         } else {
-	    flag = ARKStepSVtolerances(arkode_mem, relTol, atol); 
-	    if (check_flag(&flag, "ARKStepSVtolerances", 1)) return 1;
+	    int flag = ARKStepSVtolerances(arkode_mem, relTol, atol); 
+	    if (check_flag(&flag, "ARKStepSVtolerances", 1)) amrex::Abort("Problem in ReSetTolODE");
         }
 }
 

--- a/Reactions/Fuego/CPU/actual_CARKODE.cpp
+++ b/Reactions/Fuego/CPU/actual_CARKODE.cpp
@@ -28,6 +28,7 @@
 #pragma omp threadprivate(y,LS,A)
 #pragma omp threadprivate(arkode_mem,data)
 #pragma omp threadprivate(rhoX_init,rhoXsrc_ext,rYsrc)
+#pragma omp threadprivate(typVals)
 #endif
 /**********************************/
 

--- a/Reactions/Fuego/CPU/actual_CARKODE.cpp
+++ b/Reactions/Fuego/CPU/actual_CARKODE.cpp
@@ -47,12 +47,31 @@ void SetTypValsODE(std::vector<double> ExtTypVals) {
 	amrex::Vector<std::string> kname;
 	CKSYMS_STR(kname);
 
+#ifdef _OPENMP
+	/* omp thread if applicable */
+        if (omp_get_thread_num() == 0){
+	    amrex::Print() << "Set the typVals in PelePhysics: \n  ";
+            for (int i=0; i<size_ETV-1; i++) {
+                typVals[i] = ExtTypVals[i];
+                amrex::Print() << kname[i] << ":" << typVals[i] << "  ";    
+            }
+	    typVals[size_ETV-1] = ExtTypVals[size_ETV-1];
+            amrex::Print() << "Temp:"<< typVals[size_ETV-1] <<  " \n";    
+	} else {
+            for (int i=0; i<size_ETV-1; i++) {
+                typVals[i] = ExtTypVals[i];
+            }
+	    typVals[size_ETV-1] = ExtTypVals[size_ETV-1];
+	}
+#else
+	amrex::Print() << "Set the typVals in PelePhysics: \n  ";
         for (int i=0; i<size_ETV-1; i++) {
             typVals[i] = ExtTypVals[i];
             amrex::Print() << kname[i] << ":" << typVals[i] << "  ";    
         }
 	typVals[size_ETV-1] = ExtTypVals[size_ETV-1];
         amrex::Print() << "Temp:"<< typVals[size_ETV-1] <<  " \n";    
+#endif
 }
 
 
@@ -61,7 +80,14 @@ void SetTolFactODE(double relative_tol,double absolute_tol) {
         relTol = relative_tol;
 	absTol = absolute_tol;
 
-	amrex::Print() << "RTOL, ATOL: "<<relTol<< " "<<absTol<<  " \n";
+#ifdef _OPENMP
+	/* omp thread if applicable */
+        if (omp_get_thread_num() == 0){
+	    amrex::Print() << "Set RTOL, ATOL = "<<relTol<< " "<<absTol<<  " in PelePhysics\n";
+	}
+#else
+	amrex::Print() << "Set RTOL, ATOL = "<<relTol<< " "<<absTol<<  " in PelePhysics\n";
+#endif
 }
 
 
@@ -85,7 +111,7 @@ void ReSetTolODE() {
 #else
             if (data->iverbose > 0) {
 #endif
-	        printf("rtol = %14.8e atolfact = %14.8e \n",relTol, absTol);
+	        printf("Setting ARK/ERKODE tolerances rtol = %14.8e atolfact = %14.8e in PelePhysics \n",relTol, absTol);
 	    }
 	    for  (int i = 0; i < data->ncells; i++) {
 	        offset = i * (NUM_SPECIES + 1);
@@ -99,7 +125,7 @@ void ReSetTolODE() {
 #else
             if (data->iverbose > 0) {
 #endif
-	        printf("rtol = %14.8e atol = %14.8e \n",relTol, absTol);
+	        printf("Setting ARK/ERKODE tolerances rtol = %14.8e atol = %14.8e in PelePhysics \n",relTol, absTol);
 	    }
             for (int i=0; i<neq_tot; i++) {
                 ratol[i] = absTol;
@@ -190,7 +216,7 @@ int reactor_init(const int* reactor_type, const int* Ncells) {
 #else
             if (data->iverbose > 0) {
 #endif
-	        printf("rtol = %14.8e atolfact = %14.8e \n",relTol, absTol);
+	        printf("Setting ARK/ERKODE tolerances rtol = %14.8e atolfact = %14.8e in PelePhysics \n",relTol, absTol);
 	    }
 	    for  (int i = 0; i < data->ncells; i++) {
 	        offset = i * (NUM_SPECIES + 1);
@@ -204,7 +230,7 @@ int reactor_init(const int* reactor_type, const int* Ncells) {
 #else
             if (data->iverbose > 0) {
 #endif
-	        printf("rtol = %14.8e atol = %14.8e \n",relTol, absTol);
+	        printf("Setting ARK/ERKODE tolerances rtol = %14.8e atol = %14.8e in PelePhysics \n",relTol, absTol);
 	    }
             for (int i=0; i<neq_tot; i++) {
                 ratol[i] = absTol;

--- a/Reactions/Fuego/CPU/actual_CARKODE.h
+++ b/Reactions/Fuego/CPU/actual_CARKODE.h
@@ -41,9 +41,7 @@ int cJac(realtype tn, N_Vector y, N_Vector fy, SUNMatrix J,
 /* Functions Called by the Program */
 extern "C"
 {
-    int SetTypValsODE(std::vector<double> ExtTypVals);
-    int reactor_init(const int* cvode_iE, const int* Ncells,
-           double relative_tol=1e-10,double absolute_tol=1e-10);
+    int reactor_init(const int* cvode_iE, const int* Ncells);
 
     int react(realtype *rY_in, realtype *rY_src_in, 
 		realtype *rX_in, realtype *rX_src_in, 
@@ -63,6 +61,11 @@ UserData AllocUserData(int iE, int num_cells);
 
 void FreeUserData(UserData data);
 
+void SetTypValsODE(std::vector<double> ExtTypVals);
+
+void SetTolFactODE(double relative_tol,double absolute_tol);
+
+void ReSetTolODE();
 
 /**********************************/
 /* Main Kernel fct called in solver RHS */

--- a/Reactions/Fuego/CPU/actual_CARKODE.h
+++ b/Reactions/Fuego/CPU/actual_CARKODE.h
@@ -41,6 +41,7 @@ int cJac(realtype tn, N_Vector y, N_Vector fy, SUNMatrix J,
 /* Functions Called by the Program */
 extern "C"
 {
+    int SetTypValsODE(std::vector<double> ExtTypVals);
     int reactor_init(const int* cvode_iE, const int* Ncells,
            double relative_tol=1e-10,double absolute_tol=1e-10);
 

--- a/Reactions/Fuego/CPU/actual_Creactor.cpp
+++ b/Reactions/Fuego/CPU/actual_Creactor.cpp
@@ -44,7 +44,7 @@
 
 /**********************************/
 /* Initialization of typVals */
-int SetTypValsCVODE(std::vector<double> ExtTypVals) {
+int SetTypValsODE(std::vector<double> ExtTypVals) {
 	int size_ETV = (NUM_SPECIES + 1);
 	if (typVals==NULL) {
 	    typVals = (double *) malloc(size_ETV*sizeof(double));

--- a/Reactions/Fuego/CPU/actual_Creactor.cpp
+++ b/Reactions/Fuego/CPU/actual_Creactor.cpp
@@ -57,14 +57,32 @@ void SetTypValsODE(std::vector<double> ExtTypVals) {
 	amrex::Vector<std::string> kname;
 	CKSYMS_STR(kname);
 
+#ifdef _OPENMP
+	/* omp thread if applicable */
+        if (omp_get_thread_num() == 0){
+	    amrex::Print() << "Set the typVals in PelePhysics: \n  ";
+            for (int i=0; i<size_ETV-1; i++) {
+                typVals[i] = ExtTypVals[i];
+                amrex::Print() << kname[i] << ":" << typVals[i] << "  ";    
+            }
+	    typVals[size_ETV-1] = ExtTypVals[size_ETV-1];
+            amrex::Print() << "Temp:"<< typVals[size_ETV-1] <<  " \n";    
+	} else {
+            for (int i=0; i<size_ETV-1; i++) {
+                typVals[i] = ExtTypVals[i];
+            }
+	    typVals[size_ETV-1] = ExtTypVals[size_ETV-1];
+	}
+#else
 	amrex::Print() << "Set the typVals in PelePhysics: \n  ";
-
         for (int i=0; i<size_ETV-1; i++) {
             typVals[i] = ExtTypVals[i];
             amrex::Print() << kname[i] << ":" << typVals[i] << "  ";    
         }
 	typVals[size_ETV-1] = ExtTypVals[size_ETV-1];
         amrex::Print() << "Temp:"<< typVals[size_ETV-1] <<  " \n";    
+#endif
+
 }
 
 
@@ -76,10 +94,10 @@ void SetTolFactODE(double relative_tol,double absolute_tol) {
 #ifdef _OPENMP
 	/* omp thread if applicable */
         if (omp_get_thread_num() == 0){
-	    amrex::Print() << "Set RTOL, ATOL = "<<relTol<< " "<<absTol<<  " \n";
+	    amrex::Print() << "Set RTOL, ATOL = "<<relTol<< " "<<absTol<<  " in PelePhysics\n";
 	}
 #else
-	amrex::Print() << "Set RTOL, ATOL = "<<relTol<< " "<<absTol<<  " \n";
+	amrex::Print() << "Set RTOL, ATOL = "<<relTol<< " "<<absTol<<  " in PelePhysics\n";
 #endif
 }
 
@@ -104,7 +122,7 @@ void ReSetTolODE() {
 #else
             if (data->iverbose > 0) {
 #endif
-	        printf("Using rtol = %14.8e atolfact = %14.8e \n",relTol, absTol);
+	        printf("Setting CVODE tolerances rtol = %14.8e atolfact = %14.8e in PelePhysics \n",relTol, absTol);
 	    }
 	    for  (int i = 0; i < data->ncells; i++) {
 	        offset = i * (NUM_SPECIES + 1);
@@ -118,7 +136,7 @@ void ReSetTolODE() {
 #else
             if (data->iverbose > 0) {
 #endif
-	        printf("Using rtol = %14.8e atol = %14.8e \n",relTol, absTol);
+	        printf("Setting CVODE tolerances rtol = %14.8e atol = %14.8e in PelePhysics \n",relTol, absTol);
 	    }
             for (int i=0; i<neq_tot; i++) {
                 ratol[i] = absTol;
@@ -196,7 +214,7 @@ int reactor_init(const int* reactor_type, const int* Ncells) {
 #else
             if (data->iverbose > 0) {
 #endif
-	        printf("rtol = %14.8e atolfact = %14.8e \n",relTol, absTol);
+	        printf("Setting CVODE tolerances rtol = %14.8e atolfact = %14.8e in PelePhysics \n",relTol, absTol);
 	    }
 	    for  (int i = 0; i < data->ncells; i++) {
 	        offset = i * (NUM_SPECIES + 1);
@@ -211,7 +229,7 @@ int reactor_init(const int* reactor_type, const int* Ncells) {
 #else
             if (data->iverbose > 0) {
 #endif
-	        printf("rtol = %14.8e atol = %14.8e \n",relTol, absTol);
+	        printf("Setting CVODE tolerances rtol = %14.8e atol = %14.8e in PelePhysics \n",relTol, absTol);
 	    }
             for (int i=0; i<neq_tot; i++) {
                 ratol[i] = absTol;

--- a/Reactions/Fuego/CPU/actual_Creactor.cpp
+++ b/Reactions/Fuego/CPU/actual_Creactor.cpp
@@ -124,8 +124,13 @@ int reactor_init(const int* reactor_type, const int* Ncells,
 	ratol = N_VGetArrayPointer(atol);
 	int offset;
 	if (typVals) {
-	    printf("Using typical values\n");
-	    printf("rtol = %14.8e atolfact = %14.8e \n",relative_tol, absolute_tol);
+#ifdef _OPENMP
+            if ((data->iverbose > 0) && (omp_thread == 0)) {
+#else
+            if (data->iverbose > 0) {
+#endif
+	        printf("rtol = %14.8e atolfact = %14.8e \n",relative_tol, absolute_tol);
+	    }
 	    for  (int i = 0; i < data->ncells; i++) {
 	        offset = i * (NUM_SPECIES + 1);
 		for  (int k = 0; k < NUM_SPECIES + 1; k++) {
@@ -134,7 +139,13 @@ int reactor_init(const int* reactor_type, const int* Ncells,
 		}
 	    }
 	} else {
-	    printf("rtol = %14.8e atol = %14.8e \n",relative_tol, absolute_tol);
+#ifdef _OPENMP
+            if ((data->iverbose > 0) && (omp_thread == 0)) {
+#else
+            if (data->iverbose > 0) {
+#endif
+	        printf("rtol = %14.8e atol = %14.8e \n",relative_tol, absolute_tol);
+	    }
             for (int i=0; i<neq_tot; i++) {
                 ratol[i] = absolute_tol;
             }

--- a/Reactions/Fuego/CPU/actual_Creactor.h
+++ b/Reactions/Fuego/CPU/actual_Creactor.h
@@ -105,9 +105,7 @@ int Precond(realtype tn, N_Vector u, N_Vector fu, booleantype jok,
 /* Functions Called by the Program */
 extern "C"
 {
-    int SetTypValsODE(std::vector<double> ExtTypVals);
-    int reactor_init(const int* cvode_iE, const int* Ncells,
-           double relative_tol=1e-10,double absolute_tol=1e-10);
+    int reactor_init(const int* cvode_iE, const int* Ncells);
 
     int react(realtype *rY_in, realtype *rY_src_in, 
 		realtype *rX_in, realtype *rX_src_in, 
@@ -130,6 +128,11 @@ void FreeUserData(UserData data);
 
 void check_state(N_Vector yvec);
 
+void SetTypValsODE(std::vector<double> ExtTypVals);
+
+void SetTolFactODE(double relative_tol,double absolute_tol);
+
+void ReSetTolODE();
 
 /**********************************/
 /* Main Kernel fct called in solver RHS */

--- a/Reactions/Fuego/CPU/actual_Creactor.h
+++ b/Reactions/Fuego/CPU/actual_Creactor.h
@@ -105,7 +105,7 @@ int Precond(realtype tn, N_Vector u, N_Vector fu, booleantype jok,
 /* Functions Called by the Program */
 extern "C"
 {
-    int SetTypValsCVODE(std::vector<double> ExtTypVals);
+    int SetTypValsODE(std::vector<double> ExtTypVals);
     int reactor_init(const int* cvode_iE, const int* Ncells,
            double relative_tol=1e-10,double absolute_tol=1e-10);
 

--- a/Reactions/Fuego/CPU/actual_Creactor.h
+++ b/Reactions/Fuego/CPU/actual_Creactor.h
@@ -107,7 +107,7 @@ extern "C"
 {
     int SetTypValsCVODE(std::vector<double> ExtTypVals);
     int reactor_init(const int* cvode_iE, const int* Ncells,
-           double relative_tol=1e-8,double absolute_tol=1e-8);
+           double relative_tol=1e-10,double absolute_tol=1e-10);
 
     int react(realtype *rY_in, realtype *rY_src_in, 
 		realtype *rX_in, realtype *rX_src_in, 

--- a/Reactions/Fuego/CPU/actual_Creactor.h
+++ b/Reactions/Fuego/CPU/actual_Creactor.h
@@ -105,7 +105,9 @@ int Precond(realtype tn, N_Vector u, N_Vector fu, booleantype jok,
 /* Functions Called by the Program */
 extern "C"
 {
-    int reactor_init(const int* cvode_iE, const int* Ncells);
+    int SetTypValsCVODE(std::vector<double> ExtTypVals);
+    int reactor_init(const int* cvode_iE, const int* Ncells,
+           double relative_tol=1e-8,double absolute_tol=1e-8);
 
     int react(realtype *rY_in, realtype *rY_src_in, 
 		realtype *rX_in, realtype *rX_src_in, 

--- a/Testing/Exec/ReactEval_C/inputs.3d
+++ b/Testing/Exec/ReactEval_C/inputs.3d
@@ -5,8 +5,8 @@ ode.ndt = 10
 # Reactor formalism: 1=full e, 2=full h
 ode.reactor_type  = 1
 # abs and rel tolerances for ODE solve
-ode.rtol = 1e-9
-ode.atol = 1e-9
+ode.rtol = 1e-10
+ode.atol = 1e-10
 # Use variable-specific abs tols in ODE solve
 # Note that atol becomes a factor
 ode.use_typ_vals = 0
@@ -29,4 +29,3 @@ amr.plot_file  = plt
 fuel_name      = CH4
 # Second dim 
 third_dim = 1024
-

--- a/Testing/Exec/ReactEval_C/inputs.3d
+++ b/Testing/Exec/ReactEval_C/inputs.3d
@@ -4,9 +4,12 @@ ode.dt  = 1.e-05
 ode.ndt = 10
 # Reactor formalism: 1=full e, 2=full h
 ode.reactor_type  = 1
-# Tolerances for ODE solve
+# abs and rel tolerances for ODE solve
 ode.rtol = 1e-9
 ode.atol = 1e-9
+# Use variable-specific abs tols in ODE solve
+# Note that atol becomes a factor
+ode.use_typ_vals = 0
 # Select ARK/CV-ODE Jacobian eval: 0=FD 1=AJ
 ode.analytical_jacobian = 0
 #CVODE SPECIFICS
@@ -26,3 +29,4 @@ amr.plot_file  = plt
 fuel_name      = CH4
 # Second dim 
 third_dim = 1024
+

--- a/Testing/Exec/ReactEval_C/main.cpp
+++ b/Testing/Exec/ReactEval_C/main.cpp
@@ -75,10 +75,11 @@ main (int   argc,
     int third_dim  = 1024;
     int ndt        = 1; 
     Real dt        = 1.e-5;
-#ifdef USE_ARKODE_PP 
+#ifdef USE_SUNDIALS_PP
     /* ARKODE parameters for now but should be for all solvers */
     Real rtol=1e-9;
     Real atol=1e-9;
+    int set_typ_vals = 0;
 #endif
 
     {
@@ -119,10 +120,11 @@ main (int   argc,
       ppode.query("ode_ncells",ode_ncells);
 #endif
 
-#ifdef USE_ARKODE_PP 
+#ifdef USE_SUNDIALS_PP
       /* Additional ARKODE queries */
       ppode.query("rtol",rtol);
       ppode.query("atol",atol);
+      ppode.query("set_typ_vals",set_typ_vals);
 #endif
 
     }
@@ -149,8 +151,6 @@ main (int   argc,
     amrex::Print() << std::endl;
 
     amrex::Print() << "Fuel: ";
-        amrex::Print() << fuel_name << ", Oxy: O2";
-    amrex::Print() << std::endl;
 
     /* take care of probin init to initialize problem */
     int probin_file_length = probin_file.length();
@@ -159,16 +159,19 @@ main (int   argc,
 	    probin_file_name[i] = probin_file[i];
     if (fuel_name == "H2") {
         fuel_idx  = H2_ID;
-	amrex::Print() << "FUEL IS H2 \n";
+        amrex::Print() << fuel_name << ", Oxy: O2";
+        amrex::Print() << std::endl;
 #ifdef CH4_ID
     } else if (fuel_name == "CH4") {
         fuel_idx  = CH4_ID;
-        amrex::Print() << "FUEL IS CH4 \n";
+        amrex::Print() << fuel_name << ", Oxy: O2";
+        amrex::Print() << std::endl;
 #endif
 #ifdef NC12H26_ID
     } else if (fuel_name == "NC12H26") {
         fuel_idx  = NC12H26_ID;
-        amrex::Print() << "FUEL IS NC12H26 \n";
+        amrex::Print() << fuel_name << ", Oxy: O2";
+        amrex::Print() << std::endl;
 #endif
     }
     oxy_idx   = O2_ID;
@@ -185,11 +188,22 @@ main (int   argc,
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-#ifdef USE_ARKODE_PP
+    // init species-specific abs tolerances
+    if (set_typ_vals) {
+        amrex::Print() << "Using user-defined typical values for the absolute tolerances of the ode solver.\n";
+        amrex::ParmParse pptv("ode");
+        int nb_typ_vals = pptv.countval("typ_vals");
+        if (nb_typ_vals != (NUM_SPECIES + 1)){
+            printf("%d %d\n", nb_typ_vals, (NUM_SPECIES + 1));
+            amrex::Abort("Not enough/too many typical values");
+        }
+        std::vector<double> typ_vals(nb_typ_vals);
+        for (int i = 0; i < nb_typ_vals; ++i) {
+                pptv.get("typ_vals", typ_vals[i],i);
+        }
+        SetTypValsCVODE(typ_vals);
+    }
     reactor_init(&ode_iE, &ode_ncells,rtol,atol);
-#else
-    reactor_init(&ode_iE, &ode_ncells);
-#endif
 #endif
 #else
 #ifdef _OPENMP

--- a/Testing/Exec/ReactEval_C/main.cpp
+++ b/Testing/Exec/ReactEval_C/main.cpp
@@ -182,13 +182,16 @@ main (int   argc,
 
     /* Initialize D/CVODE reactor */
 #ifdef USE_SUNDIALS_PP
-#ifdef USE_CUDA_SUNDIALS_PP
+  #ifdef USE_CUDA_SUNDIALS_PP
     reactor_info(&ode_iE, &ode_ncells);
-#else
+  #else
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-    // init species-specific abs tolerances
+{
+    // Set ODE r/a tolerances
+    SetTolFactODE(rtol,atol);
+    // Set species-specific abs tolerances
     if (use_typ_vals) {
         amrex::Print() << "Using user-defined typical values for the absolute tolerances of the ode solver.\n";
         amrex::ParmParse pptv("ode");
@@ -203,8 +206,9 @@ main (int   argc,
         }
         SetTypValsODE(typ_vals);
     }
-    reactor_init(&ode_iE, &ode_ncells,rtol,atol);
-#endif
+    reactor_init(&ode_iE, &ode_ncells);
+}
+  #endif
 #else
 #ifdef _OPENMP
 #pragma omp parallel

--- a/Testing/Exec/ReactEval_C/main.cpp
+++ b/Testing/Exec/ReactEval_C/main.cpp
@@ -79,7 +79,7 @@ main (int   argc,
     /* ARKODE parameters for now but should be for all solvers */
     Real rtol=1e-9;
     Real atol=1e-9;
-    int set_typ_vals = 0;
+    int use_typ_vals = 0;
 #endif
 
     {
@@ -124,7 +124,7 @@ main (int   argc,
       /* Additional ARKODE queries */
       ppode.query("rtol",rtol);
       ppode.query("atol",atol);
-      ppode.query("set_typ_vals",set_typ_vals);
+      ppode.query("use_typ_vals",use_typ_vals);
 #endif
 
     }
@@ -189,7 +189,7 @@ main (int   argc,
 #pragma omp parallel
 #endif
     // init species-specific abs tolerances
-    if (set_typ_vals) {
+    if (use_typ_vals) {
         amrex::Print() << "Using user-defined typical values for the absolute tolerances of the ode solver.\n";
         amrex::ParmParse pptv("ode");
         int nb_typ_vals = pptv.countval("typ_vals");
@@ -201,7 +201,7 @@ main (int   argc,
         for (int i = 0; i < nb_typ_vals; ++i) {
                 pptv.get("typ_vals", typ_vals[i],i);
         }
-        SetTypValsCVODE(typ_vals);
+        SetTypValsODE(typ_vals);
     }
     reactor_init(&ode_iE, &ode_ncells,rtol,atol);
 #endif
@@ -477,7 +477,7 @@ main (int   argc,
 		                &dt_incr, &time);
 #endif
 		            dt_incr =  dt/ndt;
-			    printf("%14.6e %14.6e \n", time, tmp_vect[Ncomp]);
+			    //printf("%14.6e %14.6e \n", time, tmp_vect[Ncomp]);
 			}
 		        nc = 0;
 		        for (int l = 0; l < ode_ncells ; ++l){


### PR DESCRIPTION
The user has the option to specify his own relative and absolute tolerances AND to properly scale the absolute tolerances used in the CVODE/ARKODE and ERKODE chem solvers. In PelePhysics, these can be specified directly by the user as is shown in the main.cpp of the ReactEval_C test case. 
Note that the RegTests should not be affected by this merge as the default is to NOT use this new machinery and to fall back to the fixed atol/rtol = 1e-10 currently in place. 
Note 2: DVODE has not been adapted to these customeries.