### PR TITLE
Rename TRY2P to RTY2P

### DIFF
--- a/Eos/Fuego/EOS.H
+++ b/Eos/Fuego/EOS.H
@@ -133,7 +133,7 @@ RYET2P(
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
 void
-TRY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
+RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
 {
   CKPY(&R, &T, Y, &P);
 }

--- a/Eos/GammaLaw/EOS.H
+++ b/Eos/GammaLaw/EOS.H
@@ -146,7 +146,7 @@ HY2T(amrex::Real H, amrex::Real Y[], amrex::Real& T)
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
 void
-TRY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
+RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
 {
   amrex::Real Cv, E;
   EOS::TY2Cv(T, Y, Cv);


### PR DESCRIPTION
I think this was my fault early on when creating these function names.

Also, can we set the default branch here to `development`? I feel like nobody uses the `master` branch.