### PR TITLE
Plm/anne/dev gpu

### DIFF
--- a/Support/Fuego/Mechanism/Models/Make.package
+++ b/Support/Fuego/Mechanism/Models/Make.package
@@ -1,1 +1,2 @@
 F90EXE_sources += mod_fuego.F90
+CEXE_headers += PPHYS_CONSTANTS.H

--- a/Support/Fuego/Mechanism/Models/PPHYS_CONSTANTS.H
+++ b/Support/Fuego/Mechanism/Models/PPHYS_CONSTANTS.H
@@ -1,0 +1,18 @@
+#ifndef _PPHYS_CONSTANTS_H_
+#define _PPHYS_CONSTANTS_H_
+
+ 
+
+#define PP_RU_CGS   83144626.1815324
+#define PP_RU_MKS   8.31446261815324
+#define PP_PA_CGS   1013250.0
+#define PP_PA_MKS   101325.0
+#define PP_RUC_CGS  1.98721558317399615845
+
+#define C_AW   12.011150 
+#define H_AW   1.007970
+#define O_AW   15.999400
+#define N_AW   14.006700
+#define AR_AW  39.948000
+
+#endif


### PR DESCRIPTION
In this branch a .H file has been added where constants such as the P atmospheric and Universal gas constant should be defined. There are CGS and MKS versions, and it's just a template for now as I probably have forgotten other important constants.
This is intended to be used instead of calling Fuego's CKRP.
Ideally, these constants would be used everywhere in PP too, to ensure consistency 