### PR TITLE
gpu block size in arkode

### DIFF
--- a/Reactions/Fuego/GPU/arkode/reactor.cpp
+++ b/Reactions/Fuego/GPU/arkode/reactor.cpp
@@ -55,7 +55,7 @@ int react(realtype *rY_in, realtype *rY_src_in,
     user_data->ireactor_type           = reactor_type; 
     user_data->iverbose                = 1;
     user_data->stream                  = stream;
-    user_data->nbBlocks                = NCELLS/32;
+    user_data->nbBlocks                = std::max(1,NCELLS/32);
     user_data->nbThreads               = 32;
 
     y = N_VNewManaged_Cuda(neq_tot);


### PR DESCRIPTION
We need a minimum of 1 block for rhs kernel launch. Most often things work without this fix, but with low blocking_factors and max_grid_sizes things fail without this fix.