### PR TITLE
Feature null reaction dir

### DIFF
--- a/Reactions/Null/Make.package
+++ b/Reactions/Null/Make.package
@@ -1,0 +1,3 @@
+Blocs   += $(PELE_PHYSICS_HOME)/Reactions/Fuego/Null
+CEXE_headers += reactor.h  
+CEXE_sources += reactor.cpp

--- a/Reactions/Null/Make.package
+++ b/Reactions/Null/Make.package
@@ -1,3 +1,2 @@
-Blocs   += $(PELE_PHYSICS_HOME)/Reactions/Fuego/Null
 CEXE_headers += reactor.h  
 CEXE_sources += reactor.cpp

--- a/Reactions/Null/reactor.cpp
+++ b/Reactions/Null/reactor.cpp
@@ -28,7 +28,7 @@ int react(const Box& box,
           Real &time) {
 
     /* Initial time and time to reach after integration */
-    time_init = time;
+    Real time_init = time;
 
 #ifdef MOD_REACTOR
     /* If reactor mode is activated, update time to perform subcycling */
@@ -51,7 +51,7 @@ int react_2(const Box& box,
           Real &time) {
 
     /* Initial time and time to reach after integration */
-    time_init = time;
+    Real time_init = time;
 
 #ifdef MOD_REACTOR
     /* If reactor mode is activated, update time to perform subcycling */
@@ -62,12 +62,12 @@ int react_2(const Box& box,
 }
 
 /* Main routine for CVode integration: classic version */
-int react(realtype *rY_in, realtype *rY_src_in, 
-          realtype *rX_in, realtype *rX_src_in,
-          realtype &dt_react, realtype &time){
+int react(amrex::Real *rY_in, amrex::Real *rY_src_in, 
+          amrex::Real *rX_in, amrex::Real *rX_src_in,
+          amrex::Real &dt_react, amrex::Real &time) {
 
     /* Initial time and time to reach after integration */
-    time_init = time;
+    Real time_init = time;
 
 #ifdef MOD_REACTOR
     /* If reactor mode is activated, update time */
@@ -78,7 +78,7 @@ int react(realtype *rY_in, realtype *rY_src_in,
 }
 
 /* Free memory */
-void reactor_close(){ }
+void reactor_close() {}
 
 
 /* End of file  */

--- a/Reactions/Null/reactor.cpp
+++ b/Reactions/Null/reactor.cpp
@@ -3,6 +3,13 @@
 using namespace amrex;
 
 /**********************************/
+/* Global Variables */
+  int ireactor_type;
+  int eint_rho = 1; // in/out = rhoE/rhoY
+  int enth_rho = 2; // in/out = rhoH/rhoY 
+/**********************************/
+
+/**********************************/
 /* Set or update typVals */
 void SetTypValsODE(const std::vector<double>& ExtTypVals) {}
 
@@ -13,7 +20,10 @@ void SetTolFactODE(double relative_tol,double absolute_tol) {}
 void ReSetTolODE() {}
 
 /* Initialization routine, called once at the begining of the problem */
-int reactor_init(int reactor_type, int ode_ncells) { return(0); }
+int reactor_init(int reactor_type, int ode_ncells) { 
+    ireactor_type = reactor_type;
+    return(0); 
+}
 
 /* Main routine for CVode integration: integrate a Box version 1*/
 int react(const Box& box,
@@ -27,31 +37,50 @@ int react(const Box& box,
           Real &dt_react,
           Real &time) {
 
-    /* Initial time and time to reach after integration */
-    Real time_init = time;
-
-#ifdef MOD_REACTOR
-    /* If reactor mode is activated, update time to perform subcycling */
-    time  = time_init + dt_react;
+    int omp_thread = 0;
+#ifdef _OPENMP
+    omp_thread = omp_get_thread_num(); 
 #endif
-    /* Get estimate of how hard the integration process was */
-    return 0;
-}
-
-/* Main routine for CVode integration: integrate a Box version 2*/
-int react_2(const Box& box,
-          Array4<Real> const& rY_in,
-          Array4<Real> const& rY_src_in,
-          Array4<Real> const& T_in,
-          Array4<Real> const& rEner_in,
-          Array4<Real> const& rEner_src_in,
-          Array4<Real> const& FC_in,
-          Array4<int> const& mask_in,
-          Real &dt_react,
-          Real &time) {
 
     /* Initial time and time to reach after integration */
     Real time_init = time;
+
+    /* Perform integration one cell at a time */
+    ParallelFor(box,
+    [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    {
+        // Integration of external source term
+        Real renergy_loc  = rEner_in(i,j,k,0) + rEner_src_in(i,j,k,0) * dt_react; 
+        rEner_in(i,j,k,0) = renergy_loc;
+        Real rY_loc[NUM_SPECIES];
+        for (int n = 0; n < NUM_SPECIES; n++){
+            rY_loc[n] = rY_in(i,j,k,n) + rY_src_in(i,j,k,n) * dt_react;
+            rY_in(i,j,k,n) = rY_loc[n];
+        }
+        /* T update with energy and Y */
+        // Get updated rho
+        Real rho_loc = 0.0;
+        for (int n = 0; n < NUM_SPECIES; n++) {
+            rho_loc += rY_loc[n]; 
+        }
+        // Get updated Ys
+        Real Y_loc[NUM_SPECIES];
+        for (int n = 0; n < NUM_SPECIES; n++) {
+            Y_loc[n] = rY_loc[n] / rho_loc;
+        }
+        // Get updated energy
+        Real energy_loc = renergy_loc / rho_loc;
+        // Get curr estimate of T
+        Real T_loc    = T_in(i,j,k,0);
+        if (ireactor_type == eint_rho){
+            EOS::EY2T(energy_loc,Y_loc,T_loc);
+        } else {
+            EOS::HY2T(energy_loc,Y_loc,T_loc);
+        }
+        T_in(i,j,k,0) = T_loc;
+        /* Dummy */
+        FC_in(i,j,k,0) = 0.0;
+    });  
 
 #ifdef MOD_REACTOR
     /* If reactor mode is activated, update time to perform subcycling */

--- a/Reactions/Null/reactor.cpp
+++ b/Reactions/Null/reactor.cpp
@@ -1,0 +1,84 @@
+#include <reactor.h> 
+
+using namespace amrex;
+
+/**********************************/
+/* Set or update typVals */
+void SetTypValsODE(const std::vector<double>& ExtTypVals) {}
+
+/* Set or update the rel/abs tolerances  */
+void SetTolFactODE(double relative_tol,double absolute_tol) {}
+
+/* Function to ReSet the tol of the cvode object directly */
+void ReSetTolODE() {}
+
+/* Initialization routine, called once at the begining of the problem */
+int reactor_init(int reactor_type, int ode_ncells) { return(0); }
+
+/* Main routine for CVode integration: integrate a Box version 1*/
+int react(const Box& box,
+          Array4<Real> const& rY_in,
+          Array4<Real> const& rY_src_in,
+          Array4<Real> const& T_in,
+          Array4<Real> const& rEner_in,
+          Array4<Real> const& rEner_src_in,
+          Array4<Real> const& FC_in,
+          Array4<int> const& mask,
+          Real &dt_react,
+          Real &time) {
+
+    /* Initial time and time to reach after integration */
+    time_init = time;
+
+#ifdef MOD_REACTOR
+    /* If reactor mode is activated, update time to perform subcycling */
+    time  = time_init + dt_react;
+#endif
+    /* Get estimate of how hard the integration process was */
+    return 0;
+}
+
+/* Main routine for CVode integration: integrate a Box version 2*/
+int react_2(const Box& box,
+          Array4<Real> const& rY_in,
+          Array4<Real> const& rY_src_in,
+          Array4<Real> const& T_in,
+          Array4<Real> const& rEner_in,
+          Array4<Real> const& rEner_src_in,
+          Array4<Real> const& FC_in,
+          Array4<int> const& mask_in,
+          Real &dt_react,
+          Real &time) {
+
+    /* Initial time and time to reach after integration */
+    time_init = time;
+
+#ifdef MOD_REACTOR
+    /* If reactor mode is activated, update time to perform subcycling */
+    time  = time_init + dt_react;
+#endif
+    /* Get estimate of how hard the integration process was */
+    return 0;
+}
+
+/* Main routine for CVode integration: classic version */
+int react(realtype *rY_in, realtype *rY_src_in, 
+          realtype *rX_in, realtype *rX_src_in,
+          realtype &dt_react, realtype &time){
+
+    /* Initial time and time to reach after integration */
+    time_init = time;
+
+#ifdef MOD_REACTOR
+    /* If reactor mode is activated, update time */
+    time  = time_init + dt_react;
+#endif
+    /* Get estimate of how hard the integration process was */
+    return 0;
+}
+
+/* Free memory */
+void reactor_close(){ }
+
+
+/* End of file  */

--- a/Reactions/Null/reactor.h
+++ b/Reactions/Null/reactor.h
@@ -1,3 +1,9 @@
+#include <math.h>
+
+#include <AMReX_FArrayBox.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_iMultiFab.H>
+
 /**********************************/
 /* Functions Called by the Program */
 int reactor_init(int cvode_iE, int Ncells);

--- a/Reactions/Null/reactor.h
+++ b/Reactions/Null/reactor.h
@@ -4,6 +4,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_iMultiFab.H>
 
+#include <EOS.H>
 /**********************************/
 /* Functions Called by the Program */
 int reactor_init(int cvode_iE, int Ncells);
@@ -16,17 +17,6 @@ int react(const amrex::Box& box,
           amrex::Array4<amrex::Real> const& rEner_src_in,
           amrex::Array4<amrex::Real> const& FC_in,
           amrex::Array4<int> const& mask, 
-          amrex::Real &dt_react,
-          amrex::Real &time);
-
-int react_2(const amrex::Box& box,
-          amrex::Array4<amrex::Real> const& rY_in,
-          amrex::Array4<amrex::Real> const& rY_src_in, 
-          amrex::Array4<amrex::Real> const& T_in,
-          amrex::Array4<amrex::Real> const& rEner_in,  
-          amrex::Array4<amrex::Real> const& rEner_src_in,
-          amrex::Array4<amrex::Real> const& FC_in,
-          amrex::Array4<int> const& mask,
           amrex::Real &dt_react,
           amrex::Real &time);
 

--- a/Reactions/Null/reactor.h
+++ b/Reactions/Null/reactor.h
@@ -1,0 +1,41 @@
+/**********************************/
+/* Functions Called by the Program */
+int reactor_init(int cvode_iE, int Ncells);
+
+int react(const amrex::Box& box,
+          amrex::Array4<amrex::Real> const& rY_in,
+          amrex::Array4<amrex::Real> const& rY_src_in, 
+          amrex::Array4<amrex::Real> const& T_in, 
+          amrex::Array4<amrex::Real> const& rEner_in,  
+          amrex::Array4<amrex::Real> const& rEner_src_in,
+          amrex::Array4<amrex::Real> const& FC_in,
+          amrex::Array4<int> const& mask, 
+          amrex::Real &dt_react,
+          amrex::Real &time);
+
+int react_2(const amrex::Box& box,
+          amrex::Array4<amrex::Real> const& rY_in,
+          amrex::Array4<amrex::Real> const& rY_src_in, 
+          amrex::Array4<amrex::Real> const& T_in,
+          amrex::Array4<amrex::Real> const& rEner_in,  
+          amrex::Array4<amrex::Real> const& rEner_src_in,
+          amrex::Array4<amrex::Real> const& FC_in,
+          amrex::Array4<int> const& mask,
+          amrex::Real &dt_react,
+          amrex::Real &time);
+
+int react(amrex::Real *rY_in, amrex::Real *rY_src_in, 
+	      amrex::Real *rX_in, amrex::Real *rX_src_in, 
+	      amrex::Real &dt_react, amrex::Real &time);
+
+void reactor_close();
+
+
+/**********************************/
+/* Helper functions */
+
+void SetTypValsODE(const std::vector<double>& ExtTypVals);
+
+void SetTolFactODE(double relative_tol,double absolute_tol);
+
+void ReSetTolODE();

--- a/Testing/Exec/EosEval/GNUmakefile
+++ b/Testing/Exec/EosEval/GNUmakefile
@@ -26,7 +26,7 @@ ifeq ($(FUEGO_GAS), TRUE)
 else
   Eos_dir         = GammaLaw
   Chemistry_Model = Null
-  Reactions_dir   = Fuego
+  Reactions_dir   = Null
   Transport_dir   = Constant
 endif
 

--- a/Testing/Exec/EosEval/main.cpp
+++ b/Testing/Exec/EosEval/main.cpp
@@ -26,7 +26,7 @@ main (int   argc,
     
       std::vector<int> npts(3,1);
       for (int i = 0; i < BL_SPACEDIM; ++i) {
-	npts[i] = 128;
+          npts[i] = 128;
       }
     
       Box domain(IntVect(D_DECL(0,0,0)),
@@ -34,8 +34,8 @@ main (int   argc,
 
       std::vector<Real> plo(3,0), phi(3,0), dx(3,1);
       for (int i=0; i<BL_SPACEDIM; ++i) {
-	phi[i] = domain.length(i);
-	dx[i] = (phi[i] - plo[i])/domain.length(i);
+          phi[i] = domain.length(i);
+          dx[i] = (phi[i] - plo[i])/domain.length(i);
       }
     
       int max_size = 32;
@@ -62,18 +62,19 @@ main (int   argc,
 #endif
       for (MFIter mfi(mass_frac,amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
 
-	const Box& gbox = mfi.tilebox();
+          const Box& gbox = mfi.tilebox();
 
-	Array4<Real> const& Y_a    = mass_frac.array(mfi);
-	Array4<Real> const& T_a    = temperature.array(mfi);
-	Array4<Real> const& rho_a  = density.array(mfi);
-	Array4<Real> const& e_a    = energy.array(mfi);
+          Array4<Real> const& Y_a    = mass_frac.array(mfi);
+          Array4<Real> const& T_a    = temperature.array(mfi);
+          Array4<Real> const& rho_a  = density.array(mfi);
+          Array4<Real> const& e_a    = energy.array(mfi);
 
-	amrex::ParallelFor(gbox, 
-	    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-		initialize_data(i, j, k, Y_a, T_a, rho_a, e_a ,
-				dx, plo, phi);
-	});
+          amrex::ParallelFor(gbox, 
+              [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                  initialize_data(i, j, k, Y_a, T_a, rho_a, e_a ,
+                                  dx, plo, phi);
+              }
+          );
 
       }
 
@@ -94,17 +95,18 @@ main (int   argc,
 #endif
       for (MFIter mfi(mass_frac,amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
 
-	const Box& gbox = mfi.tilebox();
+          const Box& gbox = mfi.tilebox();
 
-	Array4<Real> const& Y_a    = mass_frac.array(mfi);
-	Array4<Real> const& T_a    = temperature.array(mfi);
-	Array4<Real> const& cp_a   = cp.array(mfi);
+          Array4<Real> const& Y_a    = mass_frac.array(mfi);
+          Array4<Real> const& T_a    = temperature.array(mfi);
+          Array4<Real> const& cp_a   = cp.array(mfi);
 
-	amrex::ParallelFor(gbox, 
-	    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-	    get_cp(i, j, k, 
-	           Y_a, T_a, cp_a);
-	});
+          amrex::ParallelFor(gbox, 
+              [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                  get_cp(i, j, k, 
+                         Y_a, T_a, cp_a);
+              }
+          );
       }
       MultiFab::Copy(VarPlt,cp,0,0,1,num_grow);
 
@@ -114,17 +116,17 @@ main (int   argc,
 #endif
       for (MFIter mfi(mass_frac,amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
 
-	const Box& gbox = mfi.tilebox();
+          const Box& gbox = mfi.tilebox();
 
-	Array4<Real> const& Y_a    = mass_frac.array(mfi);
-	Array4<Real> const& T_a    = temperature.array(mfi);
-	Array4<Real> const& cv_a   = cv.array(mfi);
+          Array4<Real> const& Y_a    = mass_frac.array(mfi);
+          Array4<Real> const& T_a    = temperature.array(mfi);
+          Array4<Real> const& cv_a   = cv.array(mfi);
 
-	amrex::ParallelFor(gbox, 
-	    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-	    get_cv(i, j, k, 
-	           Y_a, T_a, cv_a);
-	});
+          amrex::ParallelFor(gbox, 
+              [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                  get_cv(i, j, k, 
+                         Y_a, T_a, cv_a);
+          });
       }
       MultiFab::Copy(VarPlt,cv,0,1,1,num_grow);
 
@@ -134,17 +136,17 @@ main (int   argc,
 #endif
       for (MFIter mfi(mass_frac,amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
 
-	const Box& gbox = mfi.tilebox();
+          const Box& gbox = mfi.tilebox();
 
-	Array4<Real> const& Y_a    = mass_frac.array(mfi);
-	Array4<Real> const& T_a    = temperature.array(mfi);
-	Array4<Real> const& e_a    = energy.array(mfi);
+          Array4<Real> const& Y_a    = mass_frac.array(mfi);
+          Array4<Real> const& T_a    = temperature.array(mfi);
+          Array4<Real> const& e_a    = energy.array(mfi);
 
-	amrex::ParallelFor(gbox, 
-	    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-	    get_T_from_EY(i, j, k, 
-	           Y_a, T_a, e_a);
-	});
+          amrex::ParallelFor(gbox, 
+              [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                  get_T_from_EY(i, j, k, 
+                                Y_a, T_a, e_a);
+          });
       }
       MultiFab::Copy(VarPlt,temperature,0,2,1,num_grow);
       MultiFab::Copy(VarPlt,energy,0,3,1,num_grow);

--- a/Testing/Exec/EosEval_FORTRAN/GNUmakefile
+++ b/Testing/Exec/EosEval_FORTRAN/GNUmakefile
@@ -27,7 +27,7 @@ ifeq ($(FUEGO_GAS), TRUE)
 else
   Eos_dir         = GammaLaw
   Chemistry_Model = Null
-  Reactions_dir   = Fuego
+  Reactions_dir   = Null
   Transport_dir   = Constant
 endif
 

--- a/Testing/Exec/EosEval_FORTRAN/main.cpp
+++ b/Testing/Exec/EosEval_FORTRAN/main.cpp
@@ -28,13 +28,13 @@ main (int   argc,
       std::vector<int> probin_file_name(probin_file_length);
 
       for (int i = 0; i < probin_file_length; i++)
-	probin_file_name[i] = probin_file[i];
+          probin_file_name[i] = probin_file[i];
 
       extern_init(&(probin_file_name[0]),&probin_file_length);
     
       std::vector<int> npts(3,1);
       for (int i = 0; i < BL_SPACEDIM; ++i) {
-	npts[i] = 128;
+          npts[i] = 128;
       }
     
       Box domain(IntVect(D_DECL(0,0,0)),
@@ -42,8 +42,8 @@ main (int   argc,
 
       std::vector<Real> plo(3,0), phi(3,0), dx(3,1);
       for (int i=0; i<BL_SPACEDIM; ++i) {
-	phi[i] = domain.length(i);
-	dx[i] = (phi[i] - plo[i])/domain.length(i);
+          phi[i] = domain.length(i);
+          dx[i] = (phi[i] - plo[i])/domain.length(i);
       }
     
       int max_size = 32;
@@ -69,13 +69,13 @@ main (int   argc,
 #pragma omp parallel
 #endif
       for (MFIter mfi(mass_frac,tilesize); mfi.isValid(); ++mfi) {
-	const Box& box = mfi.tilebox();
-	initialize_data(ARLIM_3D(box.loVect()), ARLIM_3D(box.hiVect()),
-			BL_TO_FORTRAN_N_3D(mass_frac[mfi],0),
-			BL_TO_FORTRAN_N_3D(temperature[mfi],0),
-			BL_TO_FORTRAN_N_3D(density[mfi],0),
-			BL_TO_FORTRAN_N_3D(energy[mfi],0),
-			&(dx[0]), &(plo[0]), &(phi[0]));
+          const Box& box = mfi.tilebox();
+          initialize_data(ARLIM_3D(box.loVect()), ARLIM_3D(box.hiVect()),
+                          BL_TO_FORTRAN_N_3D(mass_frac[mfi],0),
+                          BL_TO_FORTRAN_N_3D(temperature[mfi],0),
+                          BL_TO_FORTRAN_N_3D(density[mfi],0),
+                          BL_TO_FORTRAN_N_3D(energy[mfi],0),
+                          &(dx[0]), &(plo[0]), &(phi[0]));
       }
 
       // Plot init state for debug purposes
@@ -94,11 +94,11 @@ main (int   argc,
 #pragma omp parallel
 #endif
       for (MFIter mfi(mass_frac,tilesize); mfi.isValid(); ++mfi) {
-	const Box& box = mfi.tilebox();
-	get_cp(ARLIM_3D(box.loVect()), ARLIM_3D(box.hiVect()),
-	       BL_TO_FORTRAN_N_3D(mass_frac[mfi],0),
-	       BL_TO_FORTRAN_N_3D(temperature[mfi],0),
-	       BL_TO_FORTRAN_N_3D(cp[mfi],0));
+          const Box& box = mfi.tilebox();
+          get_cp(ARLIM_3D(box.loVect()), ARLIM_3D(box.hiVect()),
+               BL_TO_FORTRAN_N_3D(mass_frac[mfi],0),
+               BL_TO_FORTRAN_N_3D(temperature[mfi],0),
+               BL_TO_FORTRAN_N_3D(cp[mfi],0));
       }
       MultiFab::Copy(VarPlt,cp,0,0,1,num_grow);
 
@@ -106,11 +106,11 @@ main (int   argc,
 #pragma omp parallel
 #endif
       for (MFIter mfi(mass_frac,tilesize); mfi.isValid(); ++mfi) {
-	const Box& box = mfi.tilebox();
-	get_cv(ARLIM_3D(box.loVect()), ARLIM_3D(box.hiVect()),
-	       BL_TO_FORTRAN_N_3D(mass_frac[mfi],0),
-	       BL_TO_FORTRAN_N_3D(temperature[mfi],0),
-	       BL_TO_FORTRAN_N_3D(cv[mfi],0));
+          const Box& box = mfi.tilebox();
+          get_cv(ARLIM_3D(box.loVect()), ARLIM_3D(box.hiVect()),
+               BL_TO_FORTRAN_N_3D(mass_frac[mfi],0),
+               BL_TO_FORTRAN_N_3D(temperature[mfi],0),
+               BL_TO_FORTRAN_N_3D(cv[mfi],0));
       }
       MultiFab::Copy(VarPlt,cv,0,1,1,num_grow);
 
@@ -118,12 +118,12 @@ main (int   argc,
 #pragma omp parallel
 #endif
       for (MFIter mfi(mass_frac,tilesize); mfi.isValid(); ++mfi) {
-	const Box& box = mfi.tilebox();
-	get_T_from_EY(ARLIM_3D(box.loVect()), ARLIM_3D(box.hiVect()),
-	       BL_TO_FORTRAN_N_3D(mass_frac[mfi],0),
-	       BL_TO_FORTRAN_N_3D(temperature[mfi],0),
-	       BL_TO_FORTRAN_N_3D(density[mfi],0),
-	       BL_TO_FORTRAN_N_3D(energy[mfi],0));
+          const Box& box = mfi.tilebox();
+          get_T_from_EY(ARLIM_3D(box.loVect()), ARLIM_3D(box.hiVect()),
+               BL_TO_FORTRAN_N_3D(mass_frac[mfi],0),
+               BL_TO_FORTRAN_N_3D(temperature[mfi],0),
+               BL_TO_FORTRAN_N_3D(density[mfi],0),
+               BL_TO_FORTRAN_N_3D(energy[mfi],0));
       }
       MultiFab::Copy(VarPlt,temperature,0,2,1,num_grow);
       MultiFab::Copy(VarPlt,energy,0,3,1,num_grow);

--- a/Testing/Exec/Make.PelePhysics
+++ b/Testing/Exec/Make.PelePhysics
@@ -71,7 +71,7 @@ ifeq ($(USE_F90_PP),TRUE)
     INCLUDE_LOCATIONS += $(REACTIONS_HOME_F90) $(REACTIONS_PATH_F90)
     VPATH_LOCATIONS   += $(REACTIONS_HOME_F90) $(REACTIONS_PATH_F90)
 endif
-ifdef Chemistry_Model
+#ifdef Chemistry_Model
   ifeq ($(Eos_dir), GammaLaw)
     ifneq ($(Chemistry_Model), Null)
       $(error Chemistry_Model definition not compatible with Eos_Dir=GammaLaw)
@@ -83,7 +83,7 @@ ifdef Chemistry_Model
   Bpack += $(CHEM_HOME)/Make.package \
            $(CHEM_ALL)/Make.package
   Blocs += $(CHEM_HOME) $(CHEM_ALL)
-endif
+#endif
 Blocs   += $(PELE_PHYSICS_HOME)/Support/Fuego/Evaluation
 
 # Transport
@@ -145,9 +145,9 @@ INCLUDE_LOCATIONS +=  $(AMREX_HOME)/Tools/C_scripts
 
 MNAMES := EOS=$(EOS_PATH) REACTIONS=$(REACTIONS_PATH)
 MNAMES += TRANSPORT=$(TRAN_HOME)
-ifdef Chemistry_Model
+#ifdef Chemistry_Model
   MNAMES += CHEMISTRY=$(Chemistry_Model)
-endif
+#endif
 
 include $(PELE_PHYSICS_HOME)/ThirdParty/Make.ThirdParty
 

--- a/Testing/Exec/Make.PelePhysics
+++ b/Testing/Exec/Make.PelePhysics
@@ -71,19 +71,17 @@ ifeq ($(USE_F90_PP),TRUE)
     INCLUDE_LOCATIONS += $(REACTIONS_HOME_F90) $(REACTIONS_PATH_F90)
     VPATH_LOCATIONS   += $(REACTIONS_HOME_F90) $(REACTIONS_PATH_F90)
 endif
-#ifdef Chemistry_Model
-  ifeq ($(Eos_dir), GammaLaw)
-    ifneq ($(Chemistry_Model), Null)
-      $(error Chemistry_Model definition not compatible with Eos_Dir=GammaLaw)
-    endif
+ifeq ($(Eos_dir), GammaLaw)
+  ifneq ($(Chemistry_Model), Null)
+    $(error Chemistry_Model definition not compatible with Eos_Dir=GammaLaw)
   endif
-  CHEM_HOME = $(PELE_PHYSICS_HOME)/Support/Fuego/Mechanism/Models/$(Chemistry_Model)
-  CHEM_ALL  = $(PELE_PHYSICS_HOME)/Support/Fuego/Mechanism/Models
-  VPATH_LOCATIONS += $(CHEM_HOME) $(CHEM_ALL)
-  Bpack += $(CHEM_HOME)/Make.package \
-           $(CHEM_ALL)/Make.package
-  Blocs += $(CHEM_HOME) $(CHEM_ALL)
-#endif
+endif
+CHEM_HOME = $(PELE_PHYSICS_HOME)/Support/Fuego/Mechanism/Models/$(Chemistry_Model)
+CHEM_ALL  = $(PELE_PHYSICS_HOME)/Support/Fuego/Mechanism/Models
+VPATH_LOCATIONS += $(CHEM_HOME) $(CHEM_ALL)
+Bpack += $(CHEM_HOME)/Make.package \
+         $(CHEM_ALL)/Make.package
+Blocs += $(CHEM_HOME) $(CHEM_ALL)
 Blocs   += $(PELE_PHYSICS_HOME)/Support/Fuego/Evaluation
 
 # Transport
@@ -145,9 +143,7 @@ INCLUDE_LOCATIONS +=  $(AMREX_HOME)/Tools/C_scripts
 
 MNAMES := EOS=$(EOS_PATH) REACTIONS=$(REACTIONS_PATH)
 MNAMES += TRANSPORT=$(TRAN_HOME)
-#ifdef Chemistry_Model
-  MNAMES += CHEMISTRY=$(Chemistry_Model)
-#endif
+MNAMES += CHEMISTRY=$(Chemistry_Model)
 
 include $(PELE_PHYSICS_HOME)/ThirdParty/Make.ThirdParty
 

--- a/Testing/Exec/ReactEval_C/GNUmakefile
+++ b/Testing/Exec/ReactEval_C/GNUmakefile
@@ -50,10 +50,10 @@ ifeq ($(FUEGO_GAS), TRUE)
   Reactions_dir   = Fuego
   Transport_dir   = Simple
 else
+  Eos_dir         = GammaLaw
   Chemistry_Model = Null
-  Eos_dir       = GammaLaw
-  Reactions_dir = Fuego
-  Transport_dir = Constant
+  Reactions_dir   = Null
+  Transport_dir   = Constant
 endif
 
 Bpack   := ./Make.package

--- a/Testing/Exec/TranEval/GNUmakefile
+++ b/Testing/Exec/TranEval/GNUmakefile
@@ -26,7 +26,7 @@ ifeq ($(FUEGO_GAS), TRUE)
 else
   Eos_dir         = GammaLaw
   Chemistry_Model = Null
-  Reactions_dir   = Fuego
+  Reactions_dir   = Null
   Transport_dir   = Constant
 endif
 

--- a/Testing/Exec/TranEval/main.cpp
+++ b/Testing/Exec/TranEval/main.cpp
@@ -28,7 +28,7 @@ main (int   argc,
     
       std::vector<int> npts(3,1);
       for (int i = 0; i < BL_SPACEDIM; ++i) {
-	npts[i] = 128;
+          npts[i] = 128;
       }
     
       Box domain(IntVect(D_DECL(0,0,0)),
@@ -36,8 +36,8 @@ main (int   argc,
 
       std::vector<Real> plo(3,0), phi(3,0), dx(3,1);
       for (int i=0; i<BL_SPACEDIM; ++i) {
-	phi[i] = domain.length(i);
-	dx[i] = (phi[i] - plo[i])/domain.length(i);
+          phi[i] = domain.length(i);
+          dx[i] = (phi[i] - plo[i])/domain.length(i);
       }
     
       int max_size = 32;
@@ -63,17 +63,17 @@ main (int   argc,
 #endif
       for (MFIter mfi(mass_frac,amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
 
-	const Box& gbox = mfi.tilebox();
+          const Box& gbox = mfi.tilebox();
 
-	Array4<Real> const& Y_a    = mass_frac.array(mfi);
-	Array4<Real> const& T_a    = temperature.array(mfi);
-	Array4<Real> const& rho_a  = density.array(mfi);
+          Array4<Real> const& Y_a    = mass_frac.array(mfi);
+          Array4<Real> const& T_a    = temperature.array(mfi);
+          Array4<Real> const& rho_a  = density.array(mfi);
 
-	amrex::ParallelFor(gbox, 
-	    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-		initialize_data(i, j, k, Y_a, T_a, rho_a, 
-				dx, plo, phi);
-	});
+          amrex::ParallelFor(gbox, 
+              [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                  initialize_data(i, j, k, Y_a, T_a, rho_a, 
+                                  dx, plo, phi);
+          });
 
       }
 
@@ -95,21 +95,21 @@ main (int   argc,
 #endif
       for (MFIter mfi(mass_frac,amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
 
-	const Box& gbox = mfi.tilebox();
+          const Box& gbox = mfi.tilebox();
 
-	Array4<Real> const& Y_a    = mass_frac.array(mfi);
-	Array4<Real> const& T_a    = temperature.array(mfi);
-	Array4<Real> const& rho_a  = density.array(mfi);
-	Array4<Real> const& D_a    = D.array(mfi);
-	Array4<Real> const& mu_a   = mu.array(mfi);
-	Array4<Real> const& xi_a   = xi.array(mfi);
-	Array4<Real> const& lam_a  = lam.array(mfi);
+          Array4<Real> const& Y_a    = mass_frac.array(mfi);
+          Array4<Real> const& T_a    = temperature.array(mfi);
+          Array4<Real> const& rho_a  = density.array(mfi);
+          Array4<Real> const& D_a    = D.array(mfi);
+          Array4<Real> const& mu_a   = mu.array(mfi);
+          Array4<Real> const& xi_a   = xi.array(mfi);
+          Array4<Real> const& lam_a  = lam.array(mfi);
 
-	amrex::launch(gbox, [=] AMREX_GPU_DEVICE(amrex::Box const& tbx) {
-		get_transport_coeffs(tbx,
-				Y_a, T_a, rho_a, 
-				D_a, mu_a, xi_a, lam_a);
-	});
+          amrex::launch(gbox, [=] AMREX_GPU_DEVICE(amrex::Box const& tbx) {
+                    get_transport_coeffs(tbx,
+                                         Y_a, T_a, rho_a, 
+                                         D_a, mu_a, xi_a, lam_a);
+          });
       }
 
       transport_close();

--- a/Testing/Exec/TranEval_FORTRAN/GNUmakefile
+++ b/Testing/Exec/TranEval_FORTRAN/GNUmakefile
@@ -26,7 +26,7 @@ ifeq ($(FUEGO_GAS), TRUE)
 else
   Eos_dir         = GammaLaw
   Chemistry_Model = Null
-  Reactions_dir   = Fuego
+  Reactions_dir   = Null
   Transport_dir   = Constant
 endif
 

--- a/Testing/Exec/TranEval_FORTRAN/main.cpp
+++ b/Testing/Exec/TranEval_FORTRAN/main.cpp
@@ -29,13 +29,13 @@ main (int   argc,
       std::vector<int> probin_file_name(probin_file_length);
 
       for (int i = 0; i < probin_file_length; i++)
-	probin_file_name[i] = probin_file[i];
+          probin_file_name[i] = probin_file[i];
 
       extern_init(&(probin_file_name[0]),&probin_file_length);
     
       std::vector<int> npts(3,1);
       for (int i = 0; i < BL_SPACEDIM; ++i) {
-	npts[i] = 128;
+          npts[i] = 128;
       }
     
       Box domain(IntVect(D_DECL(0,0,0)),
@@ -43,8 +43,8 @@ main (int   argc,
 
       std::vector<Real> plo(3,0), phi(3,0), dx(3,1);
       for (int i=0; i<BL_SPACEDIM; ++i) {
-	phi[i] = domain.length(i);
-	dx[i] = (phi[i] - plo[i])/domain.length(i);
+          phi[i] = domain.length(i);
+          dx[i] = (phi[i] - plo[i])/domain.length(i);
       }
     
       int max_size = 32;
@@ -69,12 +69,12 @@ main (int   argc,
 #pragma omp parallel
 #endif
       for (MFIter mfi(mass_frac,tilesize); mfi.isValid(); ++mfi) {
-	const Box& box = mfi.tilebox();
-	initialize_data(ARLIM_3D(box.loVect()), ARLIM_3D(box.hiVect()),
-			BL_TO_FORTRAN_N_3D(mass_frac[mfi],0),
-			BL_TO_FORTRAN_N_3D(temperature[mfi],0),
-			BL_TO_FORTRAN_N_3D(density[mfi],0),
-			&(dx[0]), &(plo[0]), &(phi[0]));
+          const Box& box = mfi.tilebox();
+          initialize_data(ARLIM_3D(box.loVect()), ARLIM_3D(box.hiVect()),
+                          BL_TO_FORTRAN_N_3D(mass_frac[mfi],0),
+                          BL_TO_FORTRAN_N_3D(temperature[mfi],0),
+                          BL_TO_FORTRAN_N_3D(density[mfi],0),
+                          &(dx[0]), &(plo[0]), &(phi[0]));
       }
 
       // Plot init state for debug purposes
@@ -91,15 +91,15 @@ main (int   argc,
 #pragma omp parallel
 #endif
       for (MFIter mfi(mass_frac,tilesize); mfi.isValid(); ++mfi) {
-	const Box& box = mfi.tilebox();
-	get_transport_coeffs_F(ARLIM_3D(box.loVect()), ARLIM_3D(box.hiVect()),
-			     BL_TO_FORTRAN_N_3D(mass_frac[mfi],0),
-			     BL_TO_FORTRAN_N_3D(temperature[mfi],0),
-			     BL_TO_FORTRAN_N_3D(density[mfi],0),
-			     BL_TO_FORTRAN_N_3D(D[mfi],0),
-			     BL_TO_FORTRAN_N_3D(D[mfi],NUM_SPECIES),
-			     BL_TO_FORTRAN_N_3D(D[mfi],NUM_SPECIES+1),
-			     BL_TO_FORTRAN_N_3D(D[mfi],NUM_SPECIES+2));
+          const Box& box = mfi.tilebox();
+          get_transport_coeffs_F(ARLIM_3D(box.loVect()), ARLIM_3D(box.hiVect()),
+               BL_TO_FORTRAN_N_3D(mass_frac[mfi],0),
+               BL_TO_FORTRAN_N_3D(temperature[mfi],0),
+               BL_TO_FORTRAN_N_3D(density[mfi],0),
+               BL_TO_FORTRAN_N_3D(D[mfi],0),
+               BL_TO_FORTRAN_N_3D(D[mfi],NUM_SPECIES),
+               BL_TO_FORTRAN_N_3D(D[mfi],NUM_SPECIES+1),
+               BL_TO_FORTRAN_N_3D(D[mfi],NUM_SPECIES+2));
       }
 
       std::string outfile = amrex::Concatenate(pltfile,1); // Need a number other than zero for reg test to pass


### PR DESCRIPTION
This branch reinstate the "Null" reaction folder so that when "no chemistry" is needed (in the sense that no reactions occur, not necessarily mean we have no species) then react() simply does nothing.
Makes it possible to compile non reacting test cases without sundials.
Does not break anything or changes any structure in place currently in any of the Pele codes