### PR TITLE
Use amrex::Real instead of double during Fuego code generation

### DIFF
--- a/Support/Fuego/Mechanism/Models/Davis/chemistry_file.H
+++ b/Support/Fuego/Mechanism/Models/Davis/chemistry_file.H
@@ -7,28 +7,28 @@
 
 extern "C"
 {
-AMREX_GPU_HOST_DEVICE void get_imw(double imw_new[]);
-AMREX_GPU_HOST_DEVICE void get_mw(double mw_new[]);
-void egtransetEPS(double *  EPS);
-void egtransetSIG(double* SIG);
-void atomicWeight(double *  awt);
-void molecularWeight(double *  wt);
-AMREX_GPU_HOST_DEVICE void gibbs(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void helmholtz(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void speciesEntropy(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void cp_R(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void cv_R(double *  species, double *  tc);
-void equilibriumConstants(double *  kc, double *  g_RT, double T);
-AMREX_GPU_HOST_DEVICE void productionRate(double *  wdot, double *  sc, double T);
-AMREX_GPU_HOST_DEVICE void comp_qfqr(double *  q_f, double *  q_r, double *  sc, double *  tc, double invT);
+AMREX_GPU_HOST_DEVICE void get_imw(amrex::Real imw_new[]);
+AMREX_GPU_HOST_DEVICE void get_mw(amrex::Real mw_new[]);
+void egtransetEPS(amrex::Real *  EPS);
+void egtransetSIG(amrex::Real* SIG);
+void atomicWeight(amrex::Real *  awt);
+void molecularWeight(amrex::Real *  wt);
+AMREX_GPU_HOST_DEVICE void gibbs(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void helmholtz(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void speciesEnthalpy(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void speciesEntropy(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void cp_R(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void cv_R(amrex::Real *  species, amrex::Real *  tc);
+void equilibriumConstants(amrex::Real *  kc, amrex::Real *  g_RT, amrex::Real T);
+AMREX_GPU_HOST_DEVICE void productionRate(amrex::Real *  wdot, amrex::Real *  sc, amrex::Real T);
+AMREX_GPU_HOST_DEVICE void comp_qfqr(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  sc, amrex::Real *  tc, amrex::Real invT);
 #ifndef AMREX_USE_CUDA
-void comp_k_f(double *  tc, double invT, double *  k_f);
-void comp_Kc(double *  tc, double invT, double *  Kc);
+void comp_k_f(amrex::Real *  tc, amrex::Real invT, amrex::Real *  k_f);
+void comp_Kc(amrex::Real *  tc, amrex::Real invT, amrex::Real *  Kc);
 #endif
-AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  speciesConc, double T);
-AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *  speciesConc, double T);
+AMREX_GPU_HOST_DEVICE void progressRate(amrex::Real *  qdot, amrex::Real *  speciesConc, amrex::Real T);
+AMREX_GPU_HOST_DEVICE void progressRateFR(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  speciesConc, amrex::Real T);
 AMREX_GPU_HOST_DEVICE void CKINIT();
 AMREX_GPU_HOST_DEVICE void CKFINALIZE();
 #ifndef AMREX_USE_CUDA
@@ -36,87 +36,87 @@ void GET_REACTION_MAP(int *  rmap);
 void SetAllDefaults();
 #endif
 void CKINDX(int * mm, int * kk, int * ii, int * nfit );
-void CKXNUM(char * line, int * nexp, int * lout, int * nval, double *  rval, int * kerr, int lenline);
-void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, double *  rval, int * kerr, int lenline, int lenkray);
+void CKXNUM(char * line, int * nexp, int * lout, int * nval, amrex::Real *  rval, int * kerr, int lenline);
+void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, amrex::Real *  rval, int * kerr, int lenline, int lenkray);
 void CKSYME_STR(amrex::Vector<std::string>& ename);
 void CKSYME(int * kname, int * lenkname);
 void CKSYMS_STR(amrex::Vector<std::string>& kname);
 void CKSYMS(int * kname, int * lenkname);
-void CKRP(double *  ru, double *  ruc, double *  pa);
-void CKPX(double *  rho, double *  T, double *  x, double *  P);
-AMREX_GPU_HOST_DEVICE void CKPY(double *  rho, double *  T, double *  y, double *  P);
-void CKPC(double *  rho, double *  T, double *  c, double *  P);
-void CKRHOX(double *  P, double *  T, double *  x, double *  rho);
-AMREX_GPU_HOST_DEVICE void CKRHOY(double *  P, double *  T, double *  y, double *  rho);
-void CKRHOC(double *  P, double *  T, double *  c, double *  rho);
-void CKWT(double *  wt);
-void CKAWT(double *  awt);
-AMREX_GPU_HOST_DEVICE void CKMMWY(double *  y, double *  wtm);
-void CKMMWX(double *  x, double *  wtm);
-void CKMMWC(double *  c, double *  wtm);
-AMREX_GPU_HOST_DEVICE void CKYTX(double *  y, double *  x);
-void CKYTCP(double *  P, double *  T, double *  y, double *  c);
-AMREX_GPU_HOST_DEVICE void CKYTCR(double *  rho, double *  T, double *  y, double *  c);
-AMREX_GPU_HOST_DEVICE void CKXTY(double *  x, double *  y);
-void CKXTCP(double *  P, double *  T, double *  x, double *  c);
-void CKXTCR(double *  rho, double *  T, double *  x, double *  c);
-void CKCTX(double *  c, double *  x);
-void CKCTY(double *  c, double *  y);
-void CKCPOR(double *  T, double *  cpor);
-void CKHORT(double *  T, double *  hort);
-void CKSOR(double *  T, double *  sor);
-void CKCVML(double *  T, double *  cvml);
-void CKCPML(double *  T, double *  cvml);
-void CKUML(double *  T, double *  uml);
-void CKHML(double *  T, double *  uml);
-void CKGML(double *  T, double *  gml);
-void CKAML(double *  T, double *  aml);
-void CKSML(double *  T, double *  sml);
-AMREX_GPU_HOST_DEVICE void CKCVMS(double *  T, double *  cvms);
-AMREX_GPU_HOST_DEVICE void CKCPMS(double *  T, double *  cvms);
-AMREX_GPU_HOST_DEVICE void CKUMS(double *  T, double *  ums);
-AMREX_GPU_HOST_DEVICE void CKHMS(double *  T, double *  ums);
-void CKGMS(double *  T, double *  gms);
-void CKAMS(double *  T, double *  ams);
-void CKSMS(double *  T, double *  sms);
-void CKCPBL(double *  T, double *  x, double *  cpbl);
-AMREX_GPU_HOST_DEVICE void CKCPBS(double *  T, double *  y, double *  cpbs);
-void CKCVBL(double *  T, double *  x, double *  cpbl);
-AMREX_GPU_HOST_DEVICE void CKCVBS(double *  T, double *  y, double *  cpbs);
-void CKHBML(double *  T, double *  x, double *  hbml);
-AMREX_GPU_HOST_DEVICE void CKHBMS(double *  T, double *  y, double *  hbms);
-void CKUBML(double *  T, double *  x, double *  ubml);
-AMREX_GPU_HOST_DEVICE void CKUBMS(double *  T, double *  y, double *  ubms);
-void CKSBML(double *  P, double *  T, double *  x, double *  sbml);
-void CKSBMS(double *  P, double *  T, double *  y, double *  sbms);
-void CKGBML(double *  P, double *  T, double *  x, double *  gbml);
-void CKGBMS(double *  P, double *  T, double *  y, double *  gbms);
-void CKABML(double *  P, double *  T, double *  x, double *  abml);
-void CKABMS(double *  P, double *  T, double *  y, double *  abms);
-AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C, double *  wdot);
-void CKWYP(double *  P, double *  T, double *  y, double *  wdot);
-void CKWXP(double *  P, double *  T, double *  x, double *  wdot);
-AMREX_GPU_HOST_DEVICE void CKWYR(double *  rho, double *  T, double *  y, double *  wdot);
-void CKWXR(double *  rho, double *  T, double *  x, double *  wdot);
-void CKQC(double *  T, double *  C, double *  qdot);
-void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r);
-void CKQYP(double *  P, double *  T, double *  y, double *  qdot);
-void CKQXP(double *  P, double *  T, double *  x, double *  qdot);
-void CKQYR(double *  rho, double *  T, double *  y, double *  qdot);
-void CKQXR(double *  rho, double *  T, double *  x, double *  qdot);
+void CKRP(amrex::Real *  ru, amrex::Real *  ruc, amrex::Real *  pa);
+void CKPX(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  P);
+AMREX_GPU_HOST_DEVICE void CKPY(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  P);
+void CKPC(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  c, amrex::Real *  P);
+void CKRHOX(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  rho);
+AMREX_GPU_HOST_DEVICE void CKRHOY(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  rho);
+void CKRHOC(amrex::Real *  P, amrex::Real *  T, amrex::Real *  c, amrex::Real *  rho);
+void CKWT(amrex::Real *  wt);
+void CKAWT(amrex::Real *  awt);
+AMREX_GPU_HOST_DEVICE void CKMMWY(amrex::Real *  y, amrex::Real *  wtm);
+void CKMMWX(amrex::Real *  x, amrex::Real *  wtm);
+void CKMMWC(amrex::Real *  c, amrex::Real *  wtm);
+AMREX_GPU_HOST_DEVICE void CKYTX(amrex::Real *  y, amrex::Real *  x);
+void CKYTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  c);
+AMREX_GPU_HOST_DEVICE void CKYTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  c);
+AMREX_GPU_HOST_DEVICE void CKXTY(amrex::Real *  x, amrex::Real *  y);
+void CKXTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c);
+void CKXTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c);
+void CKCTX(amrex::Real *  c, amrex::Real *  x);
+void CKCTY(amrex::Real *  c, amrex::Real *  y);
+void CKCPOR(amrex::Real *  T, amrex::Real *  cpor);
+void CKHORT(amrex::Real *  T, amrex::Real *  hort);
+void CKSOR(amrex::Real *  T, amrex::Real *  sor);
+void CKCVML(amrex::Real *  T, amrex::Real *  cvml);
+void CKCPML(amrex::Real *  T, amrex::Real *  cvml);
+void CKUML(amrex::Real *  T, amrex::Real *  uml);
+void CKHML(amrex::Real *  T, amrex::Real *  uml);
+void CKGML(amrex::Real *  T, amrex::Real *  gml);
+void CKAML(amrex::Real *  T, amrex::Real *  aml);
+void CKSML(amrex::Real *  T, amrex::Real *  sml);
+AMREX_GPU_HOST_DEVICE void CKCVMS(amrex::Real *  T, amrex::Real *  cvms);
+AMREX_GPU_HOST_DEVICE void CKCPMS(amrex::Real *  T, amrex::Real *  cvms);
+AMREX_GPU_HOST_DEVICE void CKUMS(amrex::Real *  T, amrex::Real *  ums);
+AMREX_GPU_HOST_DEVICE void CKHMS(amrex::Real *  T, amrex::Real *  ums);
+void CKGMS(amrex::Real *  T, amrex::Real *  gms);
+void CKAMS(amrex::Real *  T, amrex::Real *  ams);
+void CKSMS(amrex::Real *  T, amrex::Real *  sms);
+void CKCPBL(amrex::Real *  T, amrex::Real *  x, amrex::Real *  cpbl);
+AMREX_GPU_HOST_DEVICE void CKCPBS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  cpbs);
+void CKCVBL(amrex::Real *  T, amrex::Real *  x, amrex::Real *  cpbl);
+AMREX_GPU_HOST_DEVICE void CKCVBS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  cpbs);
+void CKHBML(amrex::Real *  T, amrex::Real *  x, amrex::Real *  hbml);
+AMREX_GPU_HOST_DEVICE void CKHBMS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  hbms);
+void CKUBML(amrex::Real *  T, amrex::Real *  x, amrex::Real *  ubml);
+AMREX_GPU_HOST_DEVICE void CKUBMS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  ubms);
+void CKSBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  sbml);
+void CKSBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  sbms);
+void CKGBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  gbml);
+void CKGBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  gbms);
+void CKABML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  abml);
+void CKABMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  abms);
+AMREX_GPU_HOST_DEVICE void CKWC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  wdot);
+void CKWYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  wdot);
+void CKWXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  wdot);
+AMREX_GPU_HOST_DEVICE void CKWYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  wdot);
+void CKWXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  wdot);
+void CKQC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  qdot);
+void CKKFKR(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  q_f, amrex::Real *  q_r);
+void CKQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot);
+void CKQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot);
+void CKQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot);
+void CKQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot);
 void CKNU(int * kdim, int * nuki);
 #ifndef AMREX_USE_CUDA
 void CKINU(int * i, int * nspec, int * ki, int * nu);
 #endif
 void CKNCF(int * ncf);
-void CKABE(double *  a, double *  b, double *  e );
-void CKEQC(double *  T, double *  C , double *  eqcon );
-void CKEQYP(double *  P, double *  T, double *  y, double *  eqcon);
-void CKEQXP(double *  P, double *  T, double *  x, double *  eqcon);
-void CKEQYR(double *  rho, double *  T, double *  y, double *  eqcon);
-void CKEQXR(double *  rho, double *  T, double *  x, double *  eqcon);
-AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  T, int * consP);
-AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double *  Tp, int * HP);
+void CKABE(amrex::Real *  a, amrex::Real *  b, amrex::Real *  e );
+void CKEQC(amrex::Real *  T, amrex::Real *  C , amrex::Real *  eqcon );
+void CKEQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon);
+void CKEQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon);
+void CKEQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon);
+void CKEQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon);
+AMREX_GPU_HOST_DEVICE void DWDOT(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  T, int * consP);
+AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * HP);
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO(int * nJdata, int * consP, int NCELLS);
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST(int * nJdata, int * consP, int NCELLS);
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED(int * nJdata, int * consP);
@@ -125,27 +125,27 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSR(int * colVals, int * rowPtrs, in
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtrs, int * consP, int NCELLS, int base);
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, int * colPtrs, int * indx, int * consP);
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, int * rowPtr, int * consP, int base);
-AMREX_GPU_HOST_DEVICE void aJacobian(double *  J, double *  sc, double T, int consP);
-AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T, int HP);
-AMREX_GPU_HOST_DEVICE void dcvpRdT(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t, int *ierr);
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t, int *ierr);
-void GET_CRITPARAMS(double *  Tci, double *  ai, double *  bi, double *  acentric_i);
+AMREX_GPU_HOST_DEVICE void aJacobian(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int consP);
+AMREX_GPU_HOST_DEVICE void aJacobian_precond(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int HP);
+AMREX_GPU_HOST_DEVICE void dcvpRdT(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(amrex::Real *  e, amrex::Real *  y, amrex::Real *  t, int *ierr);
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(amrex::Real *  h, amrex::Real *  y, amrex::Real *  t, int *ierr);
+void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i);
 /*vector version */
-void VCKYTX(int *  np, double *  y, double *  x);
-void VCKHMS(int *  np, double *  T, double *  ums);
-void VCKWYR(int *  np, double *  rho, double *  T,
-            double *  y,
-            double *  wdot);
+void VCKYTX(int *  np, amrex::Real *  y, amrex::Real *  x);
+void VCKHMS(int *  np, amrex::Real *  T, amrex::Real *  ums);
+void VCKWYR(int *  np, amrex::Real *  rho, amrex::Real *  T,
+            amrex::Real *  y,
+            amrex::Real *  wdot);
 #ifndef AMREX_USE_CUDA
-void vproductionRate(int npt, double *  wdot, double *  c, double *  T);
-void VCKPY(int *  np, double *  rho, double *  T, double *  y, double *  P);
-void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT);
-void vcomp_gibbs(int npt, double *  g_RT, double *  tc);
-void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT);
-void vcomp_wdot(int npt, double *  wdot, double *  mixture, double *  sc,
-                double *  k_f_s, double *  Kc_s,
-                double *  tc, double *  invT, double *  T);
+void vproductionRate(int npt, amrex::Real *  wdot, amrex::Real *  c, amrex::Real *  T);
+void VCKPY(int *  np, amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  P);
+void vcomp_k_f(int npt, amrex::Real *  k_f_s, amrex::Real *  tc, amrex::Real *  invT);
+void vcomp_gibbs(int npt, amrex::Real *  g_RT, amrex::Real *  tc);
+void vcomp_Kc(int npt, amrex::Real *  Kc_s, amrex::Real *  g_RT, amrex::Real *  invT);
+void vcomp_wdot(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,
+                amrex::Real *  k_f_s, amrex::Real *  Kc_s,
+                amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T);
 #endif
 /*Transport function declarations */
 void egtransetLENIMC(int* LENIMC);
@@ -153,46 +153,46 @@ void egtransetLENRMC(int* LENRMC);
 void egtransetNO(int* NO);
 void egtransetKK(int* KK);
 void egtransetNLITE(int* NLITE);
-void egtransetPATM(double* PATM);
-void egtransetWT(double* WT);
-void egtransetEPS(double* EPS);
-void egtransetSIG(double* SIG);
-void egtransetDIP(double* DIP);
-void egtransetPOL(double* POL);
-void egtransetZROT(double* ZROT);
+void egtransetPATM(amrex::Real* PATM);
+void egtransetWT(amrex::Real* WT);
+void egtransetEPS(amrex::Real* EPS);
+void egtransetSIG(amrex::Real* SIG);
+void egtransetDIP(amrex::Real* DIP);
+void egtransetPOL(amrex::Real* POL);
+void egtransetZROT(amrex::Real* ZROT);
 void egtransetNLIN(int* NLIN);
-void egtransetCOFETA(double* COFETA);
-void egtransetCOFLAM(double* COFLAM);
-void egtransetCOFD(double* COFD);
+void egtransetCOFETA(amrex::Real* COFETA);
+void egtransetCOFLAM(amrex::Real* COFLAM);
+void egtransetCOFD(amrex::Real* COFD);
 void egtransetKTDIF(int* KTDIF);
 /*gauss-jordan solver external routine */
-AMREX_GPU_HOST_DEVICE void sgjsolve(double* A, double* x, double* b);
-AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(double* A, double* x, double* b);
+AMREX_GPU_HOST_DEVICE void sgjsolve(amrex::Real* A, amrex::Real* x, amrex::Real* b);
+AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(amrex::Real* A, amrex::Real* x, amrex::Real* b);
 }
 
 #ifndef AMREX_USE_CUDA
 namespace thermo
 {
 
-    extern double fwd_A[38], fwd_beta[38], fwd_Ea[38];
-    extern double low_A[38], low_beta[38], low_Ea[38];
-    extern double rev_A[38], rev_beta[38], rev_Ea[38];
-    extern double troe_a[38],troe_Ts[38], troe_Tss[38], troe_Tsss[38];
-    extern double sri_a[38], sri_b[38], sri_c[38], sri_d[38], sri_e[38];
-    extern double activation_units[38], prefactor_units[38], phase_units[38];
+    extern amrex::Real fwd_A[38], fwd_beta[38], fwd_Ea[38];
+    extern amrex::Real low_A[38], low_beta[38], low_Ea[38];
+    extern amrex::Real rev_A[38], rev_beta[38], rev_Ea[38];
+    extern amrex::Real troe_a[38],troe_Ts[38], troe_Tss[38], troe_Tsss[38];
+    extern amrex::Real sri_a[38], sri_b[38], sri_c[38], sri_d[38], sri_e[38];
+    extern amrex::Real activation_units[38], prefactor_units[38], phase_units[38];
     extern int is_PD[38], troe_len[38], sri_len[38], nTB[38], *TBid[38];
-    extern double *TB[38];
-    extern std::vector<std::vector<double>> kiv; 
-    extern std::vector<std::vector<double>> nuv; 
+    extern amrex::Real *TB[38];
+    extern std::vector<std::vector<amrex::Real>> kiv; 
+    extern std::vector<std::vector<amrex::Real>> nuv; 
 
-    extern double fwd_A_DEF[38], fwd_beta_DEF[38], fwd_Ea_DEF[38];
-    extern double low_A_DEF[38], low_beta_DEF[38], low_Ea_DEF[38];
-    extern double rev_A_DEF[38], rev_beta_DEF[38], rev_Ea_DEF[38];
-    extern double troe_a_DEF[38],troe_Ts_DEF[38], troe_Tss_DEF[38], troe_Tsss_DEF[38];
-    extern double sri_a_DEF[38], sri_b_DEF[38], sri_c_DEF[38], sri_d_DEF[38], sri_e_DEF[38];
-    extern double activation_units_DEF[38], prefactor_units_DEF[38], phase_units_DEF[38];
+    extern amrex::Real fwd_A_DEF[38], fwd_beta_DEF[38], fwd_Ea_DEF[38];
+    extern amrex::Real low_A_DEF[38], low_beta_DEF[38], low_Ea_DEF[38];
+    extern amrex::Real rev_A_DEF[38], rev_beta_DEF[38], rev_Ea_DEF[38];
+    extern amrex::Real troe_a_DEF[38],troe_Ts_DEF[38], troe_Tss_DEF[38], troe_Tsss_DEF[38];
+    extern amrex::Real sri_a_DEF[38], sri_b_DEF[38], sri_c_DEF[38], sri_d_DEF[38], sri_e_DEF[38];
+    extern amrex::Real activation_units_DEF[38], prefactor_units_DEF[38], phase_units_DEF[38];
     extern int is_PD_DEF[38], troe_len_DEF[38], sri_len_DEF[38], nTB_DEF[38], *TBid_DEF[38];
-    extern double *TB_DEF[38];
+    extern amrex::Real *TB_DEF[38];
     extern std::vector<int> rxn_map;
 }
 #endif

--- a/Support/Fuego/Mechanism/Models/Davis/mechanism.cpp
+++ b/Support/Fuego/Mechanism/Models/Davis/mechanism.cpp
@@ -3,25 +3,25 @@
 #ifndef AMREX_USE_CUDA
 namespace thermo
 {
-    double fwd_A[38], fwd_beta[38], fwd_Ea[38];
-    double low_A[38], low_beta[38], low_Ea[38];
-    double rev_A[38], rev_beta[38], rev_Ea[38];
-    double troe_a[38],troe_Ts[38], troe_Tss[38], troe_Tsss[38];
-    double sri_a[38], sri_b[38], sri_c[38], sri_d[38], sri_e[38];
-    double activation_units[38], prefactor_units[38], phase_units[38];
+    amrex::Real fwd_A[38], fwd_beta[38], fwd_Ea[38];
+    amrex::Real low_A[38], low_beta[38], low_Ea[38];
+    amrex::Real rev_A[38], rev_beta[38], rev_Ea[38];
+    amrex::Real troe_a[38],troe_Ts[38], troe_Tss[38], troe_Tsss[38];
+    amrex::Real sri_a[38], sri_b[38], sri_c[38], sri_d[38], sri_e[38];
+    amrex::Real activation_units[38], prefactor_units[38], phase_units[38];
     int is_PD[38], troe_len[38], sri_len[38], nTB[38], *TBid[38];
-    double *TB[38];
-    std::vector<std::vector<double>> kiv(38); 
-    std::vector<std::vector<double>> nuv(38); 
+    amrex::Real *TB[38];
+    std::vector<std::vector<amrex::Real>> kiv(38); 
+    std::vector<std::vector<amrex::Real>> nuv(38); 
 
-    double fwd_A_DEF[38], fwd_beta_DEF[38], fwd_Ea_DEF[38];
-    double low_A_DEF[38], low_beta_DEF[38], low_Ea_DEF[38];
-    double rev_A_DEF[38], rev_beta_DEF[38], rev_Ea_DEF[38];
-    double troe_a_DEF[38],troe_Ts_DEF[38], troe_Tss_DEF[38], troe_Tsss_DEF[38];
-    double sri_a_DEF[38], sri_b_DEF[38], sri_c_DEF[38], sri_d_DEF[38], sri_e_DEF[38];
-    double activation_units_DEF[38], prefactor_units_DEF[38], phase_units_DEF[38];
+    amrex::Real fwd_A_DEF[38], fwd_beta_DEF[38], fwd_Ea_DEF[38];
+    amrex::Real low_A_DEF[38], low_beta_DEF[38], low_Ea_DEF[38];
+    amrex::Real rev_A_DEF[38], rev_beta_DEF[38], rev_Ea_DEF[38];
+    amrex::Real troe_a_DEF[38],troe_Ts_DEF[38], troe_Tss_DEF[38], troe_Tsss_DEF[38];
+    amrex::Real sri_a_DEF[38], sri_b_DEF[38], sri_c_DEF[38], sri_d_DEF[38], sri_e_DEF[38];
+    amrex::Real activation_units_DEF[38], prefactor_units_DEF[38], phase_units_DEF[38];
     int is_PD_DEF[38], troe_len_DEF[38], sri_len_DEF[38], nTB_DEF[38], *TBid_DEF[38];
-    double *TB_DEF[38];
+    amrex::Real *TB_DEF[38];
     std::vector<int> rxn_map;
 };
 
@@ -30,7 +30,7 @@ using namespace thermo;
 
 /* Inverse molecular weights */
 /* TODO: check necessity on CPU */
-static AMREX_GPU_DEVICE_MANAGED double imw[14] = {
+static AMREX_GPU_DEVICE_MANAGED amrex::Real imw[14] = {
     1.0 / 2.015940,  /*H2 */
     1.0 / 1.007970,  /*H */
     1.0 / 39.948000,  /*AR */
@@ -48,7 +48,7 @@ static AMREX_GPU_DEVICE_MANAGED double imw[14] = {
 
 /* Inverse molecular weights */
 /* TODO: check necessity because redundant with molecularWeight */
-static AMREX_GPU_DEVICE_MANAGED double molecular_weights[14] = {
+static AMREX_GPU_DEVICE_MANAGED amrex::Real molecular_weights[14] = {
     2.015940,  /*H2 */
     1.007970,  /*H */
     39.948000,  /*AR */
@@ -65,13 +65,13 @@ static AMREX_GPU_DEVICE_MANAGED double molecular_weights[14] = {
     44.009950};  /*CO2 */
 
 AMREX_GPU_HOST_DEVICE
-void get_imw(double imw_new[]){
+void get_imw(amrex::Real imw_new[]){
     for(int i = 0; i<14; ++i) imw_new[i] = imw[i];
 }
 
 /* TODO: check necessity because redundant with CKWT */
 AMREX_GPU_HOST_DEVICE
-void get_mw(double mw_new[]){
+void get_mw(amrex::Real mw_new[]){
     for(int i = 0; i<14; ++i) mw_new[i] = molecular_weights[i];
 }
 
@@ -147,7 +147,7 @@ void CKINIT()
     phase_units[3]      = pow(10,-12.000000);
     is_PD[3] = 0;
     nTB[3] = 5;
-    TB[3] = (double *) malloc(5 * sizeof(double));
+    TB[3] = (amrex::Real *) malloc(5 * sizeof(amrex::Real));
     TBid[3] = (int *) malloc(5 * sizeof(int));
     TBid[3][0] = 0; TB[3][0] = 0; // H2
     TBid[3][1] = 9; TB[3][1] = 0; // H2O
@@ -206,7 +206,7 @@ void CKINIT()
     phase_units[4]      = pow(10,-12.000000);
     is_PD[4] = 0;
     nTB[4] = 6;
-    TB[4] = (double *) malloc(6 * sizeof(double));
+    TB[4] = (amrex::Real *) malloc(6 * sizeof(amrex::Real));
     TBid[4] = (int *) malloc(6 * sizeof(int));
     TBid[4][0] = 0; TB[4][0] = 2; // H2
     TBid[4][1] = 9; TB[4][1] = 6.2999999999999998; // H2O
@@ -227,7 +227,7 @@ void CKINIT()
     phase_units[5]      = pow(10,-12.000000);
     is_PD[5] = 0;
     nTB[5] = 6;
-    TB[5] = (double *) malloc(6 * sizeof(double));
+    TB[5] = (amrex::Real *) malloc(6 * sizeof(amrex::Real));
     TBid[5] = (int *) malloc(6 * sizeof(int));
     TBid[5][0] = 0; TB[5][0] = 2; // H2
     TBid[5][1] = 9; TB[5][1] = 12; // H2O
@@ -248,7 +248,7 @@ void CKINIT()
     phase_units[6]      = pow(10,-12.000000);
     is_PD[6] = 0;
     nTB[6] = 6;
-    TB[6] = (double *) malloc(6 * sizeof(double));
+    TB[6] = (amrex::Real *) malloc(6 * sizeof(amrex::Real));
     TBid[6] = (int *) malloc(6 * sizeof(int));
     TBid[6][0] = 0; TB[6][0] = 2.3999999999999999; // H2
     TBid[6][1] = 9; TB[6][1] = 15.4; // H2O
@@ -276,7 +276,7 @@ void CKINIT()
     phase_units[0]      = pow(10,-12.000000);
     is_PD[0] = 1;
     nTB[0] = 7;
-    TB[0] = (double *) malloc(7 * sizeof(double));
+    TB[0] = (amrex::Real *) malloc(7 * sizeof(amrex::Real));
     TBid[0] = (int *) malloc(7 * sizeof(int));
     TBid[0][0] = 11; TB[0][0] = 0.84999999999999998; // O2
     TBid[0][1] = 9; TB[0][1] = 11.890000000000001; // H2O
@@ -319,7 +319,7 @@ void CKINIT()
     phase_units[1]      = pow(10,-12.000000);
     is_PD[1] = 1;
     nTB[1] = 6;
-    TB[1] = (double *) malloc(6 * sizeof(double));
+    TB[1] = (amrex::Real *) malloc(6 * sizeof(amrex::Real));
     TBid[1] = (int *) malloc(6 * sizeof(int));
     TBid[1][0] = 0; TB[1][0] = 2; // H2
     TBid[1][1] = 9; TB[1][1] = 6; // H2O
@@ -499,7 +499,7 @@ void CKINIT()
     phase_units[2]      = pow(10,-12.000000);
     is_PD[2] = 1;
     nTB[2] = 6;
-    TB[2] = (double *) malloc(6 * sizeof(double));
+    TB[2] = (amrex::Real *) malloc(6 * sizeof(amrex::Real));
     TBid[2] = (int *) malloc(6 * sizeof(int));
     TBid[2][0] = 0; TB[2][0] = 2; // H2
     TBid[2][1] = 9; TB[2][1] = 12; // H2O
@@ -624,7 +624,7 @@ void CKINIT()
     phase_units[7]      = pow(10,-6.000000);
     is_PD[7] = 0;
     nTB[7] = 4;
-    TB[7] = (double *) malloc(4 * sizeof(double));
+    TB[7] = (amrex::Real *) malloc(4 * sizeof(amrex::Real));
     TBid[7] = (int *) malloc(4 * sizeof(int));
     TBid[7][0] = 0; TB[7][0] = 2; // H2
     TBid[7][1] = 9; TB[7][1] = 0; // H2O
@@ -668,12 +668,12 @@ void GET_REACTION_MAP(int *rmap)
 }
 
 #include <ReactionData.H>
-double* GetParamPtr(int                reaction_id,
+amrex::Real* GetParamPtr(int                reaction_id,
                     REACTION_PARAMETER param_id,
                     int                species_id,
                     int                get_default)
 {
-  double* ret = 0;
+  amrex::Real* ret = 0;
   if (reaction_id<0 || reaction_id>=38) {
     printf("Bad reaction id = %d",reaction_id);
     abort();
@@ -773,7 +773,7 @@ void ResetAllParametersToDefault()
 
         nTB[i]  = nTB_DEF[i];
         if (nTB[i] != 0) {
-           TB[i] = (double *) malloc(sizeof(double) * nTB[i]);
+           TB[i] = (amrex::Real *) malloc(sizeof(amrex::Real) * nTB[i]);
            TBid[i] = (int *) malloc(sizeof(int) * nTB[i]);
            for (int j=0; j<nTB[i]; j++) {
              TB[i][j] = TB_DEF[i][j];
@@ -825,7 +825,7 @@ void SetAllDefaults()
 
         nTB_DEF[i]  = nTB[i];
         if (nTB_DEF[i] != 0) {
-           TB_DEF[i] = (double *) malloc(sizeof(double) * nTB_DEF[i]);
+           TB_DEF[i] = (amrex::Real *) malloc(sizeof(amrex::Real) * nTB_DEF[i]);
            TBid_DEF[i] = (int *) malloc(sizeof(int) * nTB_DEF[i]);
            for (int j=0; j<nTB_DEF[i]; j++) {
              TB_DEF[i][j] = TB[i][j];
@@ -874,7 +874,7 @@ void CKINDX(int * mm, int * kk, int * ii, int * nfit)
 
 
 /* ckxnum... for parsing strings  */
-void CKXNUM(char * line, int * nexp, int * lout, int * nval, double *  rval, int * kerr, int lenline )
+void CKXNUM(char * line, int * nexp, int * lout, int * nval, amrex::Real *  rval, int * kerr, int lenline )
 {
     int n,i; /*Loop Counters */
     char cstr[1000];
@@ -907,7 +907,7 @@ void CKXNUM(char * line, int * nexp, int * lout, int * nval, double *  rval, int
 
 
 /* cksnum... for parsing strings  */
-void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, double *  rval, int * kerr, int lenline, int lenkray)
+void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, amrex::Real *  rval, int * kerr, int lenline, int lenkray)
 {
     /*Not done yet ... */
 }
@@ -1074,7 +1074,7 @@ void CKSYMS(int * kname, int * plenkname )
 
 
 /* Returns R, Rc, Patm */
-void CKRP(double *  ru, double *  ruc, double *  pa)
+void CKRP(amrex::Real *  ru, amrex::Real *  ruc, amrex::Real *  pa)
 {
      *ru  = 8.31446261815324e+07; 
      *ruc = 1.98721558317399615845; 
@@ -1083,9 +1083,9 @@ void CKRP(double *  ru, double *  ruc, double *  pa)
 
 
 /*Compute P = rhoRT/W(x) */
-void CKPX(double *  rho, double *  T, double *  x, double *  P)
+void CKPX(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  P)
 {
-    double XW = 0;/* To hold mean molecular wt */
+    amrex::Real XW = 0;/* To hold mean molecular wt */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
     XW += x[2]*39.948000; /*AR */
@@ -1107,9 +1107,9 @@ void CKPX(double *  rho, double *  T, double *  x, double *  P)
 
 
 /*Compute P = rhoRT/W(y) */
-AMREX_GPU_HOST_DEVICE void CKPY(double *  rho, double *  T, double *  y,  double *  P)
+AMREX_GPU_HOST_DEVICE void CKPY(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  P)
 {
-    double YOW = 0;/* for computing mean MW */
+    amrex::Real YOW = 0;/* for computing mean MW */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*H */
     YOW += y[2]*imw[2]; /*AR */
@@ -1132,9 +1132,9 @@ AMREX_GPU_HOST_DEVICE void CKPY(double *  rho, double *  T, double *  y,  double
 
 #ifndef AMREX_USE_CUDA
 /*Compute P = rhoRT/W(y) */
-void VCKPY(int *  np, double *  rho, double *  T, double *  y,  double *  P)
+void VCKPY(int *  np, amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  P)
 {
-    double YOW[*np];
+    amrex::Real YOW[*np];
     for (int i=0; i<(*np); i++) {
         YOW[i] = 0.0;
     }
@@ -1155,12 +1155,12 @@ void VCKPY(int *  np, double *  rho, double *  T, double *  y,  double *  P)
 
 
 /*Compute P = rhoRT/W(c) */
-void CKPC(double *  rho, double *  T, double *  c,  double *  P)
+void CKPC(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  c,  amrex::Real *  P)
 {
     int id; /*loop counter */
     /*See Eq 5 in CK Manual */
-    double W = 0;
-    double sumC = 0;
+    amrex::Real W = 0;
+    amrex::Real sumC = 0;
     W += c[0]*2.015940; /*H2 */
     W += c[1]*1.007970; /*H */
     W += c[2]*39.948000; /*AR */
@@ -1186,9 +1186,9 @@ void CKPC(double *  rho, double *  T, double *  c,  double *  P)
 
 
 /*Compute rho = PW(x)/RT */
-void CKRHOX(double *  P, double *  T, double *  x,  double *  rho)
+void CKRHOX(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  rho)
 {
-    double XW = 0;/* To hold mean molecular wt */
+    amrex::Real XW = 0;/* To hold mean molecular wt */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
     XW += x[2]*39.948000; /*AR */
@@ -1210,10 +1210,10 @@ void CKRHOX(double *  P, double *  T, double *  x,  double *  rho)
 
 
 /*Compute rho = P*W(y)/RT */
-AMREX_GPU_HOST_DEVICE void CKRHOY(double *  P, double *  T, double *  y,  double *  rho)
+AMREX_GPU_HOST_DEVICE void CKRHOY(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  rho)
 {
-    double YOW = 0;
-    double tmp[14];
+    amrex::Real YOW = 0;
+    amrex::Real tmp[14];
 
     for (int i = 0; i < 14; i++)
     {
@@ -1230,12 +1230,12 @@ AMREX_GPU_HOST_DEVICE void CKRHOY(double *  P, double *  T, double *  y,  double
 
 
 /*Compute rho = P*W(c)/(R*T) */
-void CKRHOC(double *  P, double *  T, double *  c,  double *  rho)
+void CKRHOC(amrex::Real *  P, amrex::Real *  T, amrex::Real *  c,  amrex::Real *  rho)
 {
     int id; /*loop counter */
     /*See Eq 5 in CK Manual */
-    double W = 0;
-    double sumC = 0;
+    amrex::Real W = 0;
+    amrex::Real sumC = 0;
     W += c[0]*2.015940; /*H2 */
     W += c[1]*1.007970; /*H */
     W += c[2]*39.948000; /*AR */
@@ -1261,14 +1261,14 @@ void CKRHOC(double *  P, double *  T, double *  c,  double *  rho)
 
 
 /*get molecular weight for all species */
-void CKWT( double *  wt)
+void CKWT( amrex::Real *  wt)
 {
     get_mw(wt);
 }
 
 
 /*get atomic weight for all elements */
-void CKAWT( double *  awt)
+void CKAWT( amrex::Real *  awt)
 {
     atomicWeight(awt);
 }
@@ -1276,10 +1276,10 @@ void CKAWT( double *  awt)
 
 /*given y[species]: mass fractions */
 /*returns mean molecular weight (gm/mole) */
-AMREX_GPU_HOST_DEVICE void CKMMWY(double *  y,  double *  wtm)
+AMREX_GPU_HOST_DEVICE void CKMMWY(amrex::Real *  y,  amrex::Real *  wtm)
 {
-    double YOW = 0;
-    double tmp[14];
+    amrex::Real YOW = 0;
+    amrex::Real tmp[14];
 
     for (int i = 0; i < 14; i++)
     {
@@ -1297,9 +1297,9 @@ AMREX_GPU_HOST_DEVICE void CKMMWY(double *  y,  double *  wtm)
 
 /*given x[species]: mole fractions */
 /*returns mean molecular weight (gm/mole) */
-void CKMMWX(double *  x,  double *  wtm)
+void CKMMWX(amrex::Real *  x,  amrex::Real *  wtm)
 {
-    double XW = 0;/* see Eq 4 in CK Manual */
+    amrex::Real XW = 0;/* see Eq 4 in CK Manual */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
     XW += x[2]*39.948000; /*AR */
@@ -1322,12 +1322,12 @@ void CKMMWX(double *  x,  double *  wtm)
 
 /*given c[species]: molar concentration */
 /*returns mean molecular weight (gm/mole) */
-void CKMMWC(double *  c,  double *  wtm)
+void CKMMWC(amrex::Real *  c,  amrex::Real *  wtm)
 {
     int id; /*loop counter */
     /*See Eq 5 in CK Manual */
-    double W = 0;
-    double sumC = 0;
+    amrex::Real W = 0;
+    amrex::Real sumC = 0;
     W += c[0]*2.015940; /*H2 */
     W += c[1]*1.007970; /*H */
     W += c[2]*39.948000; /*AR */
@@ -1354,10 +1354,10 @@ void CKMMWC(double *  c,  double *  wtm)
 
 
 /*convert y[species] (mass fracs) to x[species] (mole fracs) */
-AMREX_GPU_HOST_DEVICE void CKYTX(double *  y,  double *  x)
+AMREX_GPU_HOST_DEVICE void CKYTX(amrex::Real *  y,  amrex::Real *  x)
 {
-    double YOW = 0;
-    double tmp[14];
+    amrex::Real YOW = 0;
+    amrex::Real tmp[14];
 
     for (int i = 0; i < 14; i++)
     {
@@ -1368,7 +1368,7 @@ AMREX_GPU_HOST_DEVICE void CKYTX(double *  y,  double *  x)
         YOW += tmp[i];
     }
 
-    double YOWINV = 1.0/YOW;
+    amrex::Real YOWINV = 1.0/YOW;
 
     for (int i = 0; i < 14; i++)
     {
@@ -1380,9 +1380,9 @@ AMREX_GPU_HOST_DEVICE void CKYTX(double *  y,  double *  x)
 
 #ifndef AMREX_USE_CUDA
 /*convert y[npoints*species] (mass fracs) to x[npoints*species] (mole fracs) */
-void VCKYTX(int *  np, double *  y,  double *  x)
+void VCKYTX(int *  np, amrex::Real *  y,  amrex::Real *  x)
 {
-    double YOW[*np];
+    amrex::Real YOW[*np];
     for (int i=0; i<(*np); i++) {
         YOW[i] = 0.0;
     }
@@ -1406,17 +1406,17 @@ void VCKYTX(int *  np, double *  y,  double *  x)
 }
 #else
 /*TODO: remove this on GPU */
-void VCKYTX(int *  np, double *  y,  double *  x)
+void VCKYTX(int *  np, amrex::Real *  y,  amrex::Real *  x)
 {
 }
 #endif
 
 
 /*convert y[species] (mass fracs) to c[species] (molar conc) */
-void CKYTCP(double *  P, double *  T, double *  y,  double *  c)
+void CKYTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  c)
 {
-    double YOW = 0;
-    double PWORT;
+    amrex::Real YOW = 0;
+    amrex::Real PWORT;
 
     /*Compute inverse of mean molecular wt first */
     for (int i = 0; i < 14; i++)
@@ -1441,7 +1441,7 @@ void CKYTCP(double *  P, double *  T, double *  y,  double *  c)
 
 
 /*convert y[species] (mass fracs) to c[species] (molar conc) */
-AMREX_GPU_HOST_DEVICE void CKYTCR(double *  rho, double *  T, double *  y,  double *  c)
+AMREX_GPU_HOST_DEVICE void CKYTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  c)
 {
     for (int i = 0; i < 14; i++)
     {
@@ -1451,9 +1451,9 @@ AMREX_GPU_HOST_DEVICE void CKYTCR(double *  rho, double *  T, double *  y,  doub
 
 
 /*convert x[species] (mole fracs) to y[species] (mass fracs) */
-AMREX_GPU_HOST_DEVICE void CKXTY(double *  x,  double *  y)
+AMREX_GPU_HOST_DEVICE void CKXTY(amrex::Real *  x,  amrex::Real *  y)
 {
-    double XW = 0; /*See Eq 4, 9 in CK Manual */
+    amrex::Real XW = 0; /*See Eq 4, 9 in CK Manual */
     /*Compute mean molecular wt first */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
@@ -1470,7 +1470,7 @@ AMREX_GPU_HOST_DEVICE void CKXTY(double *  x,  double *  y)
     XW += x[12]*34.014740; /*H2O2 */
     XW += x[13]*44.009950; /*CO2 */
     /*Now compute conversion */
-    double XWinv = 1.0/XW;
+    amrex::Real XWinv = 1.0/XW;
     y[0] = x[0]*2.015940*XWinv; 
     y[1] = x[1]*1.007970*XWinv; 
     y[2] = x[2]*39.948000*XWinv; 
@@ -1491,10 +1491,10 @@ AMREX_GPU_HOST_DEVICE void CKXTY(double *  x,  double *  y)
 
 
 /*convert x[species] (mole fracs) to c[species] (molar conc) */
-void CKXTCP(double *  P, double *  T, double *  x,  double *  c)
+void CKXTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  c)
 {
     int id; /*loop counter */
-    double PORT = (*P)/(8.31446261815324e+07 * (*T)); /*P/RT */
+    amrex::Real PORT = (*P)/(8.31446261815324e+07 * (*T)); /*P/RT */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 14; ++id) {
@@ -1506,11 +1506,11 @@ void CKXTCP(double *  P, double *  T, double *  x,  double *  c)
 
 
 /*convert x[species] (mole fracs) to c[species] (molar conc) */
-void CKXTCR(double *  rho, double *  T, double *  x, double *  c)
+void CKXTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c)
 {
     int id; /*loop counter */
-    double XW = 0; /*See Eq 4, 11 in CK Manual */
-    double ROW; 
+    amrex::Real XW = 0; /*See Eq 4, 11 in CK Manual */
+    amrex::Real ROW; 
     /*Compute mean molecular wt first */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
@@ -1538,10 +1538,10 @@ void CKXTCR(double *  rho, double *  T, double *  x, double *  c)
 
 
 /*convert c[species] (molar conc) to x[species] (mole fracs) */
-void CKCTX(double *  c, double *  x)
+void CKCTX(amrex::Real *  c, amrex::Real *  x)
 {
     int id; /*loop counter */
-    double sumC = 0; 
+    amrex::Real sumC = 0; 
 
     /*compute sum of c  */
     for (id = 0; id < 14; ++id) {
@@ -1549,7 +1549,7 @@ void CKCTX(double *  c, double *  x)
     }
 
     /* See Eq 13  */
-    double sumCinv = 1.0/sumC;
+    amrex::Real sumCinv = 1.0/sumC;
     for (id = 0; id < 14; ++id) {
         x[id] = c[id]*sumCinv;
     }
@@ -1559,9 +1559,9 @@ void CKCTX(double *  c, double *  x)
 
 
 /*convert c[species] (molar conc) to y[species] (mass fracs) */
-void CKCTY(double *  c, double *  y)
+void CKCTY(amrex::Real *  c, amrex::Real *  y)
 {
-    double CW = 0; /*See Eq 12 in CK Manual */
+    amrex::Real CW = 0; /*See Eq 12 in CK Manual */
     /*compute denominator in eq 12 first */
     CW += c[0]*2.015940; /*H2 */
     CW += c[1]*1.007970; /*H */
@@ -1578,7 +1578,7 @@ void CKCTY(double *  c, double *  y)
     CW += c[12]*34.014740; /*H2O2 */
     CW += c[13]*44.009950; /*CO2 */
     /*Now compute conversion */
-    double CWinv = 1.0/CW;
+    amrex::Real CWinv = 1.0/CW;
     y[0] = c[0]*2.015940*CWinv; 
     y[1] = c[1]*1.007970*CWinv; 
     y[2] = c[2]*39.948000*CWinv; 
@@ -1600,41 +1600,41 @@ void CKCTY(double *  c, double *  y)
 
 /*get Cp/R as a function of T  */
 /*for all species (Eq 19) */
-void CKCPOR(double *  T, double *  cpor)
+void CKCPOR(amrex::Real *  T, amrex::Real *  cpor)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cp_R(cpor, tc);
 }
 
 
 /*get H/RT as a function of T  */
 /*for all species (Eq 20) */
-void CKHORT(double *  T, double *  hort)
+void CKHORT(amrex::Real *  T, amrex::Real *  hort)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEnthalpy(hort, tc);
 }
 
 
 /*get S/R as a function of T  */
 /*for all species (Eq 21) */
-void CKSOR(double *  T, double *  sor)
+void CKSOR(amrex::Real *  T, amrex::Real *  sor)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEntropy(sor, tc);
 }
 
 
 /*get specific heat at constant volume as a function  */
 /*of T for all species (molar units) */
-void CKCVML(double *  T,  double *  cvml)
+void CKCVML(amrex::Real *  T,  amrex::Real *  cvml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cv_R(cvml, tc);
 
     /*convert to chemkin units */
@@ -1646,11 +1646,11 @@ void CKCVML(double *  T,  double *  cvml)
 
 /*get specific heat at constant pressure as a  */
 /*function of T for all species (molar units) */
-void CKCPML(double *  T,  double *  cpml)
+void CKCPML(amrex::Real *  T,  amrex::Real *  cpml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cp_R(cpml, tc);
 
     /*convert to chemkin units */
@@ -1662,12 +1662,12 @@ void CKCPML(double *  T,  double *  cpml)
 
 /*get internal energy as a function  */
 /*of T for all species (molar units) */
-void CKUML(double *  T,  double *  uml)
+void CKUML(amrex::Real *  T,  amrex::Real *  uml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(uml, tc);
 
     /*convert to chemkin units */
@@ -1679,12 +1679,12 @@ void CKUML(double *  T,  double *  uml)
 
 /*get enthalpy as a function  */
 /*of T for all species (molar units) */
-void CKHML(double *  T,  double *  hml)
+void CKHML(amrex::Real *  T,  amrex::Real *  hml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hml, tc);
 
     /*convert to chemkin units */
@@ -1696,12 +1696,12 @@ void CKHML(double *  T,  double *  hml)
 
 /*get standard-state Gibbs energy as a function  */
 /*of T for all species (molar units) */
-void CKGML(double *  T,  double *  gml)
+void CKGML(amrex::Real *  T,  amrex::Real *  gml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     gibbs(gml, tc);
 
     /*convert to chemkin units */
@@ -1713,12 +1713,12 @@ void CKGML(double *  T,  double *  gml)
 
 /*get standard-state Helmholtz free energy as a  */
 /*function of T for all species (molar units) */
-void CKAML(double *  T,  double *  aml)
+void CKAML(amrex::Real *  T,  amrex::Real *  aml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     helmholtz(aml, tc);
 
     /*convert to chemkin units */
@@ -1729,11 +1729,11 @@ void CKAML(double *  T,  double *  aml)
 
 
 /*Returns the standard-state entropies in molar units */
-void CKSML(double *  T,  double *  sml)
+void CKSML(amrex::Real *  T,  amrex::Real *  sml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEntropy(sml, tc);
 
     /*convert to chemkin units */
@@ -1745,10 +1745,10 @@ void CKSML(double *  T,  double *  sml)
 
 /*Returns the specific heats at constant volume */
 /*in mass units (Eq. 29) */
-AMREX_GPU_HOST_DEVICE void CKCVMS(double *  T,  double *  cvms)
+AMREX_GPU_HOST_DEVICE void CKCVMS(amrex::Real *  T,  amrex::Real *  cvms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cv_R(cvms, tc);
     /*multiply by R/molecularweight */
     cvms[0] *= 4.124360158612479e+07; /*H2 */
@@ -1770,10 +1770,10 @@ AMREX_GPU_HOST_DEVICE void CKCVMS(double *  T,  double *  cvms)
 
 /*Returns the specific heats at constant pressure */
 /*in mass units (Eq. 26) */
-AMREX_GPU_HOST_DEVICE void CKCPMS(double *  T,  double *  cpms)
+AMREX_GPU_HOST_DEVICE void CKCPMS(amrex::Real *  T,  amrex::Real *  cpms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cp_R(cpms, tc);
     /*multiply by R/molecularweight */
     cpms[0] *= 4.124360158612479e+07; /*H2 */
@@ -1794,11 +1794,11 @@ AMREX_GPU_HOST_DEVICE void CKCPMS(double *  T,  double *  cpms)
 
 
 /*Returns internal energy in mass units (Eq 30.) */
-AMREX_GPU_HOST_DEVICE void CKUMS(double *  T,  double *  ums)
+AMREX_GPU_HOST_DEVICE void CKUMS(amrex::Real *  T,  amrex::Real *  ums)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(ums, tc);
     for (int i = 0; i < 14; i++)
     {
@@ -1808,11 +1808,11 @@ AMREX_GPU_HOST_DEVICE void CKUMS(double *  T,  double *  ums)
 
 
 /*Returns enthalpy in mass units (Eq 27.) */
-AMREX_GPU_HOST_DEVICE void CKHMS(double *  T,  double *  hms)
+AMREX_GPU_HOST_DEVICE void CKHMS(amrex::Real *  T,  amrex::Real *  hms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hms, tc);
     for (int i = 0; i < 14; i++)
     {
@@ -1823,9 +1823,9 @@ AMREX_GPU_HOST_DEVICE void CKHMS(double *  T,  double *  hms)
 
 #ifndef AMREX_USE_CUDA
 /*Returns enthalpy in mass units (Eq 27.) */
-void VCKHMS(int *  np, double *  T,  double *  hms)
+void VCKHMS(int *  np, amrex::Real *  T,  amrex::Real *  hms)
 {
-    double tc[5], h[14];
+    amrex::Real tc[5], h[14];
 
     for (int i=0; i<(*np); i++) {
         tc[0] = 0.0;
@@ -1860,18 +1860,18 @@ void VCKHMS(int *  np, double *  T,  double *  hms)
 }
 #else
 /*TODO: remove this on GPU */
-void VCKHMS(int *  np, double *  T,  double *  hms)
+void VCKHMS(int *  np, amrex::Real *  T,  amrex::Real *  hms)
 {
 }
 #endif
 
 
 /*Returns gibbs in mass units (Eq 31.) */
-void CKGMS(double *  T,  double *  gms)
+void CKGMS(amrex::Real *  T,  amrex::Real *  gms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     gibbs(gms, tc);
     for (int i = 0; i < 14; i++)
     {
@@ -1881,11 +1881,11 @@ void CKGMS(double *  T,  double *  gms)
 
 
 /*Returns helmholtz in mass units (Eq 32.) */
-void CKAMS(double *  T,  double *  ams)
+void CKAMS(amrex::Real *  T,  amrex::Real *  ams)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     helmholtz(ams, tc);
     for (int i = 0; i < 14; i++)
     {
@@ -1895,10 +1895,10 @@ void CKAMS(double *  T,  double *  ams)
 
 
 /*Returns the entropies in mass units (Eq 28.) */
-void CKSMS(double *  T,  double *  sms)
+void CKSMS(amrex::Real *  T,  amrex::Real *  sms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEntropy(sms, tc);
     /*multiply by R/molecularweight */
     sms[0] *= 4.124360158612479e+07; /*H2 */
@@ -1919,13 +1919,13 @@ void CKSMS(double *  T,  double *  sms)
 
 
 /*Returns the mean specific heat at CP (Eq. 33) */
-void CKCPBL(double *  T, double *  x,  double *  cpbl)
+void CKCPBL(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  cpbl)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cpor[14]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cpor[14]; /* temporary storage */
     cp_R(cpor, tc);
 
     /*perform dot product */
@@ -1938,12 +1938,12 @@ void CKCPBL(double *  T, double *  x,  double *  cpbl)
 
 
 /*Returns the mean specific heat at CP (Eq. 34) */
-AMREX_GPU_HOST_DEVICE void CKCPBS(double *  T, double *  y,  double *  cpbs)
+AMREX_GPU_HOST_DEVICE void CKCPBS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  cpbs)
 {
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cpor[14], tresult[14]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cpor[14], tresult[14]; /* temporary storage */
     cp_R(cpor, tc);
     for (int i = 0; i < 14; i++)
     {
@@ -1960,13 +1960,13 @@ AMREX_GPU_HOST_DEVICE void CKCPBS(double *  T, double *  y,  double *  cpbs)
 
 
 /*Returns the mean specific heat at CV (Eq. 35) */
-void CKCVBL(double *  T, double *  x,  double *  cvbl)
+void CKCVBL(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  cvbl)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cvor[14]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cvor[14]; /* temporary storage */
     cv_R(cvor, tc);
 
     /*perform dot product */
@@ -1979,12 +1979,12 @@ void CKCVBL(double *  T, double *  x,  double *  cvbl)
 
 
 /*Returns the mean specific heat at CV (Eq. 36) */
-AMREX_GPU_HOST_DEVICE void CKCVBS(double *  T, double *  y,  double *  cvbs)
+AMREX_GPU_HOST_DEVICE void CKCVBS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  cvbs)
 {
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cvor[14]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cvor[14]; /* temporary storage */
     cv_R(cvor, tc);
     /*multiply by y/molecularweight */
     result += cvor[0]*y[0]*imw[0]; /*H2 */
@@ -2007,14 +2007,14 @@ AMREX_GPU_HOST_DEVICE void CKCVBS(double *  T, double *  y,  double *  cvbs)
 
 
 /*Returns the mean enthalpy of the mixture in molar units */
-void CKHBML(double *  T, double *  x,  double *  hbml)
+void CKHBML(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  hbml)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double hml[14]; /* temporary storage */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real hml[14]; /* temporary storage */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hml, tc);
 
     /*perform dot product */
@@ -2027,13 +2027,13 @@ void CKHBML(double *  T, double *  x,  double *  hbml)
 
 
 /*Returns mean enthalpy of mixture in mass units */
-AMREX_GPU_HOST_DEVICE void CKHBMS(double *  T, double *  y,  double *  hbms)
+AMREX_GPU_HOST_DEVICE void CKHBMS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  hbms)
 {
-    double result = 0;
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double hml[14], tmp[14]; /* temporary storage */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0;
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real hml[14], tmp[14]; /* temporary storage */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hml, tc);
     int id;
     for (id = 0; id < 14; ++id) {
@@ -2048,14 +2048,14 @@ AMREX_GPU_HOST_DEVICE void CKHBMS(double *  T, double *  y,  double *  hbms)
 
 
 /*get mean internal energy in molar units */
-void CKUBML(double *  T, double *  x,  double *  ubml)
+void CKUBML(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  ubml)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double uml[14]; /* temporary energy array */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real uml[14]; /* temporary energy array */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(uml, tc);
 
     /*perform dot product */
@@ -2068,13 +2068,13 @@ void CKUBML(double *  T, double *  x,  double *  ubml)
 
 
 /*get mean internal energy in mass units */
-AMREX_GPU_HOST_DEVICE void CKUBMS(double *  T, double *  y,  double *  ubms)
+AMREX_GPU_HOST_DEVICE void CKUBMS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  ubms)
 {
-    double result = 0;
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double ums[14]; /* temporary energy array */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0;
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real ums[14]; /* temporary energy array */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(ums, tc);
     /*perform dot product + scaling by wt */
     result += y[0]*ums[0]*imw[0]; /*H2 */
@@ -2097,15 +2097,15 @@ AMREX_GPU_HOST_DEVICE void CKUBMS(double *  T, double *  y,  double *  ubms)
 
 
 /*get mixture entropy in molar units */
-void CKSBML(double *  P, double *  T, double *  x,  double *  sbml)
+void CKSBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  sbml)
 {
     int id; /*loop counter */
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double sor[14]; /* temporary storage */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real sor[14]; /* temporary storage */
     speciesEntropy(sor, tc);
 
     /*Compute Eq 42 */
@@ -2118,16 +2118,16 @@ void CKSBML(double *  P, double *  T, double *  x,  double *  sbml)
 
 
 /*get mixture entropy in mass units */
-void CKSBMS(double *  P, double *  T, double *  y,  double *  sbms)
+void CKSBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  sbms)
 {
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double sor[14]; /* temporary storage */
-    double x[14]; /* need a ytx conversion */
-    double YOW = 0; /*See Eq 4, 6 in CK Manual */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real sor[14]; /* temporary storage */
+    amrex::Real x[14]; /* need a ytx conversion */
+    amrex::Real YOW = 0; /*See Eq 4, 6 in CK Manual */
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*H */
@@ -2180,16 +2180,16 @@ void CKSBMS(double *  P, double *  T, double *  y,  double *  sbms)
 
 
 /*Returns mean gibbs free energy in molar units */
-void CKGBML(double *  P, double *  T, double *  x,  double *  gbml)
+void CKGBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  gbml)
 {
     int id; /*loop counter */
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double gort[14]; /* temporary storage */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real gort[14]; /* temporary storage */
     /*Compute g/RT */
     gibbs(gort, tc);
 
@@ -2203,17 +2203,17 @@ void CKGBML(double *  P, double *  T, double *  x,  double *  gbml)
 
 
 /*Returns mixture gibbs free energy in mass units */
-void CKGBMS(double *  P, double *  T, double *  y,  double *  gbms)
+void CKGBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  gbms)
 {
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double gort[14]; /* temporary storage */
-    double x[14]; /* need a ytx conversion */
-    double YOW = 0; /*To hold 1/molecularweight */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real gort[14]; /* temporary storage */
+    amrex::Real x[14]; /* need a ytx conversion */
+    amrex::Real YOW = 0; /*To hold 1/molecularweight */
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*H */
@@ -2266,16 +2266,16 @@ void CKGBMS(double *  P, double *  T, double *  y,  double *  gbms)
 
 
 /*Returns mean helmholtz free energy in molar units */
-void CKABML(double *  P, double *  T, double *  x,  double *  abml)
+void CKABML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  abml)
 {
     int id; /*loop counter */
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double aort[14]; /* temporary storage */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real aort[14]; /* temporary storage */
     /*Compute g/RT */
     helmholtz(aort, tc);
 
@@ -2289,17 +2289,17 @@ void CKABML(double *  P, double *  T, double *  x,  double *  abml)
 
 
 /*Returns mixture helmholtz free energy in mass units */
-void CKABMS(double *  P, double *  T, double *  y,  double *  abms)
+void CKABMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  abms)
 {
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double aort[14]; /* temporary storage */
-    double x[14]; /* need a ytx conversion */
-    double YOW = 0; /*To hold 1/molecularweight */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real aort[14]; /* temporary storage */
+    amrex::Real x[14]; /* need a ytx conversion */
+    amrex::Real YOW = 0; /*To hold 1/molecularweight */
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*H */
@@ -2352,7 +2352,7 @@ void CKABMS(double *  P, double *  T, double *  y,  double *  abms)
 
 
 /*compute the production rate for each species */
-AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C,  double *  wdot)
+AMREX_GPU_HOST_DEVICE void CKWC(amrex::Real *  T, amrex::Real *  C,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
 
@@ -2374,12 +2374,12 @@ AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C,  double *  wdot)
 
 /*Returns the molar production rate of species */
 /*Given P, T, and mass fractions */
-void CKWYP(double *  P, double *  T, double *  y,  double *  wdot)
+void CKWYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[14]; /*temporary storage */
-    double YOW = 0; 
-    double PWORT; 
+    amrex::Real c[14]; /*temporary storage */
+    amrex::Real YOW = 0; 
+    amrex::Real PWORT; 
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*H */
@@ -2427,11 +2427,11 @@ void CKWYP(double *  P, double *  T, double *  y,  double *  wdot)
 
 /*Returns the molar production rate of species */
 /*Given P, T, and mole fractions */
-void CKWXP(double *  P, double *  T, double *  x,  double *  wdot)
+void CKWXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[14]; /*temporary storage */
-    double PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
+    amrex::Real c[14]; /*temporary storage */
+    amrex::Real PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 14; ++id) {
@@ -2450,10 +2450,10 @@ void CKWXP(double *  P, double *  T, double *  x,  double *  wdot)
 
 /*Returns the molar production rate of species */
 /*Given rho, T, and mass fractions */
-AMREX_GPU_HOST_DEVICE void CKWYR(double *  rho, double *  T, double *  y,  double *  wdot)
+AMREX_GPU_HOST_DEVICE void CKWYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[14]; /*temporary storage */
+    amrex::Real c[14]; /*temporary storage */
     /*See Eq 8 with an extra 1e6 so c goes to SI */
     c[0] = 1e6 * (*rho) * y[0]*imw[0]; 
     c[1] = 1e6 * (*rho) * y[1]*imw[1]; 
@@ -2482,12 +2482,12 @@ AMREX_GPU_HOST_DEVICE void CKWYR(double *  rho, double *  T, double *  y,  doubl
 
 /*Returns the molar production rate of species */
 /*Given rho, T, and mass fractions */
-void VCKWYR(int *  np, double *  rho, double *  T,
-	    double *  y,
-	    double *  wdot)
+void VCKWYR(int *  np, amrex::Real *  rho, amrex::Real *  T,
+	    amrex::Real *  y,
+	    amrex::Real *  wdot)
 {
 #ifndef AMREX_USE_CUDA
-    double c[14*(*np)]; /*temporary storage */
+    amrex::Real c[14*(*np)]; /*temporary storage */
     /*See Eq 8 with an extra 1e6 so c goes to SI */
     for (int n=0; n<14; n++) {
         for (int i=0; i<(*np); i++) {
@@ -2508,12 +2508,12 @@ void VCKWYR(int *  np, double *  rho, double *  T,
 
 /*Returns the molar production rate of species */
 /*Given rho, T, and mole fractions */
-void CKWXR(double *  rho, double *  T, double *  x,  double *  wdot)
+void CKWXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[14]; /*temporary storage */
-    double XW = 0; /*See Eq 4, 11 in CK Manual */
-    double ROW; 
+    amrex::Real c[14]; /*temporary storage */
+    amrex::Real XW = 0; /*See Eq 4, 11 in CK Manual */
+    amrex::Real ROW; 
     /*Compute mean molecular wt first */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
@@ -2548,7 +2548,7 @@ void CKWXR(double *  rho, double *  T, double *  x,  double *  wdot)
 
 
 /*Returns the rate of progress for each reaction */
-void CKQC(double *  T, double *  C, double *  qdot)
+void CKQC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  qdot)
 {
     int id; /*loop counter */
 
@@ -2573,11 +2573,11 @@ void CKQC(double *  T, double *  C, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given P, T, and mole fractions */
-void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r)
+void CKKFKR(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  q_f, amrex::Real *  q_r)
 {
     int id; /*loop counter */
-    double c[14]; /*temporary storage */
-    double PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
+    amrex::Real c[14]; /*temporary storage */
+    amrex::Real PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 14; ++id) {
@@ -2597,12 +2597,12 @@ void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r)
 
 /*Returns the progress rates of each reactions */
 /*Given P, T, and mass fractions */
-void CKQYP(double *  P, double *  T, double *  y, double *  qdot)
+void CKQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[14]; /*temporary storage */
-    double YOW = 0; 
-    double PWORT; 
+    amrex::Real c[14]; /*temporary storage */
+    amrex::Real YOW = 0; 
+    amrex::Real PWORT; 
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*H */
@@ -2650,11 +2650,11 @@ void CKQYP(double *  P, double *  T, double *  y, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given P, T, and mole fractions */
-void CKQXP(double *  P, double *  T, double *  x, double *  qdot)
+void CKQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[14]; /*temporary storage */
-    double PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
+    amrex::Real c[14]; /*temporary storage */
+    amrex::Real PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 14; ++id) {
@@ -2673,10 +2673,10 @@ void CKQXP(double *  P, double *  T, double *  x, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given rho, T, and mass fractions */
-void CKQYR(double *  rho, double *  T, double *  y, double *  qdot)
+void CKQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[14]; /*temporary storage */
+    amrex::Real c[14]; /*temporary storage */
     /*See Eq 8 with an extra 1e6 so c goes to SI */
     c[0] = 1e6 * (*rho) * y[0]*imw[0]; 
     c[1] = 1e6 * (*rho) * y[1]*imw[1]; 
@@ -2705,12 +2705,12 @@ void CKQYR(double *  rho, double *  T, double *  y, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given rho, T, and mole fractions */
-void CKQXR(double *  rho, double *  T, double *  x, double *  qdot)
+void CKQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[14]; /*temporary storage */
-    double XW = 0; /*See Eq 4, 11 in CK Manual */
-    double ROW; 
+    amrex::Real c[14]; /*temporary storage */
+    amrex::Real XW = 0; /*See Eq 4, 11 in CK Manual */
+    amrex::Real ROW; 
     /*Compute mean molecular wt first */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
@@ -3070,7 +3070,7 @@ void CKNCF(int * ncf)
 
 /*Returns the arrehenius coefficients  */
 /*for all reactions */
-void CKABE( double *  a, double *  b, double *  e)
+void CKABE( amrex::Real *  a, amrex::Real *  b, amrex::Real *  e)
 {
     // (11):  H + O2 (+M) <=> HO2 (+M)
     a[0] = 5116000000000;
@@ -3268,11 +3268,11 @@ void CKABE( double *  a, double *  b, double *  e)
 
 
 /*Returns the equil constants for each reaction */
-void CKEQC(double *  T, double *  C, double *  eqcon)
+void CKEQC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[14]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[14]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -3398,11 +3398,11 @@ void CKEQC(double *  T, double *  C, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given P, T, and mass fractions */
-void CKEQYP(double *  P, double *  T, double *  y, double *  eqcon)
+void CKEQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[14]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[14]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -3528,11 +3528,11 @@ void CKEQYP(double *  P, double *  T, double *  y, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given P, T, and mole fractions */
-void CKEQXP(double *  P, double *  T, double *  x, double *  eqcon)
+void CKEQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[14]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[14]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -3658,11 +3658,11 @@ void CKEQXP(double *  P, double *  T, double *  x, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given rho, T, and mass fractions */
-void CKEQYR(double *  rho, double *  T, double *  y, double *  eqcon)
+void CKEQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[14]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[14]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -3788,11 +3788,11 @@ void CKEQYR(double *  rho, double *  T, double *  y, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given rho, T, and mole fractions */
-void CKEQXR(double *  rho, double *  T, double *  x, double *  eqcon)
+void CKEQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[14]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[14]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -3918,12 +3918,12 @@ void CKEQXR(double *  rho, double *  T, double *  x, double *  eqcon)
 #ifdef AMREX_USE_CUDA
 /*GPU version of productionRate: no more use of thermo namespace vectors */
 /*compute the production rate for each species */
-AMREX_GPU_HOST_DEVICE inline void  productionRate(double * wdot, double * sc, double T)
+AMREX_GPU_HOST_DEVICE inline void  productionRate(amrex::Real * wdot, amrex::Real * sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 
-    double qdot, q_f[38], q_r[38];
+    amrex::Real qdot, q_f[38], q_r[38];
     comp_qfqr(q_f, q_r, sc, tc, invT);
 
     for (int i = 0; i < 14; ++i) {
@@ -4157,7 +4157,7 @@ AMREX_GPU_HOST_DEVICE inline void  productionRate(double * wdot, double * sc, do
     return;
 }
 
-AMREX_GPU_HOST_DEVICE inline void comp_qfqr(double *  qf, double * qr, double * sc, double * tc, double invT)
+AMREX_GPU_HOST_DEVICE inline void comp_qfqr(amrex::Real *  qf, amrex::Real * qr, amrex::Real * sc, amrex::Real * tc, amrex::Real invT)
 {
 
     /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
@@ -4313,22 +4313,22 @@ AMREX_GPU_HOST_DEVICE inline void comp_qfqr(double *  qf, double * qr, double * 
     qr[37] = sc[8]*sc[10];
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int i = 0; i < 14; ++i) {
         mixture += sc[i];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[14];
+    amrex::Real g_RT[14];
     gibbs(g_RT, tc);
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 * invT;
-    double refCinv = 1 / refC;
+    amrex::Real refC = 101325 / 8.31446 * invT;
+    amrex::Real refCinv = 1 / refC;
 
     /* Evaluate the kfs */
-    double k_f, k_r, Corr;
-    double redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;
+    amrex::Real k_f, k_r, Corr;
+    amrex::Real redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;
 
     // (0):  H + O2 <=> O + OH
     k_f = 1.0000000000000002e-06 * 26440000000000000 
@@ -4595,27 +4595,27 @@ AMREX_GPU_HOST_DEVICE inline void comp_qfqr(double *  qf, double * qr, double * 
 
 
 #ifndef AMREX_USE_CUDA
-static double T_save = -1;
+static amrex::Real T_save = -1;
 #ifdef _OPENMP
 #pragma omp threadprivate(T_save)
 #endif
 
-static double k_f_save[38];
+static amrex::Real k_f_save[38];
 #ifdef _OPENMP
 #pragma omp threadprivate(k_f_save)
 #endif
 
-static double Kc_save[38];
+static amrex::Real Kc_save[38];
 #ifdef _OPENMP
 #pragma omp threadprivate(Kc_save)
 #endif
 
 
 /*compute the production rate for each species pointwise on CPU */
-void productionRate(double *  wdot, double *  sc, double T)
+void productionRate(amrex::Real *  wdot, amrex::Real *  sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 
     if (T != T_save)
     {
@@ -4624,7 +4624,7 @@ void productionRate(double *  wdot, double *  sc, double T)
         comp_Kc(tc,invT,Kc_save);
     }
 
-    double qdot, q_f[38], q_r[38];
+    amrex::Real qdot, q_f[38], q_r[38];
     comp_qfqr(q_f, q_r, sc, tc, invT);
 
     for (int i = 0; i < 14; ++i) {
@@ -4858,7 +4858,7 @@ void productionRate(double *  wdot, double *  sc, double T)
     return;
 }
 
-void comp_k_f(double *  tc, double invT, double *  k_f)
+void comp_k_f(amrex::Real *  tc, amrex::Real invT, amrex::Real *  k_f)
 {
     for (int i=0; i<38; ++i) {
         k_f[i] = prefactor_units[i] * fwd_A[i]
@@ -4867,10 +4867,10 @@ void comp_k_f(double *  tc, double invT, double *  k_f)
     return;
 }
 
-void comp_Kc(double *  tc, double invT, double *  Kc)
+void comp_Kc(amrex::Real *  tc, amrex::Real invT, amrex::Real *  Kc)
 {
     /*compute the Gibbs free energy */
-    double g_RT[14];
+    amrex::Real g_RT[14];
     gibbs(g_RT, tc);
 
     Kc[0] = g_RT[1] - g_RT[8] + g_RT[11];
@@ -4917,8 +4917,8 @@ void comp_Kc(double *  tc, double invT, double *  Kc)
     };
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 * invT;
-    double refCinv = 1 / refC;
+    amrex::Real refC = 101325 / 8.31446 * invT;
+    amrex::Real refCinv = 1 / refC;
 
     Kc[0] *= refCinv;
     Kc[1] *= refCinv;
@@ -4936,7 +4936,7 @@ void comp_Kc(double *  tc, double invT, double *  Kc)
     return;
 }
 
-void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double invT)
+void comp_qfqr(amrex::Real *  qf, amrex::Real *  qr, amrex::Real *  sc, amrex::Real *  tc, amrex::Real invT)
 {
 
     /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
@@ -5091,27 +5091,27 @@ void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double in
     qf[37] = sc[7]*sc[11];
     qr[37] = sc[8]*sc[10];
 
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int i = 0; i < 14; ++i) {
         mixture += sc[i];
     }
 
-    double Corr[38];
+    amrex::Real Corr[38];
     for (int i = 0; i < 38; ++i) {
         Corr[i] = 1.0;
     }
 
     /* troe */
     {
-        double alpha[2];
+        amrex::Real alpha[2];
         alpha[0] = mixture + (TB[0][0] - 1)*sc[11] + (TB[0][1] - 1)*sc[9] + (TB[0][2] - 1)*sc[10] + (TB[0][3] - 1)*sc[13] + (TB[0][4] - 1)*sc[2] + (TB[0][5] - 1)*sc[4] + (TB[0][6] - 1)*sc[0];
         alpha[1] = mixture + (TB[1][0] - 1)*sc[0] + (TB[1][1] - 1)*sc[9] + (TB[1][2] - 1)*sc[10] + (TB[1][3] - 1)*sc[13] + (TB[1][4] - 1)*sc[2] + (TB[1][5] - 1)*sc[4];
         for (int i=0; i<2; i++)
         {
-            double redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;
+            amrex::Real redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;
             redP = alpha[i-0] / k_f_save[i] * phase_units[i] * low_A[i] * exp(low_beta[i] * tc[0] - activation_units[i] * low_Ea[i] *invT);
             F = redP / (1.0 + redP);
             logPred = log10(redP);
@@ -5129,15 +5129,15 @@ void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double in
 
     /* Lindemann */
     {
-        double alpha;
+        amrex::Real alpha;
         alpha = mixture + (TB[2][0] - 1)*sc[0] + (TB[2][1] - 1)*sc[9] + (TB[2][2] - 1)*sc[10] + (TB[2][3] - 1)*sc[13] + (TB[2][4] - 1)*sc[2] + (TB[2][5] - 1)*sc[4];
-        double redP = alpha / k_f_save[2] * phase_units[2] * low_A[2] * exp(low_beta[2] * tc[0] - activation_units[2] * low_Ea[2] * invT);
+        amrex::Real redP = alpha / k_f_save[2] * phase_units[2] * low_A[2] * exp(low_beta[2] * tc[0] - activation_units[2] * low_Ea[2] * invT);
         Corr[2] = redP / (1. + redP);
     }
 
     /* simple three-body correction */
     {
-        double alpha;
+        amrex::Real alpha;
         alpha = mixture + (TB[3][0] - 1)*sc[0] + (TB[3][1] - 1)*sc[9] + (TB[3][2] - 1)*sc[13] + (TB[3][3] - 1)*sc[2] + (TB[3][4] - 1)*sc[4];
         Corr[3] = alpha;
         alpha = mixture + (TB[4][0] - 1)*sc[0] + (TB[4][1] - 1)*sc[9] + (TB[4][2] - 1)*sc[10] + (TB[4][3] - 1)*sc[13] + (TB[4][4] - 1)*sc[2] + (TB[4][5] - 1)*sc[4];
@@ -5163,10 +5163,10 @@ void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double in
 
 #ifndef AMREX_USE_CUDA
 /*compute the production rate for each species */
-void vproductionRate(int npt, double *  wdot, double *  sc, double *  T)
+void vproductionRate(int npt, amrex::Real *  wdot, amrex::Real *  sc, amrex::Real *  T)
 {
-    double k_f_s[38*npt], Kc_s[38*npt], mixture[npt], g_RT[14*npt];
-    double tc[5*npt], invT[npt];
+    amrex::Real k_f_s[38*npt], Kc_s[38*npt], mixture[npt], g_RT[14*npt];
+    amrex::Real tc[5*npt], invT[npt];
 
     for (int i=0; i<npt; i++) {
         tc[0*npt+i] = log(T[i]);
@@ -5197,7 +5197,7 @@ void vproductionRate(int npt, double *  wdot, double *  sc, double *  T)
     vcomp_wdot(npt, wdot, mixture, sc, k_f_s, Kc_s, tc, invT, T);
 }
 
-void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT)
+void vcomp_k_f(int npt, amrex::Real *  k_f_s, amrex::Real *  tc, amrex::Real *  invT)
 {
     for (int i=0; i<npt; i++) {
         k_f_s[0*npt+i] = prefactor_units[0] * fwd_A[0] * exp(fwd_beta[0] * tc[i] - activation_units[0] * fwd_Ea[0] * invT[i]);
@@ -5241,11 +5241,11 @@ void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT)
     }
 }
 
-void vcomp_gibbs(int npt, double *  g_RT, double *  tc)
+void vcomp_gibbs(int npt, amrex::Real *  g_RT, amrex::Real *  tc)
 {
     /*compute the Gibbs free energy */
     for (int i=0; i<npt; i++) {
-        double tg[5], g[14];
+        amrex::Real tg[5], g[14];
         tg[0] = tc[0*npt+i];
         tg[1] = tc[1*npt+i];
         tg[2] = tc[2*npt+i];
@@ -5271,12 +5271,12 @@ void vcomp_gibbs(int npt, double *  g_RT, double *  tc)
     }
 }
 
-void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT)
+void vcomp_Kc(int npt, amrex::Real *  Kc_s, amrex::Real *  g_RT, amrex::Real *  invT)
 {
     for (int i=0; i<npt; i++) {
         /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-        double refC = (101325. / 8.31451) * invT[i];
-        double refCinv = 1.0 / refC;
+        amrex::Real refC = (101325. / 8.31451) * invT[i];
+        amrex::Real refCinv = 1.0 / refC;
 
         Kc_s[0*npt+i] = refCinv * exp((g_RT[1*npt+i] + g_RT[11*npt+i]) - (g_RT[8*npt+i]));
         Kc_s[1*npt+i] = refCinv * exp((g_RT[6*npt+i] + g_RT[6*npt+i]) - (g_RT[12*npt+i]));
@@ -5319,16 +5319,16 @@ void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT)
     }
 }
 
-void vcomp_wdot(int npt, double *  wdot, double *  mixture, double *  sc,
-		double *  k_f_s, double *  Kc_s,
-		double *  tc, double *  invT, double *  T)
+void vcomp_wdot(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,
+		amrex::Real *  k_f_s, amrex::Real *  Kc_s,
+		amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T)
 {
     for (int i=0; i<npt; i++) {
-        double qdot, q_f, q_r, phi_f, phi_r, k_f, k_r, Kc;
-        double alpha;
-        double redP, F;
-        double logPred;
-        double logFcent, troe_c, troe_n, troe, F_troe;
+        amrex::Real qdot, q_f, q_r, phi_f, phi_r, k_f, k_r, Kc;
+        amrex::Real alpha;
+        amrex::Real redP, F;
+        amrex::Real logPred;
+        amrex::Real logFcent, troe_c, troe_n, troe, F_troe;
 
         /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
         phi_f = sc[1*npt+i]*sc[11*npt+i];
@@ -5899,9 +5899,9 @@ void vcomp_wdot(int npt, double *  wdot, double *  mixture, double *  sc,
 #endif
 
 /*compute an approx to the reaction Jacobian (for preconditioning) */
-AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double *  Tp, int * HP)
+AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * HP)
 {
-    double c[14];
+    amrex::Real c[14];
 
     for (int k=0; k<14; k++) {
         c[k] = 1.e6 * sc[k];
@@ -5920,9 +5920,9 @@ AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double * 
 }
 
 /*compute the reaction Jacobian */
-AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  Tp, int * consP)
+AMREX_GPU_HOST_DEVICE void DWDOT(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * consP)
 {
-    double c[14];
+    amrex::Real c[14];
 
     for (int k=0; k<14; k++) {
         c[k] = 1.e6 * sc[k];
@@ -5943,8 +5943,8 @@ AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  Tp, int * 
 /*compute the sparsity pattern of the chemistry Jacobian */
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO( int * nJdata, int * consP, int NCELLS)
 {
-    double c[14];
-    double J[225];
+    amrex::Real c[14];
+    amrex::Real J[225];
 
     for (int k=0; k<14; k++) {
         c[k] = 1.0/ 14.000000 ;
@@ -5971,8 +5971,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_INFO( int * nJdata, int * consP, int NCELLS)
 /*compute the sparsity pattern of the system Jacobian */
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST( int * nJdata, int * consP, int NCELLS)
 {
-    double c[14];
-    double J[225];
+    amrex::Real c[14];
+    amrex::Real J[225];
 
     for (int k=0; k<14; k++) {
         c[k] = 1.0/ 14.000000 ;
@@ -6003,8 +6003,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST( int * nJdata, int * consP, int NC
 /*compute the sparsity pattern of the simplified (for preconditioning) system Jacobian */
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED( int * nJdata, int * consP)
 {
-    double c[14];
-    double J[225];
+    amrex::Real c[14];
+    amrex::Real J[225];
 
     for (int k=0; k<14; k++) {
         c[k] = 1.0/ 14.000000 ;
@@ -6034,8 +6034,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED( int * nJdata, int * co
 /*compute the sparsity pattern of the chemistry Jacobian in CSC format -- base 0 */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSC(int *  rowVals, int *  colPtrs, int * consP, int NCELLS)
 {
-    double c[14];
-    double J[225];
+    amrex::Real c[14];
+    amrex::Real J[225];
     int offset_row;
     int offset_col;
 
@@ -6067,8 +6067,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSC(int *  rowVals, int *  colPtrs, 
 /*compute the sparsity pattern of the chemistry Jacobian in CSR format -- base 0 */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSR(int * colVals, int * rowPtrs, int * consP, int NCELLS, int base)
 {
-    double c[14];
-    double J[225];
+    amrex::Real c[14];
+    amrex::Real J[225];
     int offset;
 
     for (int k=0; k<14; k++) {
@@ -6116,8 +6116,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSR(int * colVals, int * rowPtrs, in
 /*CSR format BASE is user choice */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtr, int * consP, int NCELLS, int base)
 {
-    double c[14];
-    double J[225];
+    amrex::Real c[14];
+    amrex::Real J[225];
     int offset;
 
     for (int k=0; k<14; k++) {
@@ -6175,8 +6175,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtr
 /*BASE 0 */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, int * colPtrs, int * indx, int * consP)
 {
-    double c[14];
-    double J[225];
+    amrex::Real c[14];
+    amrex::Real J[225];
 
     for (int k=0; k<14; k++) {
         c[k] = 1.0/ 14.000000 ;
@@ -6210,8 +6210,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, i
 /*CSR format BASE is under choice */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, int * rowPtr, int * consP, int base)
 {
-    double c[14];
-    double J[225];
+    amrex::Real c[14];
+    amrex::Real J[225];
 
     for (int k=0; k<14; k++) {
         c[k] = 1.0/ 14.000000 ;
@@ -6262,7 +6262,7 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, i
 #ifdef AMREX_USE_CUDA
 /*compute the reaction Jacobian on GPU */
 AMREX_GPU_HOST_DEVICE
-void aJacobian(double * J, double * sc, double T, int consP)
+void aJacobian(amrex::Real * J, amrex::Real * sc, amrex::Real T, int consP)
 {
 
 
@@ -6270,43 +6270,43 @@ void aJacobian(double * J, double * sc, double T, int consP)
         J[i] = 0.0;
     }
 
-    double wdot[14];
+    amrex::Real wdot[14];
     for (int k=0; k<14; k++) {
         wdot[k] = 0.0;
     }
 
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
-    double invT2 = invT * invT;
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
+    amrex::Real invT2 = invT * invT;
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
-    double refCinv = 1.0 / refC;
+    amrex::Real refC = 101325 / 8.31446 / T;
+    amrex::Real refCinv = 1.0 / refC;
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int k = 0; k < 14; ++k) {
         mixture += sc[k];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[14];
+    amrex::Real g_RT[14];
     gibbs(g_RT, tc);
 
     /*compute the species enthalpy */
-    double h_RT[14];
+    amrex::Real h_RT[14];
     speciesEnthalpy(h_RT, tc);
 
-    double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
-    double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
-    double dqdci, dcdc_fac, dqdc[14];
-    double Pr, fPr, F, k_0, logPr;
-    double logFcent, troe_c, troe_n, troePr_den, troePr, troe;
-    double Fcent1, Fcent2, Fcent3, Fcent;
-    double dlogFdc, dlogFdn, dlogFdcn_fac;
-    double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
-    const double ln10 = log(10.0);
-    const double log10e = 1.0/log(10.0);
+    amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
+    amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
+    amrex::Real dqdci, dcdc_fac, dqdc[14];
+    amrex::Real Pr, fPr, F, k_0, logPr;
+    amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;
+    amrex::Real Fcent1, Fcent2, Fcent3, Fcent;
+    amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;
+    amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
+    const amrex::Real ln10 = log(10.0);
+    const amrex::Real log10e = 1.0/log(10.0);
     /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
     /*a pressure-fall-off reaction */
     /* also 3-body */
@@ -8511,8 +8511,8 @@ void aJacobian(double * J, double * sc, double T, int consP)
     J[220] += dqdT;               /* dwdot[CO]/dT */
     J[221] -= dqdT;               /* dwdot[O2]/dT */
 
-    double c_R[14], dcRdT[14], e_RT[14];
-    double * eh_RT;
+    amrex::Real c_R[14], dcRdT[14], e_RT[14];
+    amrex::Real * eh_RT;
     if (consP) {
         cp_R(c_R, tc);
         dcvpRdT(dcRdT, tc);
@@ -8525,7 +8525,7 @@ void aJacobian(double * J, double * sc, double T, int consP)
         eh_RT = &e_RT[0];
     }
 
-    double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
+    amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
     for (int k = 0; k < 14; ++k) {
         cmix += c_R[k]*sc[k];
         dcmixdT += dcRdT[k]*sc[k];
@@ -8533,11 +8533,11 @@ void aJacobian(double * J, double * sc, double T, int consP)
         dehmixdT += invT*(c_R[k]-eh_RT[k])*wdot[k] + eh_RT[k]*J[210+k];
     }
 
-    double cmixinv = 1.0/cmix;
-    double tmp1 = ehmix*cmixinv;
-    double tmp3 = cmixinv*T;
-    double tmp2 = tmp1*tmp3;
-    double dehmixdc;
+    amrex::Real cmixinv = 1.0/cmix;
+    amrex::Real tmp1 = ehmix*cmixinv;
+    amrex::Real tmp3 = cmixinv*T;
+    amrex::Real tmp2 = tmp1*tmp3;
+    amrex::Real dehmixdc;
     /* dTdot/d[X] */
     for (int k = 0; k < 14; ++k) {
         dehmixdc = 0.0;
@@ -8556,49 +8556,49 @@ return;
 
 #ifndef AMREX_USE_CUDA
 /*compute the reaction Jacobian on CPU */
-void aJacobian(double *  J, double *  sc, double T, int consP)
+void aJacobian(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int consP)
 {
     for (int i=0; i<225; i++) {
         J[i] = 0.0;
     }
 
-    double wdot[14];
+    amrex::Real wdot[14];
     for (int k=0; k<14; k++) {
         wdot[k] = 0.0;
     }
 
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
-    double invT2 = invT * invT;
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
+    amrex::Real invT2 = invT * invT;
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
-    double refCinv = 1.0 / refC;
+    amrex::Real refC = 101325 / 8.31446 / T;
+    amrex::Real refCinv = 1.0 / refC;
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int k = 0; k < 14; ++k) {
         mixture += sc[k];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[14];
+    amrex::Real g_RT[14];
     gibbs(g_RT, tc);
 
     /*compute the species enthalpy */
-    double h_RT[14];
+    amrex::Real h_RT[14];
     speciesEnthalpy(h_RT, tc);
 
-    double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
-    double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
-    double dqdci, dcdc_fac, dqdc[14];
-    double Pr, fPr, F, k_0, logPr;
-    double logFcent, troe_c, troe_n, troePr_den, troePr, troe;
-    double Fcent1, Fcent2, Fcent3, Fcent;
-    double dlogFdc, dlogFdn, dlogFdcn_fac;
-    double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
-    const double ln10 = log(10.0);
-    const double log10e = 1.0/log(10.0);
+    amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
+    amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
+    amrex::Real dqdci, dcdc_fac, dqdc[14];
+    amrex::Real Pr, fPr, F, k_0, logPr;
+    amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;
+    amrex::Real Fcent1, Fcent2, Fcent3, Fcent;
+    amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;
+    amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
+    const amrex::Real ln10 = log(10.0);
+    const amrex::Real log10e = 1.0/log(10.0);
     /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
     /*a pressure-fall-off reaction */
     /* also 3-body */
@@ -10806,8 +10806,8 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
     J[220] += dqdT;               /* dwdot[CO]/dT */
     J[221] -= dqdT;               /* dwdot[O2]/dT */
 
-    double c_R[14], dcRdT[14], e_RT[14];
-    double * eh_RT;
+    amrex::Real c_R[14], dcRdT[14], e_RT[14];
+    amrex::Real * eh_RT;
     if (consP) {
         cp_R(c_R, tc);
         dcvpRdT(dcRdT, tc);
@@ -10820,7 +10820,7 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
         eh_RT = &e_RT[0];
     }
 
-    double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
+    amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
     for (int k = 0; k < 14; ++k) {
         cmix += c_R[k]*sc[k];
         dcmixdT += dcRdT[k]*sc[k];
@@ -10828,11 +10828,11 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
         dehmixdT += invT*(c_R[k]-eh_RT[k])*wdot[k] + eh_RT[k]*J[210+k];
     }
 
-    double cmixinv = 1.0/cmix;
-    double tmp1 = ehmix*cmixinv;
-    double tmp3 = cmixinv*T;
-    double tmp2 = tmp1*tmp3;
-    double dehmixdc;
+    amrex::Real cmixinv = 1.0/cmix;
+    amrex::Real tmp1 = ehmix*cmixinv;
+    amrex::Real tmp3 = cmixinv*T;
+    amrex::Real tmp2 = tmp1*tmp3;
+    amrex::Real dehmixdc;
     /* dTdot/d[X] */
     for (int k = 0; k < 14; ++k) {
         dehmixdc = 0.0;
@@ -10848,49 +10848,49 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
 
 
 /*compute an approx to the reaction Jacobian */
-AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T, int HP)
+AMREX_GPU_HOST_DEVICE void aJacobian_precond(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int HP)
 {
     for (int i=0; i<225; i++) {
         J[i] = 0.0;
     }
 
-    double wdot[14];
+    amrex::Real wdot[14];
     for (int k=0; k<14; k++) {
         wdot[k] = 0.0;
     }
 
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
-    double invT2 = invT * invT;
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
+    amrex::Real invT2 = invT * invT;
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
-    double refCinv = 1.0 / refC;
+    amrex::Real refC = 101325 / 8.31446 / T;
+    amrex::Real refCinv = 1.0 / refC;
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int k = 0; k < 14; ++k) {
         mixture += sc[k];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[14];
+    amrex::Real g_RT[14];
     gibbs(g_RT, tc);
 
     /*compute the species enthalpy */
-    double h_RT[14];
+    amrex::Real h_RT[14];
     speciesEnthalpy(h_RT, tc);
 
-    double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
-    double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
-    double dqdci, dcdc_fac, dqdc[14];
-    double Pr, fPr, F, k_0, logPr;
-    double logFcent, troe_c, troe_n, troePr_den, troePr, troe;
-    double Fcent1, Fcent2, Fcent3, Fcent;
-    double dlogFdc, dlogFdn, dlogFdcn_fac;
-    double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
-    const double ln10 = log(10.0);
-    const double log10e = 1.0/log(10.0);
+    amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
+    amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
+    amrex::Real dqdci, dcdc_fac, dqdc[14];
+    amrex::Real Pr, fPr, F, k_0, logPr;
+    amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;
+    amrex::Real Fcent1, Fcent2, Fcent3, Fcent;
+    amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;
+    amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
+    const amrex::Real ln10 = log(10.0);
+    const amrex::Real log10e = 1.0/log(10.0);
     /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
     /*a pressure-fall-off reaction */
     /* also 3-body */
@@ -12783,8 +12783,8 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
     J[220] += dqdT;               /* dwdot[CO]/dT */
     J[221] -= dqdT;               /* dwdot[O2]/dT */
 
-    double c_R[14], dcRdT[14], e_RT[14];
-    double * eh_RT;
+    amrex::Real c_R[14], dcRdT[14], e_RT[14];
+    amrex::Real * eh_RT;
     if (HP) {
         cp_R(c_R, tc);
         dcvpRdT(dcRdT, tc);
@@ -12797,7 +12797,7 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
         eh_RT = &e_RT[0];
     }
 
-    double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
+    amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
     for (int k = 0; k < 14; ++k) {
         cmix += c_R[k]*sc[k];
         dcmixdT += dcRdT[k]*sc[k];
@@ -12805,11 +12805,11 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
         dehmixdT += invT*(c_R[k]-eh_RT[k])*wdot[k] + eh_RT[k]*J[210+k];
     }
 
-    double cmixinv = 1.0/cmix;
-    double tmp1 = ehmix*cmixinv;
-    double tmp3 = cmixinv*T;
-    double tmp2 = tmp1*tmp3;
-    double dehmixdc;
+    amrex::Real cmixinv = 1.0/cmix;
+    amrex::Real tmp1 = ehmix*cmixinv;
+    amrex::Real tmp3 = cmixinv*T;
+    amrex::Real tmp2 = tmp1*tmp3;
+    amrex::Real dehmixdc;
     /* dTdot/d[X] */
     for (int k = 0; k < 14; ++k) {
         dehmixdc = 0.0;
@@ -12825,11 +12825,11 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
 
 /*compute d(Cp/R)/dT and d(Cv/R)/dT at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void dcvpRdT(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void dcvpRdT(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -13008,10 +13008,10 @@ AMREX_GPU_HOST_DEVICE void dcvpRdT(double * species, double *  tc)
 
 
 /*compute the progress rate for each reaction */
-AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  sc, double T)
+AMREX_GPU_HOST_DEVICE void progressRate(amrex::Real *  qdot, amrex::Real *  sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 
 #ifndef AMREX_USE_CUDA
     if (T != T_save)
@@ -13022,7 +13022,7 @@ AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  sc, double T)
     }
 #endif
 
-    double q_f[38], q_r[38];
+    amrex::Real q_f[38], q_r[38];
     comp_qfqr(q_f, q_r, sc, tc, invT);
 
     for (int i = 0; i < 38; ++i) {
@@ -13034,10 +13034,10 @@ AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  sc, double T)
 
 
 /*compute the progress rate for each reaction */
-AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *  sc, double T)
+AMREX_GPU_HOST_DEVICE void progressRateFR(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 #ifndef AMREX_USE_CUDA
 
     if (T != T_save)
@@ -13055,10 +13055,10 @@ AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *
 
 
 /*compute the equilibrium constants for each reaction */
-void equilibriumConstants(double *  kc, double *  g_RT, double T)
+void equilibriumConstants(amrex::Real *  kc, amrex::Real *  g_RT, amrex::Real T)
 {
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
+    amrex::Real refC = 101325 / 8.31446 / T;
 
     /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
     kc[0] = 1.0 / (refC) * exp((g_RT[1] + g_RT[11]) - (g_RT[8]));
@@ -13180,12 +13180,12 @@ void equilibriumConstants(double *  kc, double *  g_RT, double T)
 
 /*compute the g/(RT) at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void gibbs(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void gibbs(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -13449,12 +13449,12 @@ AMREX_GPU_HOST_DEVICE void gibbs(double * species, double *  tc)
 
 /*compute the a/(RT) at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void helmholtz(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void helmholtz(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -13718,11 +13718,11 @@ AMREX_GPU_HOST_DEVICE void helmholtz(double * species, double *  tc)
 
 /*compute Cv/R at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void cv_R(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void cv_R(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -13930,11 +13930,11 @@ AMREX_GPU_HOST_DEVICE void cv_R(double * species, double *  tc)
 
 /*compute Cp/R at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void cp_R(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void cp_R(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -14142,12 +14142,12 @@ AMREX_GPU_HOST_DEVICE void cp_R(double * species, double *  tc)
 
 /*compute the e/(RT) at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -14383,12 +14383,12 @@ AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double * species, double *  tc)
 
 /*compute the h/(RT) at the given temperature (Eq 20) */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void speciesEnthalpy(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -14624,11 +14624,11 @@ AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double * species, double *  tc)
 
 /*compute the S/R at the given temperature (Eq 21) */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void speciesEntropy(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void speciesEntropy(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -14863,7 +14863,7 @@ AMREX_GPU_HOST_DEVICE void speciesEntropy(double * species, double *  tc)
 
 
 /*save atomic weights into array */
-void atomicWeight(double *  awt)
+void atomicWeight(amrex::Real *  awt)
 {
     awt[0] = 15.999400; /*O */
     awt[1] = 1.007970; /*H */
@@ -14877,19 +14877,19 @@ void atomicWeight(double *  awt)
 
 
 /* get temperature given internal energy in mass units and mass fracs */
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t, int * ierr)
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(amrex::Real *  e, amrex::Real *  y, amrex::Real *  t, int * ierr)
 {
 #ifdef CONVERGENCE
     const int maxiter = 5000;
-    const double tol  = 1.e-12;
+    const amrex::Real tol  = 1.e-12;
 #else
     const int maxiter = 200;
-    const double tol  = 1.e-6;
+    const amrex::Real tol  = 1.e-6;
 #endif
-    double ein  = *e;
-    double tmin = 90;/*max lower bound for thermo def */
-    double tmax = 4000;/*min upper bound for thermo def */
-    double e1,emin,emax,cv,t1,dt;
+    amrex::Real ein  = *e;
+    amrex::Real tmin = 90;/*max lower bound for thermo def */
+    amrex::Real tmax = 4000;/*min upper bound for thermo def */
+    amrex::Real e1,emin,emax,cv,t1,dt;
     int i;/* loop counter */
     CKUBMS(&tmin, y, &emin);
     CKUBMS(&tmax, y, &emax);
@@ -14927,19 +14927,19 @@ AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t,
 }
 
 /* get temperature given enthalpy in mass units and mass fracs */
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t, int * ierr)
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(amrex::Real *  h, amrex::Real *  y, amrex::Real *  t, int * ierr)
 {
 #ifdef CONVERGENCE
     const int maxiter = 5000;
-    const double tol  = 1.e-12;
+    const amrex::Real tol  = 1.e-12;
 #else
     const int maxiter = 200;
-    const double tol  = 1.e-6;
+    const amrex::Real tol  = 1.e-6;
 #endif
-    double hin  = *h;
-    double tmin = 90;/*max lower bound for thermo def */
-    double tmax = 4000;/*min upper bound for thermo def */
-    double h1,hmin,hmax,cp,t1,dt;
+    amrex::Real hin  = *h;
+    amrex::Real tmin = 90;/*max lower bound for thermo def */
+    amrex::Real tmax = 4000;/*min upper bound for thermo def */
+    amrex::Real h1,hmin,hmax,cp,t1,dt;
     int i;/* loop counter */
     CKHBMS(&tmin, y, &hmin);
     CKHBMS(&tmax, y, &hmax);
@@ -14978,15 +14978,15 @@ AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t,
 
 
 /*compute the critical parameters for each species */
-void GET_CRITPARAMS(double *  Tci, double *  ai, double *  bi, double *  acentric_i)
+void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i)
 {
 
-    double   EPS[14];
-    double   SIG[14];
-    double    wt[14];
-    double avogadro = 6.02214199e23;
-    double boltzmann = 1.3806503e-16; //we work in CGS
-    double Rcst = 83.144598; //in bar [CGS] !
+    amrex::Real   EPS[14];
+    amrex::Real   SIG[14];
+    amrex::Real    wt[14];
+    amrex::Real avogadro = 6.02214199e23;
+    amrex::Real boltzmann = 1.3806503e-16; //we work in CGS
+    amrex::Real Rcst = 83.144598; //in bar [CGS] !
 
     egtransetEPS(EPS);
     egtransetSIG(SIG);
@@ -15108,12 +15108,12 @@ void egtransetNLITE(int* NLITE ) {
 
 
 /*Patm in ergs/cm3 */
-void egtransetPATM(double* PATM) {
+void egtransetPATM(amrex::Real* PATM) {
     *PATM =   0.1013250000000000E+07;}
 
 
 /*the molecular weights in g/mol */
-void egtransetWT(double* WT ) {
+void egtransetWT(amrex::Real* WT ) {
     WT[0] = 2.01594000E+00;
     WT[1] = 1.00797000E+00;
     WT[2] = 3.99480000E+01;
@@ -15132,7 +15132,7 @@ void egtransetWT(double* WT ) {
 
 
 /*the lennard-jones potential well depth eps/kb in K */
-void egtransetEPS(double* EPS ) {
+void egtransetEPS(amrex::Real* EPS ) {
     EPS[0] = 3.80000000E+01;
     EPS[1] = 1.45000000E+02;
     EPS[2] = 1.36500000E+02;
@@ -15151,7 +15151,7 @@ void egtransetEPS(double* EPS ) {
 
 
 /*the lennard-jones collision diameter in Angstroms */
-void egtransetSIG(double* SIG ) {
+void egtransetSIG(amrex::Real* SIG ) {
     SIG[0] = 2.92000000E+00;
     SIG[1] = 2.05000000E+00;
     SIG[2] = 3.33000000E+00;
@@ -15170,7 +15170,7 @@ void egtransetSIG(double* SIG ) {
 
 
 /*the dipole moment in Debye */
-void egtransetDIP(double* DIP ) {
+void egtransetDIP(amrex::Real* DIP ) {
     DIP[0] = 0.00000000E+00;
     DIP[1] = 0.00000000E+00;
     DIP[2] = 0.00000000E+00;
@@ -15189,7 +15189,7 @@ void egtransetDIP(double* DIP ) {
 
 
 /*the polarizability in cubic Angstroms */
-void egtransetPOL(double* POL ) {
+void egtransetPOL(amrex::Real* POL ) {
     POL[0] = 7.90000000E-01;
     POL[1] = 0.00000000E+00;
     POL[2] = 0.00000000E+00;
@@ -15208,7 +15208,7 @@ void egtransetPOL(double* POL ) {
 
 
 /*the rotational relaxation collision number at 298 K */
-void egtransetZROT(double* ZROT ) {
+void egtransetZROT(amrex::Real* ZROT ) {
     ZROT[0] = 2.80000000E+02;
     ZROT[1] = 0.00000000E+00;
     ZROT[2] = 0.00000000E+00;
@@ -15246,7 +15246,7 @@ void egtransetNLIN(int* NLIN) {
 
 
 /*Poly fits for the viscosities, dim NO*KK */
-void egtransetCOFETA(double* COFETA) {
+void egtransetCOFETA(amrex::Real* COFETA) {
     COFETA[0] = -1.37549435E+01;
     COFETA[1] = 9.65530587E-01;
     COFETA[2] = -4.45720114E-02;
@@ -15307,7 +15307,7 @@ void egtransetCOFETA(double* COFETA) {
 
 
 /*Poly fits for the conductivities, dim NO*KK */
-void egtransetCOFLAM(double* COFLAM) {
+void egtransetCOFLAM(amrex::Real* COFLAM) {
     COFLAM[0] = 1.15899058E+01;
     COFLAM[1] = -1.52427727E+00;
     COFLAM[2] = 2.72840752E-01;
@@ -15368,7 +15368,7 @@ void egtransetCOFLAM(double* COFLAM) {
 
 
 /*Poly fits for the diffusion coefficients, dim NO*KK*KK */
-void egtransetCOFD(double* COFD) {
+void egtransetCOFD(amrex::Real* COFD) {
     COFD[0] = -1.02395222E+01;
     COFD[1] = 2.15403244E+00;
     COFD[2] = -6.97480266E-02;
@@ -16165,7 +16165,7 @@ void egtransetKTDIF(int* KTDIF) {
 
 
 /*Poly fits for thermal diff ratios, dim NO*NLITE*KK */
-void egtransetCOFTD(double* COFTD) {
+void egtransetCOFTD(amrex::Real* COFTD) {
     COFTD[0] = 0.00000000E+00;
     COFTD[1] = 0.00000000E+00;
     COFTD[2] = 0.00000000E+00;
@@ -16337,12 +16337,12 @@ void egtransetCOFTD(double* COFTD) {
 }
 
 /* Replace this routine with the one generated by the Gauss Jordan solver of DW */
-AMREX_GPU_HOST_DEVICE void sgjsolve(double* A, double* x, double* b) {
+AMREX_GPU_HOST_DEVICE void sgjsolve(amrex::Real* A, amrex::Real* x, amrex::Real* b) {
     amrex::Abort("sgjsolve not implemented, choose a different solver ");
 }
 
 /* Replace this routine with the one generated by the Gauss Jordan solver of DW */
-AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(double* A, double* x, double* b) {
+AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(amrex::Real* A, amrex::Real* x, amrex::Real* b) {
     amrex::Abort("sgjsolve_simplified not implemented, choose a different solver ");
 }
 

--- a/Support/Fuego/Mechanism/Models/LiDryer/chemistry_file.H
+++ b/Support/Fuego/Mechanism/Models/LiDryer/chemistry_file.H
@@ -7,28 +7,28 @@
 
 extern "C"
 {
-AMREX_GPU_HOST_DEVICE void get_imw(double imw_new[]);
-AMREX_GPU_HOST_DEVICE void get_mw(double mw_new[]);
-void egtransetEPS(double *  EPS);
-void egtransetSIG(double* SIG);
-void atomicWeight(double *  awt);
-void molecularWeight(double *  wt);
-AMREX_GPU_HOST_DEVICE void gibbs(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void helmholtz(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void speciesEntropy(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void cp_R(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void cv_R(double *  species, double *  tc);
-void equilibriumConstants(double *  kc, double *  g_RT, double T);
-AMREX_GPU_HOST_DEVICE void productionRate(double *  wdot, double *  sc, double T);
-AMREX_GPU_HOST_DEVICE void comp_qfqr(double *  q_f, double *  q_r, double *  sc, double *  tc, double invT);
+AMREX_GPU_HOST_DEVICE void get_imw(amrex::Real imw_new[]);
+AMREX_GPU_HOST_DEVICE void get_mw(amrex::Real mw_new[]);
+void egtransetEPS(amrex::Real *  EPS);
+void egtransetSIG(amrex::Real* SIG);
+void atomicWeight(amrex::Real *  awt);
+void molecularWeight(amrex::Real *  wt);
+AMREX_GPU_HOST_DEVICE void gibbs(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void helmholtz(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void speciesEnthalpy(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void speciesEntropy(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void cp_R(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void cv_R(amrex::Real *  species, amrex::Real *  tc);
+void equilibriumConstants(amrex::Real *  kc, amrex::Real *  g_RT, amrex::Real T);
+AMREX_GPU_HOST_DEVICE void productionRate(amrex::Real *  wdot, amrex::Real *  sc, amrex::Real T);
+AMREX_GPU_HOST_DEVICE void comp_qfqr(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  sc, amrex::Real *  tc, amrex::Real invT);
 #ifndef AMREX_USE_CUDA
-void comp_k_f(double *  tc, double invT, double *  k_f);
-void comp_Kc(double *  tc, double invT, double *  Kc);
+void comp_k_f(amrex::Real *  tc, amrex::Real invT, amrex::Real *  k_f);
+void comp_Kc(amrex::Real *  tc, amrex::Real invT, amrex::Real *  Kc);
 #endif
-AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  speciesConc, double T);
-AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *  speciesConc, double T);
+AMREX_GPU_HOST_DEVICE void progressRate(amrex::Real *  qdot, amrex::Real *  speciesConc, amrex::Real T);
+AMREX_GPU_HOST_DEVICE void progressRateFR(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  speciesConc, amrex::Real T);
 AMREX_GPU_HOST_DEVICE void CKINIT();
 AMREX_GPU_HOST_DEVICE void CKFINALIZE();
 #ifndef AMREX_USE_CUDA
@@ -36,87 +36,87 @@ void GET_REACTION_MAP(int *  rmap);
 void SetAllDefaults();
 #endif
 void CKINDX(int * mm, int * kk, int * ii, int * nfit );
-void CKXNUM(char * line, int * nexp, int * lout, int * nval, double *  rval, int * kerr, int lenline);
-void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, double *  rval, int * kerr, int lenline, int lenkray);
+void CKXNUM(char * line, int * nexp, int * lout, int * nval, amrex::Real *  rval, int * kerr, int lenline);
+void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, amrex::Real *  rval, int * kerr, int lenline, int lenkray);
 void CKSYME_STR(amrex::Vector<std::string>& ename);
 void CKSYME(int * kname, int * lenkname);
 void CKSYMS_STR(amrex::Vector<std::string>& kname);
 void CKSYMS(int * kname, int * lenkname);
-void CKRP(double *  ru, double *  ruc, double *  pa);
-void CKPX(double *  rho, double *  T, double *  x, double *  P);
-AMREX_GPU_HOST_DEVICE void CKPY(double *  rho, double *  T, double *  y, double *  P);
-void CKPC(double *  rho, double *  T, double *  c, double *  P);
-void CKRHOX(double *  P, double *  T, double *  x, double *  rho);
-AMREX_GPU_HOST_DEVICE void CKRHOY(double *  P, double *  T, double *  y, double *  rho);
-void CKRHOC(double *  P, double *  T, double *  c, double *  rho);
-void CKWT(double *  wt);
-void CKAWT(double *  awt);
-AMREX_GPU_HOST_DEVICE void CKMMWY(double *  y, double *  wtm);
-void CKMMWX(double *  x, double *  wtm);
-void CKMMWC(double *  c, double *  wtm);
-AMREX_GPU_HOST_DEVICE void CKYTX(double *  y, double *  x);
-void CKYTCP(double *  P, double *  T, double *  y, double *  c);
-AMREX_GPU_HOST_DEVICE void CKYTCR(double *  rho, double *  T, double *  y, double *  c);
-AMREX_GPU_HOST_DEVICE void CKXTY(double *  x, double *  y);
-void CKXTCP(double *  P, double *  T, double *  x, double *  c);
-void CKXTCR(double *  rho, double *  T, double *  x, double *  c);
-void CKCTX(double *  c, double *  x);
-void CKCTY(double *  c, double *  y);
-void CKCPOR(double *  T, double *  cpor);
-void CKHORT(double *  T, double *  hort);
-void CKSOR(double *  T, double *  sor);
-void CKCVML(double *  T, double *  cvml);
-void CKCPML(double *  T, double *  cvml);
-void CKUML(double *  T, double *  uml);
-void CKHML(double *  T, double *  uml);
-void CKGML(double *  T, double *  gml);
-void CKAML(double *  T, double *  aml);
-void CKSML(double *  T, double *  sml);
-AMREX_GPU_HOST_DEVICE void CKCVMS(double *  T, double *  cvms);
-AMREX_GPU_HOST_DEVICE void CKCPMS(double *  T, double *  cvms);
-AMREX_GPU_HOST_DEVICE void CKUMS(double *  T, double *  ums);
-AMREX_GPU_HOST_DEVICE void CKHMS(double *  T, double *  ums);
-void CKGMS(double *  T, double *  gms);
-void CKAMS(double *  T, double *  ams);
-void CKSMS(double *  T, double *  sms);
-void CKCPBL(double *  T, double *  x, double *  cpbl);
-AMREX_GPU_HOST_DEVICE void CKCPBS(double *  T, double *  y, double *  cpbs);
-void CKCVBL(double *  T, double *  x, double *  cpbl);
-AMREX_GPU_HOST_DEVICE void CKCVBS(double *  T, double *  y, double *  cpbs);
-void CKHBML(double *  T, double *  x, double *  hbml);
-AMREX_GPU_HOST_DEVICE void CKHBMS(double *  T, double *  y, double *  hbms);
-void CKUBML(double *  T, double *  x, double *  ubml);
-AMREX_GPU_HOST_DEVICE void CKUBMS(double *  T, double *  y, double *  ubms);
-void CKSBML(double *  P, double *  T, double *  x, double *  sbml);
-void CKSBMS(double *  P, double *  T, double *  y, double *  sbms);
-void CKGBML(double *  P, double *  T, double *  x, double *  gbml);
-void CKGBMS(double *  P, double *  T, double *  y, double *  gbms);
-void CKABML(double *  P, double *  T, double *  x, double *  abml);
-void CKABMS(double *  P, double *  T, double *  y, double *  abms);
-AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C, double *  wdot);
-void CKWYP(double *  P, double *  T, double *  y, double *  wdot);
-void CKWXP(double *  P, double *  T, double *  x, double *  wdot);
-AMREX_GPU_HOST_DEVICE void CKWYR(double *  rho, double *  T, double *  y, double *  wdot);
-void CKWXR(double *  rho, double *  T, double *  x, double *  wdot);
-void CKQC(double *  T, double *  C, double *  qdot);
-void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r);
-void CKQYP(double *  P, double *  T, double *  y, double *  qdot);
-void CKQXP(double *  P, double *  T, double *  x, double *  qdot);
-void CKQYR(double *  rho, double *  T, double *  y, double *  qdot);
-void CKQXR(double *  rho, double *  T, double *  x, double *  qdot);
+void CKRP(amrex::Real *  ru, amrex::Real *  ruc, amrex::Real *  pa);
+void CKPX(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  P);
+AMREX_GPU_HOST_DEVICE void CKPY(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  P);
+void CKPC(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  c, amrex::Real *  P);
+void CKRHOX(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  rho);
+AMREX_GPU_HOST_DEVICE void CKRHOY(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  rho);
+void CKRHOC(amrex::Real *  P, amrex::Real *  T, amrex::Real *  c, amrex::Real *  rho);
+void CKWT(amrex::Real *  wt);
+void CKAWT(amrex::Real *  awt);
+AMREX_GPU_HOST_DEVICE void CKMMWY(amrex::Real *  y, amrex::Real *  wtm);
+void CKMMWX(amrex::Real *  x, amrex::Real *  wtm);
+void CKMMWC(amrex::Real *  c, amrex::Real *  wtm);
+AMREX_GPU_HOST_DEVICE void CKYTX(amrex::Real *  y, amrex::Real *  x);
+void CKYTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  c);
+AMREX_GPU_HOST_DEVICE void CKYTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  c);
+AMREX_GPU_HOST_DEVICE void CKXTY(amrex::Real *  x, amrex::Real *  y);
+void CKXTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c);
+void CKXTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c);
+void CKCTX(amrex::Real *  c, amrex::Real *  x);
+void CKCTY(amrex::Real *  c, amrex::Real *  y);
+void CKCPOR(amrex::Real *  T, amrex::Real *  cpor);
+void CKHORT(amrex::Real *  T, amrex::Real *  hort);
+void CKSOR(amrex::Real *  T, amrex::Real *  sor);
+void CKCVML(amrex::Real *  T, amrex::Real *  cvml);
+void CKCPML(amrex::Real *  T, amrex::Real *  cvml);
+void CKUML(amrex::Real *  T, amrex::Real *  uml);
+void CKHML(amrex::Real *  T, amrex::Real *  uml);
+void CKGML(amrex::Real *  T, amrex::Real *  gml);
+void CKAML(amrex::Real *  T, amrex::Real *  aml);
+void CKSML(amrex::Real *  T, amrex::Real *  sml);
+AMREX_GPU_HOST_DEVICE void CKCVMS(amrex::Real *  T, amrex::Real *  cvms);
+AMREX_GPU_HOST_DEVICE void CKCPMS(amrex::Real *  T, amrex::Real *  cvms);
+AMREX_GPU_HOST_DEVICE void CKUMS(amrex::Real *  T, amrex::Real *  ums);
+AMREX_GPU_HOST_DEVICE void CKHMS(amrex::Real *  T, amrex::Real *  ums);
+void CKGMS(amrex::Real *  T, amrex::Real *  gms);
+void CKAMS(amrex::Real *  T, amrex::Real *  ams);
+void CKSMS(amrex::Real *  T, amrex::Real *  sms);
+void CKCPBL(amrex::Real *  T, amrex::Real *  x, amrex::Real *  cpbl);
+AMREX_GPU_HOST_DEVICE void CKCPBS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  cpbs);
+void CKCVBL(amrex::Real *  T, amrex::Real *  x, amrex::Real *  cpbl);
+AMREX_GPU_HOST_DEVICE void CKCVBS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  cpbs);
+void CKHBML(amrex::Real *  T, amrex::Real *  x, amrex::Real *  hbml);
+AMREX_GPU_HOST_DEVICE void CKHBMS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  hbms);
+void CKUBML(amrex::Real *  T, amrex::Real *  x, amrex::Real *  ubml);
+AMREX_GPU_HOST_DEVICE void CKUBMS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  ubms);
+void CKSBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  sbml);
+void CKSBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  sbms);
+void CKGBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  gbml);
+void CKGBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  gbms);
+void CKABML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  abml);
+void CKABMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  abms);
+AMREX_GPU_HOST_DEVICE void CKWC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  wdot);
+void CKWYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  wdot);
+void CKWXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  wdot);
+AMREX_GPU_HOST_DEVICE void CKWYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  wdot);
+void CKWXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  wdot);
+void CKQC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  qdot);
+void CKKFKR(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  q_f, amrex::Real *  q_r);
+void CKQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot);
+void CKQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot);
+void CKQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot);
+void CKQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot);
 void CKNU(int * kdim, int * nuki);
 #ifndef AMREX_USE_CUDA
 void CKINU(int * i, int * nspec, int * ki, int * nu);
 #endif
 void CKNCF(int * ncf);
-void CKABE(double *  a, double *  b, double *  e );
-void CKEQC(double *  T, double *  C , double *  eqcon );
-void CKEQYP(double *  P, double *  T, double *  y, double *  eqcon);
-void CKEQXP(double *  P, double *  T, double *  x, double *  eqcon);
-void CKEQYR(double *  rho, double *  T, double *  y, double *  eqcon);
-void CKEQXR(double *  rho, double *  T, double *  x, double *  eqcon);
-AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  T, int * consP);
-AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double *  Tp, int * HP);
+void CKABE(amrex::Real *  a, amrex::Real *  b, amrex::Real *  e );
+void CKEQC(amrex::Real *  T, amrex::Real *  C , amrex::Real *  eqcon );
+void CKEQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon);
+void CKEQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon);
+void CKEQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon);
+void CKEQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon);
+AMREX_GPU_HOST_DEVICE void DWDOT(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  T, int * consP);
+AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * HP);
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO(int * nJdata, int * consP, int NCELLS);
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST(int * nJdata, int * consP, int NCELLS);
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED(int * nJdata, int * consP);
@@ -125,27 +125,27 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSR(int * colVals, int * rowPtrs, in
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtrs, int * consP, int NCELLS, int base);
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, int * colPtrs, int * indx, int * consP);
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, int * rowPtr, int * consP, int base);
-AMREX_GPU_HOST_DEVICE void aJacobian(double *  J, double *  sc, double T, int consP);
-AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T, int HP);
-AMREX_GPU_HOST_DEVICE void dcvpRdT(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t, int *ierr);
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t, int *ierr);
-void GET_CRITPARAMS(double *  Tci, double *  ai, double *  bi, double *  acentric_i);
+AMREX_GPU_HOST_DEVICE void aJacobian(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int consP);
+AMREX_GPU_HOST_DEVICE void aJacobian_precond(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int HP);
+AMREX_GPU_HOST_DEVICE void dcvpRdT(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(amrex::Real *  e, amrex::Real *  y, amrex::Real *  t, int *ierr);
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(amrex::Real *  h, amrex::Real *  y, amrex::Real *  t, int *ierr);
+void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i);
 /*vector version */
-void VCKYTX(int *  np, double *  y, double *  x);
-void VCKHMS(int *  np, double *  T, double *  ums);
-void VCKWYR(int *  np, double *  rho, double *  T,
-            double *  y,
-            double *  wdot);
+void VCKYTX(int *  np, amrex::Real *  y, amrex::Real *  x);
+void VCKHMS(int *  np, amrex::Real *  T, amrex::Real *  ums);
+void VCKWYR(int *  np, amrex::Real *  rho, amrex::Real *  T,
+            amrex::Real *  y,
+            amrex::Real *  wdot);
 #ifndef AMREX_USE_CUDA
-void vproductionRate(int npt, double *  wdot, double *  c, double *  T);
-void VCKPY(int *  np, double *  rho, double *  T, double *  y, double *  P);
-void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT);
-void vcomp_gibbs(int npt, double *  g_RT, double *  tc);
-void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT);
-void vcomp_wdot(int npt, double *  wdot, double *  mixture, double *  sc,
-                double *  k_f_s, double *  Kc_s,
-                double *  tc, double *  invT, double *  T);
+void vproductionRate(int npt, amrex::Real *  wdot, amrex::Real *  c, amrex::Real *  T);
+void VCKPY(int *  np, amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  P);
+void vcomp_k_f(int npt, amrex::Real *  k_f_s, amrex::Real *  tc, amrex::Real *  invT);
+void vcomp_gibbs(int npt, amrex::Real *  g_RT, amrex::Real *  tc);
+void vcomp_Kc(int npt, amrex::Real *  Kc_s, amrex::Real *  g_RT, amrex::Real *  invT);
+void vcomp_wdot(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,
+                amrex::Real *  k_f_s, amrex::Real *  Kc_s,
+                amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T);
 #endif
 /*Transport function declarations */
 void egtransetLENIMC(int* LENIMC);
@@ -153,46 +153,46 @@ void egtransetLENRMC(int* LENRMC);
 void egtransetNO(int* NO);
 void egtransetKK(int* KK);
 void egtransetNLITE(int* NLITE);
-void egtransetPATM(double* PATM);
-void egtransetWT(double* WT);
-void egtransetEPS(double* EPS);
-void egtransetSIG(double* SIG);
-void egtransetDIP(double* DIP);
-void egtransetPOL(double* POL);
-void egtransetZROT(double* ZROT);
+void egtransetPATM(amrex::Real* PATM);
+void egtransetWT(amrex::Real* WT);
+void egtransetEPS(amrex::Real* EPS);
+void egtransetSIG(amrex::Real* SIG);
+void egtransetDIP(amrex::Real* DIP);
+void egtransetPOL(amrex::Real* POL);
+void egtransetZROT(amrex::Real* ZROT);
 void egtransetNLIN(int* NLIN);
-void egtransetCOFETA(double* COFETA);
-void egtransetCOFLAM(double* COFLAM);
-void egtransetCOFD(double* COFD);
+void egtransetCOFETA(amrex::Real* COFETA);
+void egtransetCOFLAM(amrex::Real* COFLAM);
+void egtransetCOFD(amrex::Real* COFD);
 void egtransetKTDIF(int* KTDIF);
 /*gauss-jordan solver external routine */
-AMREX_GPU_HOST_DEVICE void sgjsolve(double* A, double* x, double* b);
-AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(double* A, double* x, double* b);
+AMREX_GPU_HOST_DEVICE void sgjsolve(amrex::Real* A, amrex::Real* x, amrex::Real* b);
+AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(amrex::Real* A, amrex::Real* x, amrex::Real* b);
 }
 
 #ifndef AMREX_USE_CUDA
 namespace thermo
 {
 
-    extern double fwd_A[21], fwd_beta[21], fwd_Ea[21];
-    extern double low_A[21], low_beta[21], low_Ea[21];
-    extern double rev_A[21], rev_beta[21], rev_Ea[21];
-    extern double troe_a[21],troe_Ts[21], troe_Tss[21], troe_Tsss[21];
-    extern double sri_a[21], sri_b[21], sri_c[21], sri_d[21], sri_e[21];
-    extern double activation_units[21], prefactor_units[21], phase_units[21];
+    extern amrex::Real fwd_A[21], fwd_beta[21], fwd_Ea[21];
+    extern amrex::Real low_A[21], low_beta[21], low_Ea[21];
+    extern amrex::Real rev_A[21], rev_beta[21], rev_Ea[21];
+    extern amrex::Real troe_a[21],troe_Ts[21], troe_Tss[21], troe_Tsss[21];
+    extern amrex::Real sri_a[21], sri_b[21], sri_c[21], sri_d[21], sri_e[21];
+    extern amrex::Real activation_units[21], prefactor_units[21], phase_units[21];
     extern int is_PD[21], troe_len[21], sri_len[21], nTB[21], *TBid[21];
-    extern double *TB[21];
-    extern std::vector<std::vector<double>> kiv; 
-    extern std::vector<std::vector<double>> nuv; 
+    extern amrex::Real *TB[21];
+    extern std::vector<std::vector<amrex::Real>> kiv; 
+    extern std::vector<std::vector<amrex::Real>> nuv; 
 
-    extern double fwd_A_DEF[21], fwd_beta_DEF[21], fwd_Ea_DEF[21];
-    extern double low_A_DEF[21], low_beta_DEF[21], low_Ea_DEF[21];
-    extern double rev_A_DEF[21], rev_beta_DEF[21], rev_Ea_DEF[21];
-    extern double troe_a_DEF[21],troe_Ts_DEF[21], troe_Tss_DEF[21], troe_Tsss_DEF[21];
-    extern double sri_a_DEF[21], sri_b_DEF[21], sri_c_DEF[21], sri_d_DEF[21], sri_e_DEF[21];
-    extern double activation_units_DEF[21], prefactor_units_DEF[21], phase_units_DEF[21];
+    extern amrex::Real fwd_A_DEF[21], fwd_beta_DEF[21], fwd_Ea_DEF[21];
+    extern amrex::Real low_A_DEF[21], low_beta_DEF[21], low_Ea_DEF[21];
+    extern amrex::Real rev_A_DEF[21], rev_beta_DEF[21], rev_Ea_DEF[21];
+    extern amrex::Real troe_a_DEF[21],troe_Ts_DEF[21], troe_Tss_DEF[21], troe_Tsss_DEF[21];
+    extern amrex::Real sri_a_DEF[21], sri_b_DEF[21], sri_c_DEF[21], sri_d_DEF[21], sri_e_DEF[21];
+    extern amrex::Real activation_units_DEF[21], prefactor_units_DEF[21], phase_units_DEF[21];
     extern int is_PD_DEF[21], troe_len_DEF[21], sri_len_DEF[21], nTB_DEF[21], *TBid_DEF[21];
-    extern double *TB_DEF[21];
+    extern amrex::Real *TB_DEF[21];
     extern std::vector<int> rxn_map;
 }
 #endif

--- a/Support/Fuego/Mechanism/Models/LiDryer/mechanism.cpp
+++ b/Support/Fuego/Mechanism/Models/LiDryer/mechanism.cpp
@@ -3,25 +3,25 @@
 #ifndef AMREX_USE_CUDA
 namespace thermo
 {
-    double fwd_A[21], fwd_beta[21], fwd_Ea[21];
-    double low_A[21], low_beta[21], low_Ea[21];
-    double rev_A[21], rev_beta[21], rev_Ea[21];
-    double troe_a[21],troe_Ts[21], troe_Tss[21], troe_Tsss[21];
-    double sri_a[21], sri_b[21], sri_c[21], sri_d[21], sri_e[21];
-    double activation_units[21], prefactor_units[21], phase_units[21];
+    amrex::Real fwd_A[21], fwd_beta[21], fwd_Ea[21];
+    amrex::Real low_A[21], low_beta[21], low_Ea[21];
+    amrex::Real rev_A[21], rev_beta[21], rev_Ea[21];
+    amrex::Real troe_a[21],troe_Ts[21], troe_Tss[21], troe_Tsss[21];
+    amrex::Real sri_a[21], sri_b[21], sri_c[21], sri_d[21], sri_e[21];
+    amrex::Real activation_units[21], prefactor_units[21], phase_units[21];
     int is_PD[21], troe_len[21], sri_len[21], nTB[21], *TBid[21];
-    double *TB[21];
-    std::vector<std::vector<double>> kiv(21); 
-    std::vector<std::vector<double>> nuv(21); 
+    amrex::Real *TB[21];
+    std::vector<std::vector<amrex::Real>> kiv(21); 
+    std::vector<std::vector<amrex::Real>> nuv(21); 
 
-    double fwd_A_DEF[21], fwd_beta_DEF[21], fwd_Ea_DEF[21];
-    double low_A_DEF[21], low_beta_DEF[21], low_Ea_DEF[21];
-    double rev_A_DEF[21], rev_beta_DEF[21], rev_Ea_DEF[21];
-    double troe_a_DEF[21],troe_Ts_DEF[21], troe_Tss_DEF[21], troe_Tsss_DEF[21];
-    double sri_a_DEF[21], sri_b_DEF[21], sri_c_DEF[21], sri_d_DEF[21], sri_e_DEF[21];
-    double activation_units_DEF[21], prefactor_units_DEF[21], phase_units_DEF[21];
+    amrex::Real fwd_A_DEF[21], fwd_beta_DEF[21], fwd_Ea_DEF[21];
+    amrex::Real low_A_DEF[21], low_beta_DEF[21], low_Ea_DEF[21];
+    amrex::Real rev_A_DEF[21], rev_beta_DEF[21], rev_Ea_DEF[21];
+    amrex::Real troe_a_DEF[21],troe_Ts_DEF[21], troe_Tss_DEF[21], troe_Tsss_DEF[21];
+    amrex::Real sri_a_DEF[21], sri_b_DEF[21], sri_c_DEF[21], sri_d_DEF[21], sri_e_DEF[21];
+    amrex::Real activation_units_DEF[21], prefactor_units_DEF[21], phase_units_DEF[21];
     int is_PD_DEF[21], troe_len_DEF[21], sri_len_DEF[21], nTB_DEF[21], *TBid_DEF[21];
-    double *TB_DEF[21];
+    amrex::Real *TB_DEF[21];
     std::vector<int> rxn_map;
 };
 
@@ -30,7 +30,7 @@ using namespace thermo;
 
 /* Inverse molecular weights */
 /* TODO: check necessity on CPU */
-static AMREX_GPU_DEVICE_MANAGED double imw[9] = {
+static AMREX_GPU_DEVICE_MANAGED amrex::Real imw[9] = {
     1.0 / 2.015940,  /*H2 */
     1.0 / 31.998800,  /*O2 */
     1.0 / 18.015340,  /*H2O */
@@ -43,7 +43,7 @@ static AMREX_GPU_DEVICE_MANAGED double imw[9] = {
 
 /* Inverse molecular weights */
 /* TODO: check necessity because redundant with molecularWeight */
-static AMREX_GPU_DEVICE_MANAGED double molecular_weights[9] = {
+static AMREX_GPU_DEVICE_MANAGED amrex::Real molecular_weights[9] = {
     2.015940,  /*H2 */
     31.998800,  /*O2 */
     18.015340,  /*H2O */
@@ -55,13 +55,13 @@ static AMREX_GPU_DEVICE_MANAGED double molecular_weights[9] = {
     28.013400};  /*N2 */
 
 AMREX_GPU_HOST_DEVICE
-void get_imw(double imw_new[]){
+void get_imw(amrex::Real imw_new[]){
     for(int i = 0; i<9; ++i) imw_new[i] = imw[i];
 }
 
 /* TODO: check necessity because redundant with CKWT */
 AMREX_GPU_HOST_DEVICE
-void get_mw(double mw_new[]){
+void get_mw(amrex::Real mw_new[]){
     for(int i = 0; i<9; ++i) mw_new[i] = molecular_weights[i];
 }
 
@@ -137,7 +137,7 @@ void CKINIT()
     phase_units[2]      = pow(10,-6.000000);
     is_PD[2] = 0;
     nTB[2] = 2;
-    TB[2] = (double *) malloc(2 * sizeof(double));
+    TB[2] = (amrex::Real *) malloc(2 * sizeof(amrex::Real));
     TBid[2] = (int *) malloc(2 * sizeof(int));
     TBid[2][0] = 0; TB[2][0] = 2.5; // H2
     TBid[2][1] = 2; TB[2][1] = 12; // H2O
@@ -154,7 +154,7 @@ void CKINIT()
     phase_units[3]      = pow(10,-12.000000);
     is_PD[3] = 0;
     nTB[3] = 2;
-    TB[3] = (double *) malloc(2 * sizeof(double));
+    TB[3] = (amrex::Real *) malloc(2 * sizeof(amrex::Real));
     TBid[3] = (int *) malloc(2 * sizeof(int));
     TBid[3][0] = 0; TB[3][0] = 2.5; // H2
     TBid[3][1] = 2; TB[3][1] = 12; // H2O
@@ -171,7 +171,7 @@ void CKINIT()
     phase_units[4]      = pow(10,-12.000000);
     is_PD[4] = 0;
     nTB[4] = 2;
-    TB[4] = (double *) malloc(2 * sizeof(double));
+    TB[4] = (amrex::Real *) malloc(2 * sizeof(amrex::Real));
     TBid[4] = (int *) malloc(2 * sizeof(int));
     TBid[4][0] = 0; TB[4][0] = 2.5; // H2
     TBid[4][1] = 2; TB[4][1] = 12; // H2O
@@ -188,7 +188,7 @@ void CKINIT()
     phase_units[5]      = pow(10,-12.000000);
     is_PD[5] = 0;
     nTB[5] = 2;
-    TB[5] = (double *) malloc(2 * sizeof(double));
+    TB[5] = (amrex::Real *) malloc(2 * sizeof(amrex::Real));
     TBid[5] = (int *) malloc(2 * sizeof(int));
     TBid[5][0] = 0; TB[5][0] = 2.5; // H2
     TBid[5][1] = 2; TB[5][1] = 12; // H2O
@@ -212,7 +212,7 @@ void CKINIT()
     phase_units[0]      = pow(10,-12.000000);
     is_PD[0] = 1;
     nTB[0] = 3;
-    TB[0] = (double *) malloc(3 * sizeof(double));
+    TB[0] = (amrex::Real *) malloc(3 * sizeof(amrex::Real));
     TBid[0] = (int *) malloc(3 * sizeof(int));
     TBid[0][0] = 0; TB[0][0] = 2; // H2
     TBid[0][1] = 2; TB[0][1] = 11; // H2O
@@ -315,7 +315,7 @@ void CKINIT()
     phase_units[1]      = pow(10,-6.000000);
     is_PD[1] = 1;
     nTB[1] = 2;
-    TB[1] = (double *) malloc(2 * sizeof(double));
+    TB[1] = (amrex::Real *) malloc(2 * sizeof(amrex::Real));
     TBid[1] = (int *) malloc(2 * sizeof(int));
     TBid[1][0] = 0; TB[1][0] = 2.5; // H2
     TBid[1][1] = 2; TB[1][1] = 12; // H2O
@@ -396,12 +396,12 @@ void GET_REACTION_MAP(int *rmap)
 }
 
 #include <ReactionData.H>
-double* GetParamPtr(int                reaction_id,
+amrex::Real* GetParamPtr(int                reaction_id,
                     REACTION_PARAMETER param_id,
                     int                species_id,
                     int                get_default)
 {
-  double* ret = 0;
+  amrex::Real* ret = 0;
   if (reaction_id<0 || reaction_id>=21) {
     printf("Bad reaction id = %d",reaction_id);
     abort();
@@ -501,7 +501,7 @@ void ResetAllParametersToDefault()
 
         nTB[i]  = nTB_DEF[i];
         if (nTB[i] != 0) {
-           TB[i] = (double *) malloc(sizeof(double) * nTB[i]);
+           TB[i] = (amrex::Real *) malloc(sizeof(amrex::Real) * nTB[i]);
            TBid[i] = (int *) malloc(sizeof(int) * nTB[i]);
            for (int j=0; j<nTB[i]; j++) {
              TB[i][j] = TB_DEF[i][j];
@@ -553,7 +553,7 @@ void SetAllDefaults()
 
         nTB_DEF[i]  = nTB[i];
         if (nTB_DEF[i] != 0) {
-           TB_DEF[i] = (double *) malloc(sizeof(double) * nTB_DEF[i]);
+           TB_DEF[i] = (amrex::Real *) malloc(sizeof(amrex::Real) * nTB_DEF[i]);
            TBid_DEF[i] = (int *) malloc(sizeof(int) * nTB_DEF[i]);
            for (int j=0; j<nTB_DEF[i]; j++) {
              TB_DEF[i][j] = TB[i][j];
@@ -602,7 +602,7 @@ void CKINDX(int * mm, int * kk, int * ii, int * nfit)
 
 
 /* ckxnum... for parsing strings  */
-void CKXNUM(char * line, int * nexp, int * lout, int * nval, double *  rval, int * kerr, int lenline )
+void CKXNUM(char * line, int * nexp, int * lout, int * nval, amrex::Real *  rval, int * kerr, int lenline )
 {
     int n,i; /*Loop Counters */
     char cstr[1000];
@@ -635,7 +635,7 @@ void CKXNUM(char * line, int * nexp, int * lout, int * nval, double *  rval, int
 
 
 /* cksnum... for parsing strings  */
-void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, double *  rval, int * kerr, int lenline, int lenkray)
+void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, amrex::Real *  rval, int * kerr, int lenline, int lenkray)
 {
     /*Not done yet ... */
 }
@@ -753,7 +753,7 @@ void CKSYMS(int * kname, int * plenkname )
 
 
 /* Returns R, Rc, Patm */
-void CKRP(double *  ru, double *  ruc, double *  pa)
+void CKRP(amrex::Real *  ru, amrex::Real *  ruc, amrex::Real *  pa)
 {
      *ru  = 8.31446261815324e+07; 
      *ruc = 1.98721558317399615845; 
@@ -762,9 +762,9 @@ void CKRP(double *  ru, double *  ruc, double *  pa)
 
 
 /*Compute P = rhoRT/W(x) */
-void CKPX(double *  rho, double *  T, double *  x, double *  P)
+void CKPX(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  P)
 {
-    double XW = 0;/* To hold mean molecular wt */
+    amrex::Real XW = 0;/* To hold mean molecular wt */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*31.998800; /*O2 */
     XW += x[2]*18.015340; /*H2O */
@@ -781,9 +781,9 @@ void CKPX(double *  rho, double *  T, double *  x, double *  P)
 
 
 /*Compute P = rhoRT/W(y) */
-AMREX_GPU_HOST_DEVICE void CKPY(double *  rho, double *  T, double *  y,  double *  P)
+AMREX_GPU_HOST_DEVICE void CKPY(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  P)
 {
-    double YOW = 0;/* for computing mean MW */
+    amrex::Real YOW = 0;/* for computing mean MW */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*O2 */
     YOW += y[2]*imw[2]; /*H2O */
@@ -801,9 +801,9 @@ AMREX_GPU_HOST_DEVICE void CKPY(double *  rho, double *  T, double *  y,  double
 
 #ifndef AMREX_USE_CUDA
 /*Compute P = rhoRT/W(y) */
-void VCKPY(int *  np, double *  rho, double *  T, double *  y,  double *  P)
+void VCKPY(int *  np, amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  P)
 {
-    double YOW[*np];
+    amrex::Real YOW[*np];
     for (int i=0; i<(*np); i++) {
         YOW[i] = 0.0;
     }
@@ -824,12 +824,12 @@ void VCKPY(int *  np, double *  rho, double *  T, double *  y,  double *  P)
 
 
 /*Compute P = rhoRT/W(c) */
-void CKPC(double *  rho, double *  T, double *  c,  double *  P)
+void CKPC(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  c,  amrex::Real *  P)
 {
     int id; /*loop counter */
     /*See Eq 5 in CK Manual */
-    double W = 0;
-    double sumC = 0;
+    amrex::Real W = 0;
+    amrex::Real sumC = 0;
     W += c[0]*2.015940; /*H2 */
     W += c[1]*31.998800; /*O2 */
     W += c[2]*18.015340; /*H2O */
@@ -850,9 +850,9 @@ void CKPC(double *  rho, double *  T, double *  c,  double *  P)
 
 
 /*Compute rho = PW(x)/RT */
-void CKRHOX(double *  P, double *  T, double *  x,  double *  rho)
+void CKRHOX(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  rho)
 {
-    double XW = 0;/* To hold mean molecular wt */
+    amrex::Real XW = 0;/* To hold mean molecular wt */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*31.998800; /*O2 */
     XW += x[2]*18.015340; /*H2O */
@@ -869,10 +869,10 @@ void CKRHOX(double *  P, double *  T, double *  x,  double *  rho)
 
 
 /*Compute rho = P*W(y)/RT */
-AMREX_GPU_HOST_DEVICE void CKRHOY(double *  P, double *  T, double *  y,  double *  rho)
+AMREX_GPU_HOST_DEVICE void CKRHOY(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  rho)
 {
-    double YOW = 0;
-    double tmp[9];
+    amrex::Real YOW = 0;
+    amrex::Real tmp[9];
 
     for (int i = 0; i < 9; i++)
     {
@@ -889,12 +889,12 @@ AMREX_GPU_HOST_DEVICE void CKRHOY(double *  P, double *  T, double *  y,  double
 
 
 /*Compute rho = P*W(c)/(R*T) */
-void CKRHOC(double *  P, double *  T, double *  c,  double *  rho)
+void CKRHOC(amrex::Real *  P, amrex::Real *  T, amrex::Real *  c,  amrex::Real *  rho)
 {
     int id; /*loop counter */
     /*See Eq 5 in CK Manual */
-    double W = 0;
-    double sumC = 0;
+    amrex::Real W = 0;
+    amrex::Real sumC = 0;
     W += c[0]*2.015940; /*H2 */
     W += c[1]*31.998800; /*O2 */
     W += c[2]*18.015340; /*H2O */
@@ -915,14 +915,14 @@ void CKRHOC(double *  P, double *  T, double *  c,  double *  rho)
 
 
 /*get molecular weight for all species */
-void CKWT( double *  wt)
+void CKWT( amrex::Real *  wt)
 {
     get_mw(wt);
 }
 
 
 /*get atomic weight for all elements */
-void CKAWT( double *  awt)
+void CKAWT( amrex::Real *  awt)
 {
     atomicWeight(awt);
 }
@@ -930,10 +930,10 @@ void CKAWT( double *  awt)
 
 /*given y[species]: mass fractions */
 /*returns mean molecular weight (gm/mole) */
-AMREX_GPU_HOST_DEVICE void CKMMWY(double *  y,  double *  wtm)
+AMREX_GPU_HOST_DEVICE void CKMMWY(amrex::Real *  y,  amrex::Real *  wtm)
 {
-    double YOW = 0;
-    double tmp[9];
+    amrex::Real YOW = 0;
+    amrex::Real tmp[9];
 
     for (int i = 0; i < 9; i++)
     {
@@ -951,9 +951,9 @@ AMREX_GPU_HOST_DEVICE void CKMMWY(double *  y,  double *  wtm)
 
 /*given x[species]: mole fractions */
 /*returns mean molecular weight (gm/mole) */
-void CKMMWX(double *  x,  double *  wtm)
+void CKMMWX(amrex::Real *  x,  amrex::Real *  wtm)
 {
-    double XW = 0;/* see Eq 4 in CK Manual */
+    amrex::Real XW = 0;/* see Eq 4 in CK Manual */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*31.998800; /*O2 */
     XW += x[2]*18.015340; /*H2O */
@@ -971,12 +971,12 @@ void CKMMWX(double *  x,  double *  wtm)
 
 /*given c[species]: molar concentration */
 /*returns mean molecular weight (gm/mole) */
-void CKMMWC(double *  c,  double *  wtm)
+void CKMMWC(amrex::Real *  c,  amrex::Real *  wtm)
 {
     int id; /*loop counter */
     /*See Eq 5 in CK Manual */
-    double W = 0;
-    double sumC = 0;
+    amrex::Real W = 0;
+    amrex::Real sumC = 0;
     W += c[0]*2.015940; /*H2 */
     W += c[1]*31.998800; /*O2 */
     W += c[2]*18.015340; /*H2O */
@@ -998,10 +998,10 @@ void CKMMWC(double *  c,  double *  wtm)
 
 
 /*convert y[species] (mass fracs) to x[species] (mole fracs) */
-AMREX_GPU_HOST_DEVICE void CKYTX(double *  y,  double *  x)
+AMREX_GPU_HOST_DEVICE void CKYTX(amrex::Real *  y,  amrex::Real *  x)
 {
-    double YOW = 0;
-    double tmp[9];
+    amrex::Real YOW = 0;
+    amrex::Real tmp[9];
 
     for (int i = 0; i < 9; i++)
     {
@@ -1012,7 +1012,7 @@ AMREX_GPU_HOST_DEVICE void CKYTX(double *  y,  double *  x)
         YOW += tmp[i];
     }
 
-    double YOWINV = 1.0/YOW;
+    amrex::Real YOWINV = 1.0/YOW;
 
     for (int i = 0; i < 9; i++)
     {
@@ -1024,9 +1024,9 @@ AMREX_GPU_HOST_DEVICE void CKYTX(double *  y,  double *  x)
 
 #ifndef AMREX_USE_CUDA
 /*convert y[npoints*species] (mass fracs) to x[npoints*species] (mole fracs) */
-void VCKYTX(int *  np, double *  y,  double *  x)
+void VCKYTX(int *  np, amrex::Real *  y,  amrex::Real *  x)
 {
-    double YOW[*np];
+    amrex::Real YOW[*np];
     for (int i=0; i<(*np); i++) {
         YOW[i] = 0.0;
     }
@@ -1050,17 +1050,17 @@ void VCKYTX(int *  np, double *  y,  double *  x)
 }
 #else
 /*TODO: remove this on GPU */
-void VCKYTX(int *  np, double *  y,  double *  x)
+void VCKYTX(int *  np, amrex::Real *  y,  amrex::Real *  x)
 {
 }
 #endif
 
 
 /*convert y[species] (mass fracs) to c[species] (molar conc) */
-void CKYTCP(double *  P, double *  T, double *  y,  double *  c)
+void CKYTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  c)
 {
-    double YOW = 0;
-    double PWORT;
+    amrex::Real YOW = 0;
+    amrex::Real PWORT;
 
     /*Compute inverse of mean molecular wt first */
     for (int i = 0; i < 9; i++)
@@ -1085,7 +1085,7 @@ void CKYTCP(double *  P, double *  T, double *  y,  double *  c)
 
 
 /*convert y[species] (mass fracs) to c[species] (molar conc) */
-AMREX_GPU_HOST_DEVICE void CKYTCR(double *  rho, double *  T, double *  y,  double *  c)
+AMREX_GPU_HOST_DEVICE void CKYTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  c)
 {
     for (int i = 0; i < 9; i++)
     {
@@ -1095,9 +1095,9 @@ AMREX_GPU_HOST_DEVICE void CKYTCR(double *  rho, double *  T, double *  y,  doub
 
 
 /*convert x[species] (mole fracs) to y[species] (mass fracs) */
-AMREX_GPU_HOST_DEVICE void CKXTY(double *  x,  double *  y)
+AMREX_GPU_HOST_DEVICE void CKXTY(amrex::Real *  x,  amrex::Real *  y)
 {
-    double XW = 0; /*See Eq 4, 9 in CK Manual */
+    amrex::Real XW = 0; /*See Eq 4, 9 in CK Manual */
     /*Compute mean molecular wt first */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*31.998800; /*O2 */
@@ -1109,7 +1109,7 @@ AMREX_GPU_HOST_DEVICE void CKXTY(double *  x,  double *  y)
     XW += x[7]*34.014740; /*H2O2 */
     XW += x[8]*28.013400; /*N2 */
     /*Now compute conversion */
-    double XWinv = 1.0/XW;
+    amrex::Real XWinv = 1.0/XW;
     y[0] = x[0]*2.015940*XWinv; 
     y[1] = x[1]*31.998800*XWinv; 
     y[2] = x[2]*18.015340*XWinv; 
@@ -1125,10 +1125,10 @@ AMREX_GPU_HOST_DEVICE void CKXTY(double *  x,  double *  y)
 
 
 /*convert x[species] (mole fracs) to c[species] (molar conc) */
-void CKXTCP(double *  P, double *  T, double *  x,  double *  c)
+void CKXTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  c)
 {
     int id; /*loop counter */
-    double PORT = (*P)/(8.31446261815324e+07 * (*T)); /*P/RT */
+    amrex::Real PORT = (*P)/(8.31446261815324e+07 * (*T)); /*P/RT */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 9; ++id) {
@@ -1140,11 +1140,11 @@ void CKXTCP(double *  P, double *  T, double *  x,  double *  c)
 
 
 /*convert x[species] (mole fracs) to c[species] (molar conc) */
-void CKXTCR(double *  rho, double *  T, double *  x, double *  c)
+void CKXTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c)
 {
     int id; /*loop counter */
-    double XW = 0; /*See Eq 4, 11 in CK Manual */
-    double ROW; 
+    amrex::Real XW = 0; /*See Eq 4, 11 in CK Manual */
+    amrex::Real ROW; 
     /*Compute mean molecular wt first */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*31.998800; /*O2 */
@@ -1167,10 +1167,10 @@ void CKXTCR(double *  rho, double *  T, double *  x, double *  c)
 
 
 /*convert c[species] (molar conc) to x[species] (mole fracs) */
-void CKCTX(double *  c, double *  x)
+void CKCTX(amrex::Real *  c, amrex::Real *  x)
 {
     int id; /*loop counter */
-    double sumC = 0; 
+    amrex::Real sumC = 0; 
 
     /*compute sum of c  */
     for (id = 0; id < 9; ++id) {
@@ -1178,7 +1178,7 @@ void CKCTX(double *  c, double *  x)
     }
 
     /* See Eq 13  */
-    double sumCinv = 1.0/sumC;
+    amrex::Real sumCinv = 1.0/sumC;
     for (id = 0; id < 9; ++id) {
         x[id] = c[id]*sumCinv;
     }
@@ -1188,9 +1188,9 @@ void CKCTX(double *  c, double *  x)
 
 
 /*convert c[species] (molar conc) to y[species] (mass fracs) */
-void CKCTY(double *  c, double *  y)
+void CKCTY(amrex::Real *  c, amrex::Real *  y)
 {
-    double CW = 0; /*See Eq 12 in CK Manual */
+    amrex::Real CW = 0; /*See Eq 12 in CK Manual */
     /*compute denominator in eq 12 first */
     CW += c[0]*2.015940; /*H2 */
     CW += c[1]*31.998800; /*O2 */
@@ -1202,7 +1202,7 @@ void CKCTY(double *  c, double *  y)
     CW += c[7]*34.014740; /*H2O2 */
     CW += c[8]*28.013400; /*N2 */
     /*Now compute conversion */
-    double CWinv = 1.0/CW;
+    amrex::Real CWinv = 1.0/CW;
     y[0] = c[0]*2.015940*CWinv; 
     y[1] = c[1]*31.998800*CWinv; 
     y[2] = c[2]*18.015340*CWinv; 
@@ -1219,41 +1219,41 @@ void CKCTY(double *  c, double *  y)
 
 /*get Cp/R as a function of T  */
 /*for all species (Eq 19) */
-void CKCPOR(double *  T, double *  cpor)
+void CKCPOR(amrex::Real *  T, amrex::Real *  cpor)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cp_R(cpor, tc);
 }
 
 
 /*get H/RT as a function of T  */
 /*for all species (Eq 20) */
-void CKHORT(double *  T, double *  hort)
+void CKHORT(amrex::Real *  T, amrex::Real *  hort)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEnthalpy(hort, tc);
 }
 
 
 /*get S/R as a function of T  */
 /*for all species (Eq 21) */
-void CKSOR(double *  T, double *  sor)
+void CKSOR(amrex::Real *  T, amrex::Real *  sor)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEntropy(sor, tc);
 }
 
 
 /*get specific heat at constant volume as a function  */
 /*of T for all species (molar units) */
-void CKCVML(double *  T,  double *  cvml)
+void CKCVML(amrex::Real *  T,  amrex::Real *  cvml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cv_R(cvml, tc);
 
     /*convert to chemkin units */
@@ -1265,11 +1265,11 @@ void CKCVML(double *  T,  double *  cvml)
 
 /*get specific heat at constant pressure as a  */
 /*function of T for all species (molar units) */
-void CKCPML(double *  T,  double *  cpml)
+void CKCPML(amrex::Real *  T,  amrex::Real *  cpml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cp_R(cpml, tc);
 
     /*convert to chemkin units */
@@ -1281,12 +1281,12 @@ void CKCPML(double *  T,  double *  cpml)
 
 /*get internal energy as a function  */
 /*of T for all species (molar units) */
-void CKUML(double *  T,  double *  uml)
+void CKUML(amrex::Real *  T,  amrex::Real *  uml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(uml, tc);
 
     /*convert to chemkin units */
@@ -1298,12 +1298,12 @@ void CKUML(double *  T,  double *  uml)
 
 /*get enthalpy as a function  */
 /*of T for all species (molar units) */
-void CKHML(double *  T,  double *  hml)
+void CKHML(amrex::Real *  T,  amrex::Real *  hml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hml, tc);
 
     /*convert to chemkin units */
@@ -1315,12 +1315,12 @@ void CKHML(double *  T,  double *  hml)
 
 /*get standard-state Gibbs energy as a function  */
 /*of T for all species (molar units) */
-void CKGML(double *  T,  double *  gml)
+void CKGML(amrex::Real *  T,  amrex::Real *  gml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     gibbs(gml, tc);
 
     /*convert to chemkin units */
@@ -1332,12 +1332,12 @@ void CKGML(double *  T,  double *  gml)
 
 /*get standard-state Helmholtz free energy as a  */
 /*function of T for all species (molar units) */
-void CKAML(double *  T,  double *  aml)
+void CKAML(amrex::Real *  T,  amrex::Real *  aml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     helmholtz(aml, tc);
 
     /*convert to chemkin units */
@@ -1348,11 +1348,11 @@ void CKAML(double *  T,  double *  aml)
 
 
 /*Returns the standard-state entropies in molar units */
-void CKSML(double *  T,  double *  sml)
+void CKSML(amrex::Real *  T,  amrex::Real *  sml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEntropy(sml, tc);
 
     /*convert to chemkin units */
@@ -1364,10 +1364,10 @@ void CKSML(double *  T,  double *  sml)
 
 /*Returns the specific heats at constant volume */
 /*in mass units (Eq. 29) */
-AMREX_GPU_HOST_DEVICE void CKCVMS(double *  T,  double *  cvms)
+AMREX_GPU_HOST_DEVICE void CKCVMS(amrex::Real *  T,  amrex::Real *  cvms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cv_R(cvms, tc);
     /*multiply by R/molecularweight */
     cvms[0] *= 4.124360158612479e+07; /*H2 */
@@ -1384,10 +1384,10 @@ AMREX_GPU_HOST_DEVICE void CKCVMS(double *  T,  double *  cvms)
 
 /*Returns the specific heats at constant pressure */
 /*in mass units (Eq. 26) */
-AMREX_GPU_HOST_DEVICE void CKCPMS(double *  T,  double *  cpms)
+AMREX_GPU_HOST_DEVICE void CKCPMS(amrex::Real *  T,  amrex::Real *  cpms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cp_R(cpms, tc);
     /*multiply by R/molecularweight */
     cpms[0] *= 4.124360158612479e+07; /*H2 */
@@ -1403,11 +1403,11 @@ AMREX_GPU_HOST_DEVICE void CKCPMS(double *  T,  double *  cpms)
 
 
 /*Returns internal energy in mass units (Eq 30.) */
-AMREX_GPU_HOST_DEVICE void CKUMS(double *  T,  double *  ums)
+AMREX_GPU_HOST_DEVICE void CKUMS(amrex::Real *  T,  amrex::Real *  ums)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(ums, tc);
     for (int i = 0; i < 9; i++)
     {
@@ -1417,11 +1417,11 @@ AMREX_GPU_HOST_DEVICE void CKUMS(double *  T,  double *  ums)
 
 
 /*Returns enthalpy in mass units (Eq 27.) */
-AMREX_GPU_HOST_DEVICE void CKHMS(double *  T,  double *  hms)
+AMREX_GPU_HOST_DEVICE void CKHMS(amrex::Real *  T,  amrex::Real *  hms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hms, tc);
     for (int i = 0; i < 9; i++)
     {
@@ -1432,9 +1432,9 @@ AMREX_GPU_HOST_DEVICE void CKHMS(double *  T,  double *  hms)
 
 #ifndef AMREX_USE_CUDA
 /*Returns enthalpy in mass units (Eq 27.) */
-void VCKHMS(int *  np, double *  T,  double *  hms)
+void VCKHMS(int *  np, amrex::Real *  T,  amrex::Real *  hms)
 {
-    double tc[5], h[9];
+    amrex::Real tc[5], h[9];
 
     for (int i=0; i<(*np); i++) {
         tc[0] = 0.0;
@@ -1464,18 +1464,18 @@ void VCKHMS(int *  np, double *  T,  double *  hms)
 }
 #else
 /*TODO: remove this on GPU */
-void VCKHMS(int *  np, double *  T,  double *  hms)
+void VCKHMS(int *  np, amrex::Real *  T,  amrex::Real *  hms)
 {
 }
 #endif
 
 
 /*Returns gibbs in mass units (Eq 31.) */
-void CKGMS(double *  T,  double *  gms)
+void CKGMS(amrex::Real *  T,  amrex::Real *  gms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     gibbs(gms, tc);
     for (int i = 0; i < 9; i++)
     {
@@ -1485,11 +1485,11 @@ void CKGMS(double *  T,  double *  gms)
 
 
 /*Returns helmholtz in mass units (Eq 32.) */
-void CKAMS(double *  T,  double *  ams)
+void CKAMS(amrex::Real *  T,  amrex::Real *  ams)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     helmholtz(ams, tc);
     for (int i = 0; i < 9; i++)
     {
@@ -1499,10 +1499,10 @@ void CKAMS(double *  T,  double *  ams)
 
 
 /*Returns the entropies in mass units (Eq 28.) */
-void CKSMS(double *  T,  double *  sms)
+void CKSMS(amrex::Real *  T,  amrex::Real *  sms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEntropy(sms, tc);
     /*multiply by R/molecularweight */
     sms[0] *= 4.124360158612479e+07; /*H2 */
@@ -1518,13 +1518,13 @@ void CKSMS(double *  T,  double *  sms)
 
 
 /*Returns the mean specific heat at CP (Eq. 33) */
-void CKCPBL(double *  T, double *  x,  double *  cpbl)
+void CKCPBL(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  cpbl)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cpor[9]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cpor[9]; /* temporary storage */
     cp_R(cpor, tc);
 
     /*perform dot product */
@@ -1537,12 +1537,12 @@ void CKCPBL(double *  T, double *  x,  double *  cpbl)
 
 
 /*Returns the mean specific heat at CP (Eq. 34) */
-AMREX_GPU_HOST_DEVICE void CKCPBS(double *  T, double *  y,  double *  cpbs)
+AMREX_GPU_HOST_DEVICE void CKCPBS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  cpbs)
 {
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cpor[9], tresult[9]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cpor[9], tresult[9]; /* temporary storage */
     cp_R(cpor, tc);
     for (int i = 0; i < 9; i++)
     {
@@ -1559,13 +1559,13 @@ AMREX_GPU_HOST_DEVICE void CKCPBS(double *  T, double *  y,  double *  cpbs)
 
 
 /*Returns the mean specific heat at CV (Eq. 35) */
-void CKCVBL(double *  T, double *  x,  double *  cvbl)
+void CKCVBL(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  cvbl)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cvor[9]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cvor[9]; /* temporary storage */
     cv_R(cvor, tc);
 
     /*perform dot product */
@@ -1578,12 +1578,12 @@ void CKCVBL(double *  T, double *  x,  double *  cvbl)
 
 
 /*Returns the mean specific heat at CV (Eq. 36) */
-AMREX_GPU_HOST_DEVICE void CKCVBS(double *  T, double *  y,  double *  cvbs)
+AMREX_GPU_HOST_DEVICE void CKCVBS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  cvbs)
 {
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cvor[9]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cvor[9]; /* temporary storage */
     cv_R(cvor, tc);
     /*multiply by y/molecularweight */
     result += cvor[0]*y[0]*imw[0]; /*H2 */
@@ -1601,14 +1601,14 @@ AMREX_GPU_HOST_DEVICE void CKCVBS(double *  T, double *  y,  double *  cvbs)
 
 
 /*Returns the mean enthalpy of the mixture in molar units */
-void CKHBML(double *  T, double *  x,  double *  hbml)
+void CKHBML(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  hbml)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double hml[9]; /* temporary storage */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real hml[9]; /* temporary storage */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hml, tc);
 
     /*perform dot product */
@@ -1621,13 +1621,13 @@ void CKHBML(double *  T, double *  x,  double *  hbml)
 
 
 /*Returns mean enthalpy of mixture in mass units */
-AMREX_GPU_HOST_DEVICE void CKHBMS(double *  T, double *  y,  double *  hbms)
+AMREX_GPU_HOST_DEVICE void CKHBMS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  hbms)
 {
-    double result = 0;
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double hml[9], tmp[9]; /* temporary storage */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0;
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real hml[9], tmp[9]; /* temporary storage */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hml, tc);
     int id;
     for (id = 0; id < 9; ++id) {
@@ -1642,14 +1642,14 @@ AMREX_GPU_HOST_DEVICE void CKHBMS(double *  T, double *  y,  double *  hbms)
 
 
 /*get mean internal energy in molar units */
-void CKUBML(double *  T, double *  x,  double *  ubml)
+void CKUBML(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  ubml)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double uml[9]; /* temporary energy array */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real uml[9]; /* temporary energy array */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(uml, tc);
 
     /*perform dot product */
@@ -1662,13 +1662,13 @@ void CKUBML(double *  T, double *  x,  double *  ubml)
 
 
 /*get mean internal energy in mass units */
-AMREX_GPU_HOST_DEVICE void CKUBMS(double *  T, double *  y,  double *  ubms)
+AMREX_GPU_HOST_DEVICE void CKUBMS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  ubms)
 {
-    double result = 0;
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double ums[9]; /* temporary energy array */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0;
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real ums[9]; /* temporary energy array */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(ums, tc);
     /*perform dot product + scaling by wt */
     result += y[0]*ums[0]*imw[0]; /*H2 */
@@ -1686,15 +1686,15 @@ AMREX_GPU_HOST_DEVICE void CKUBMS(double *  T, double *  y,  double *  ubms)
 
 
 /*get mixture entropy in molar units */
-void CKSBML(double *  P, double *  T, double *  x,  double *  sbml)
+void CKSBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  sbml)
 {
     int id; /*loop counter */
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double sor[9]; /* temporary storage */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real sor[9]; /* temporary storage */
     speciesEntropy(sor, tc);
 
     /*Compute Eq 42 */
@@ -1707,16 +1707,16 @@ void CKSBML(double *  P, double *  T, double *  x,  double *  sbml)
 
 
 /*get mixture entropy in mass units */
-void CKSBMS(double *  P, double *  T, double *  y,  double *  sbms)
+void CKSBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  sbms)
 {
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double sor[9]; /* temporary storage */
-    double x[9]; /* need a ytx conversion */
-    double YOW = 0; /*See Eq 4, 6 in CK Manual */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real sor[9]; /* temporary storage */
+    amrex::Real x[9]; /* need a ytx conversion */
+    amrex::Real YOW = 0; /*See Eq 4, 6 in CK Manual */
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*O2 */
@@ -1754,16 +1754,16 @@ void CKSBMS(double *  P, double *  T, double *  y,  double *  sbms)
 
 
 /*Returns mean gibbs free energy in molar units */
-void CKGBML(double *  P, double *  T, double *  x,  double *  gbml)
+void CKGBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  gbml)
 {
     int id; /*loop counter */
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double gort[9]; /* temporary storage */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real gort[9]; /* temporary storage */
     /*Compute g/RT */
     gibbs(gort, tc);
 
@@ -1777,17 +1777,17 @@ void CKGBML(double *  P, double *  T, double *  x,  double *  gbml)
 
 
 /*Returns mixture gibbs free energy in mass units */
-void CKGBMS(double *  P, double *  T, double *  y,  double *  gbms)
+void CKGBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  gbms)
 {
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double gort[9]; /* temporary storage */
-    double x[9]; /* need a ytx conversion */
-    double YOW = 0; /*To hold 1/molecularweight */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real gort[9]; /* temporary storage */
+    amrex::Real x[9]; /* need a ytx conversion */
+    amrex::Real YOW = 0; /*To hold 1/molecularweight */
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*O2 */
@@ -1825,16 +1825,16 @@ void CKGBMS(double *  P, double *  T, double *  y,  double *  gbms)
 
 
 /*Returns mean helmholtz free energy in molar units */
-void CKABML(double *  P, double *  T, double *  x,  double *  abml)
+void CKABML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  abml)
 {
     int id; /*loop counter */
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double aort[9]; /* temporary storage */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real aort[9]; /* temporary storage */
     /*Compute g/RT */
     helmholtz(aort, tc);
 
@@ -1848,17 +1848,17 @@ void CKABML(double *  P, double *  T, double *  x,  double *  abml)
 
 
 /*Returns mixture helmholtz free energy in mass units */
-void CKABMS(double *  P, double *  T, double *  y,  double *  abms)
+void CKABMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  abms)
 {
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double aort[9]; /* temporary storage */
-    double x[9]; /* need a ytx conversion */
-    double YOW = 0; /*To hold 1/molecularweight */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real aort[9]; /* temporary storage */
+    amrex::Real x[9]; /* need a ytx conversion */
+    amrex::Real YOW = 0; /*To hold 1/molecularweight */
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*O2 */
@@ -1896,7 +1896,7 @@ void CKABMS(double *  P, double *  T, double *  y,  double *  abms)
 
 
 /*compute the production rate for each species */
-AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C,  double *  wdot)
+AMREX_GPU_HOST_DEVICE void CKWC(amrex::Real *  T, amrex::Real *  C,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
 
@@ -1918,12 +1918,12 @@ AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C,  double *  wdot)
 
 /*Returns the molar production rate of species */
 /*Given P, T, and mass fractions */
-void CKWYP(double *  P, double *  T, double *  y,  double *  wdot)
+void CKWYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[9]; /*temporary storage */
-    double YOW = 0; 
-    double PWORT; 
+    amrex::Real c[9]; /*temporary storage */
+    amrex::Real YOW = 0; 
+    amrex::Real PWORT; 
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*O2 */
@@ -1961,11 +1961,11 @@ void CKWYP(double *  P, double *  T, double *  y,  double *  wdot)
 
 /*Returns the molar production rate of species */
 /*Given P, T, and mole fractions */
-void CKWXP(double *  P, double *  T, double *  x,  double *  wdot)
+void CKWXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[9]; /*temporary storage */
-    double PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
+    amrex::Real c[9]; /*temporary storage */
+    amrex::Real PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 9; ++id) {
@@ -1984,10 +1984,10 @@ void CKWXP(double *  P, double *  T, double *  x,  double *  wdot)
 
 /*Returns the molar production rate of species */
 /*Given rho, T, and mass fractions */
-AMREX_GPU_HOST_DEVICE void CKWYR(double *  rho, double *  T, double *  y,  double *  wdot)
+AMREX_GPU_HOST_DEVICE void CKWYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[9]; /*temporary storage */
+    amrex::Real c[9]; /*temporary storage */
     /*See Eq 8 with an extra 1e6 so c goes to SI */
     c[0] = 1e6 * (*rho) * y[0]*imw[0]; 
     c[1] = 1e6 * (*rho) * y[1]*imw[1]; 
@@ -2011,12 +2011,12 @@ AMREX_GPU_HOST_DEVICE void CKWYR(double *  rho, double *  T, double *  y,  doubl
 
 /*Returns the molar production rate of species */
 /*Given rho, T, and mass fractions */
-void VCKWYR(int *  np, double *  rho, double *  T,
-	    double *  y,
-	    double *  wdot)
+void VCKWYR(int *  np, amrex::Real *  rho, amrex::Real *  T,
+	    amrex::Real *  y,
+	    amrex::Real *  wdot)
 {
 #ifndef AMREX_USE_CUDA
-    double c[9*(*np)]; /*temporary storage */
+    amrex::Real c[9*(*np)]; /*temporary storage */
     /*See Eq 8 with an extra 1e6 so c goes to SI */
     for (int n=0; n<9; n++) {
         for (int i=0; i<(*np); i++) {
@@ -2037,12 +2037,12 @@ void VCKWYR(int *  np, double *  rho, double *  T,
 
 /*Returns the molar production rate of species */
 /*Given rho, T, and mole fractions */
-void CKWXR(double *  rho, double *  T, double *  x,  double *  wdot)
+void CKWXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[9]; /*temporary storage */
-    double XW = 0; /*See Eq 4, 11 in CK Manual */
-    double ROW; 
+    amrex::Real c[9]; /*temporary storage */
+    amrex::Real XW = 0; /*See Eq 4, 11 in CK Manual */
+    amrex::Real ROW; 
     /*Compute mean molecular wt first */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*31.998800; /*O2 */
@@ -2072,7 +2072,7 @@ void CKWXR(double *  rho, double *  T, double *  x,  double *  wdot)
 
 
 /*Returns the rate of progress for each reaction */
-void CKQC(double *  T, double *  C, double *  qdot)
+void CKQC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  qdot)
 {
     int id; /*loop counter */
 
@@ -2097,11 +2097,11 @@ void CKQC(double *  T, double *  C, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given P, T, and mole fractions */
-void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r)
+void CKKFKR(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  q_f, amrex::Real *  q_r)
 {
     int id; /*loop counter */
-    double c[9]; /*temporary storage */
-    double PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
+    amrex::Real c[9]; /*temporary storage */
+    amrex::Real PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 9; ++id) {
@@ -2121,12 +2121,12 @@ void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r)
 
 /*Returns the progress rates of each reactions */
 /*Given P, T, and mass fractions */
-void CKQYP(double *  P, double *  T, double *  y, double *  qdot)
+void CKQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[9]; /*temporary storage */
-    double YOW = 0; 
-    double PWORT; 
+    amrex::Real c[9]; /*temporary storage */
+    amrex::Real YOW = 0; 
+    amrex::Real PWORT; 
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*O2 */
@@ -2164,11 +2164,11 @@ void CKQYP(double *  P, double *  T, double *  y, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given P, T, and mole fractions */
-void CKQXP(double *  P, double *  T, double *  x, double *  qdot)
+void CKQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[9]; /*temporary storage */
-    double PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
+    amrex::Real c[9]; /*temporary storage */
+    amrex::Real PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 9; ++id) {
@@ -2187,10 +2187,10 @@ void CKQXP(double *  P, double *  T, double *  x, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given rho, T, and mass fractions */
-void CKQYR(double *  rho, double *  T, double *  y, double *  qdot)
+void CKQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[9]; /*temporary storage */
+    amrex::Real c[9]; /*temporary storage */
     /*See Eq 8 with an extra 1e6 so c goes to SI */
     c[0] = 1e6 * (*rho) * y[0]*imw[0]; 
     c[1] = 1e6 * (*rho) * y[1]*imw[1]; 
@@ -2214,12 +2214,12 @@ void CKQYR(double *  rho, double *  T, double *  y, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given rho, T, and mole fractions */
-void CKQXR(double *  rho, double *  T, double *  x, double *  qdot)
+void CKQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[9]; /*temporary storage */
-    double XW = 0; /*See Eq 4, 11 in CK Manual */
-    double ROW; 
+    amrex::Real c[9]; /*temporary storage */
+    amrex::Real XW = 0; /*See Eq 4, 11 in CK Manual */
+    amrex::Real ROW; 
     /*Compute mean molecular wt first */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*31.998800; /*O2 */
@@ -2451,7 +2451,7 @@ void CKNCF(int * ncf)
 
 /*Returns the arrehenius coefficients  */
 /*for all reactions */
-void CKABE( double *  a, double *  b, double *  e)
+void CKABE( amrex::Real *  a, amrex::Real *  b, amrex::Real *  e)
 {
     // (8):  H + O2 (+M) <=> HO2 (+M)
     a[0] = 1475000000000;
@@ -2564,11 +2564,11 @@ void CKABE( double *  a, double *  b, double *  e)
 
 
 /*Returns the equil constants for each reaction */
-void CKEQC(double *  T, double *  C, double *  eqcon)
+void CKEQC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[9]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[9]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -2643,11 +2643,11 @@ void CKEQC(double *  T, double *  C, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given P, T, and mass fractions */
-void CKEQYP(double *  P, double *  T, double *  y, double *  eqcon)
+void CKEQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[9]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[9]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -2722,11 +2722,11 @@ void CKEQYP(double *  P, double *  T, double *  y, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given P, T, and mole fractions */
-void CKEQXP(double *  P, double *  T, double *  x, double *  eqcon)
+void CKEQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[9]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[9]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -2801,11 +2801,11 @@ void CKEQXP(double *  P, double *  T, double *  x, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given rho, T, and mass fractions */
-void CKEQYR(double *  rho, double *  T, double *  y, double *  eqcon)
+void CKEQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[9]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[9]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -2880,11 +2880,11 @@ void CKEQYR(double *  rho, double *  T, double *  y, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given rho, T, and mole fractions */
-void CKEQXR(double *  rho, double *  T, double *  x, double *  eqcon)
+void CKEQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[9]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[9]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -2959,12 +2959,12 @@ void CKEQXR(double *  rho, double *  T, double *  x, double *  eqcon)
 #ifdef AMREX_USE_CUDA
 /*GPU version of productionRate: no more use of thermo namespace vectors */
 /*compute the production rate for each species */
-AMREX_GPU_HOST_DEVICE inline void  productionRate(double * wdot, double * sc, double T)
+AMREX_GPU_HOST_DEVICE inline void  productionRate(amrex::Real * wdot, amrex::Real * sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 
-    double qdot, q_f[21], q_r[21];
+    amrex::Real qdot, q_f[21], q_r[21];
     comp_qfqr(q_f, q_r, sc, tc, invT);
 
     for (int i = 0; i < 9; ++i) {
@@ -3094,7 +3094,7 @@ AMREX_GPU_HOST_DEVICE inline void  productionRate(double * wdot, double * sc, do
     return;
 }
 
-AMREX_GPU_HOST_DEVICE inline void comp_qfqr(double *  qf, double * qr, double * sc, double * tc, double invT)
+AMREX_GPU_HOST_DEVICE inline void comp_qfqr(amrex::Real *  qf, amrex::Real * qr, amrex::Real * sc, amrex::Real * tc, amrex::Real invT)
 {
 
     /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
@@ -3182,22 +3182,22 @@ AMREX_GPU_HOST_DEVICE inline void comp_qfqr(double *  qf, double * qr, double * 
     qr[20] = sc[2]*sc[6];
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int i = 0; i < 9; ++i) {
         mixture += sc[i];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[9];
+    amrex::Real g_RT[9];
     gibbs(g_RT, tc);
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 * invT;
-    double refCinv = 1 / refC;
+    amrex::Real refC = 101325 / 8.31446 * invT;
+    amrex::Real refCinv = 1 / refC;
 
     /* Evaluate the kfs */
-    double k_f, k_r, Corr;
-    double redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;
+    amrex::Real k_f, k_r, Corr;
+    amrex::Real redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;
 
     // (0):  H + O2 <=> O + OH
     k_f = 1.0000000000000002e-06 * 3547000000000000 
@@ -3359,27 +3359,27 @@ AMREX_GPU_HOST_DEVICE inline void comp_qfqr(double *  qf, double * qr, double * 
 
 
 #ifndef AMREX_USE_CUDA
-static double T_save = -1;
+static amrex::Real T_save = -1;
 #ifdef _OPENMP
 #pragma omp threadprivate(T_save)
 #endif
 
-static double k_f_save[21];
+static amrex::Real k_f_save[21];
 #ifdef _OPENMP
 #pragma omp threadprivate(k_f_save)
 #endif
 
-static double Kc_save[21];
+static amrex::Real Kc_save[21];
 #ifdef _OPENMP
 #pragma omp threadprivate(Kc_save)
 #endif
 
 
 /*compute the production rate for each species pointwise on CPU */
-void productionRate(double *  wdot, double *  sc, double T)
+void productionRate(amrex::Real *  wdot, amrex::Real *  sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 
     if (T != T_save)
     {
@@ -3388,7 +3388,7 @@ void productionRate(double *  wdot, double *  sc, double T)
         comp_Kc(tc,invT,Kc_save);
     }
 
-    double qdot, q_f[21], q_r[21];
+    amrex::Real qdot, q_f[21], q_r[21];
     comp_qfqr(q_f, q_r, sc, tc, invT);
 
     for (int i = 0; i < 9; ++i) {
@@ -3518,7 +3518,7 @@ void productionRate(double *  wdot, double *  sc, double T)
     return;
 }
 
-void comp_k_f(double *  tc, double invT, double *  k_f)
+void comp_k_f(amrex::Real *  tc, amrex::Real invT, amrex::Real *  k_f)
 {
     for (int i=0; i<21; ++i) {
         k_f[i] = prefactor_units[i] * fwd_A[i]
@@ -3527,10 +3527,10 @@ void comp_k_f(double *  tc, double invT, double *  k_f)
     return;
 }
 
-void comp_Kc(double *  tc, double invT, double *  Kc)
+void comp_Kc(amrex::Real *  tc, amrex::Real invT, amrex::Real *  Kc)
 {
     /*compute the Gibbs free energy */
-    double g_RT[9];
+    amrex::Real g_RT[9];
     gibbs(g_RT, tc);
 
     Kc[0] = g_RT[1] + g_RT[3] - g_RT[6];
@@ -3560,8 +3560,8 @@ void comp_Kc(double *  tc, double invT, double *  Kc)
     };
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 * invT;
-    double refCinv = 1 / refC;
+    amrex::Real refC = 101325 / 8.31446 * invT;
+    amrex::Real refCinv = 1 / refC;
 
     Kc[0] *= refCinv;
     Kc[1] *= refC;
@@ -3573,7 +3573,7 @@ void comp_Kc(double *  tc, double invT, double *  Kc)
     return;
 }
 
-void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double invT)
+void comp_qfqr(amrex::Real *  qf, amrex::Real *  qr, amrex::Real *  sc, amrex::Real *  tc, amrex::Real invT)
 {
 
     /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
@@ -3660,27 +3660,27 @@ void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double in
     qf[20] = sc[5]*sc[7];
     qr[20] = sc[2]*sc[6];
 
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int i = 0; i < 9; ++i) {
         mixture += sc[i];
     }
 
-    double Corr[21];
+    amrex::Real Corr[21];
     for (int i = 0; i < 21; ++i) {
         Corr[i] = 1.0;
     }
 
     /* troe */
     {
-        double alpha[2];
+        amrex::Real alpha[2];
         alpha[0] = mixture + (TB[0][0] - 1)*sc[0] + (TB[0][1] - 1)*sc[2] + (TB[0][2] - 1)*sc[1];
         alpha[1] = mixture + (TB[1][0] - 1)*sc[0] + (TB[1][1] - 1)*sc[2];
         for (int i=0; i<2; i++)
         {
-            double redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;
+            amrex::Real redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;
             redP = alpha[i-0] / k_f_save[i] * phase_units[i] * low_A[i] * exp(low_beta[i] * tc[0] - activation_units[i] * low_Ea[i] *invT);
             F = redP / (1.0 + redP);
             logPred = log10(redP);
@@ -3698,7 +3698,7 @@ void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double in
 
     /* simple three-body correction */
     {
-        double alpha;
+        amrex::Real alpha;
         alpha = mixture + (TB[2][0] - 1)*sc[0] + (TB[2][1] - 1)*sc[2];
         Corr[2] = alpha;
         alpha = mixture + (TB[3][0] - 1)*sc[0] + (TB[3][1] - 1)*sc[2];
@@ -3722,10 +3722,10 @@ void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double in
 
 #ifndef AMREX_USE_CUDA
 /*compute the production rate for each species */
-void vproductionRate(int npt, double *  wdot, double *  sc, double *  T)
+void vproductionRate(int npt, amrex::Real *  wdot, amrex::Real *  sc, amrex::Real *  T)
 {
-    double k_f_s[21*npt], Kc_s[21*npt], mixture[npt], g_RT[9*npt];
-    double tc[5*npt], invT[npt];
+    amrex::Real k_f_s[21*npt], Kc_s[21*npt], mixture[npt], g_RT[9*npt];
+    amrex::Real tc[5*npt], invT[npt];
 
     for (int i=0; i<npt; i++) {
         tc[0*npt+i] = log(T[i]);
@@ -3756,7 +3756,7 @@ void vproductionRate(int npt, double *  wdot, double *  sc, double *  T)
     vcomp_wdot(npt, wdot, mixture, sc, k_f_s, Kc_s, tc, invT, T);
 }
 
-void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT)
+void vcomp_k_f(int npt, amrex::Real *  k_f_s, amrex::Real *  tc, amrex::Real *  invT)
 {
     for (int i=0; i<npt; i++) {
         k_f_s[0*npt+i] = prefactor_units[0] * fwd_A[0] * exp(fwd_beta[0] * tc[i] - activation_units[0] * fwd_Ea[0] * invT[i]);
@@ -3783,11 +3783,11 @@ void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT)
     }
 }
 
-void vcomp_gibbs(int npt, double *  g_RT, double *  tc)
+void vcomp_gibbs(int npt, amrex::Real *  g_RT, amrex::Real *  tc)
 {
     /*compute the Gibbs free energy */
     for (int i=0; i<npt; i++) {
-        double tg[5], g[9];
+        amrex::Real tg[5], g[9];
         tg[0] = tc[0*npt+i];
         tg[1] = tc[1*npt+i];
         tg[2] = tc[2*npt+i];
@@ -3808,12 +3808,12 @@ void vcomp_gibbs(int npt, double *  g_RT, double *  tc)
     }
 }
 
-void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT)
+void vcomp_Kc(int npt, amrex::Real *  Kc_s, amrex::Real *  g_RT, amrex::Real *  invT)
 {
     for (int i=0; i<npt; i++) {
         /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-        double refC = (101325. / 8.31451) * invT[i];
-        double refCinv = 1.0 / refC;
+        amrex::Real refC = (101325. / 8.31451) * invT[i];
+        amrex::Real refCinv = 1.0 / refC;
 
         Kc_s[0*npt+i] = refCinv * exp((g_RT[1*npt+i] + g_RT[3*npt+i]) - (g_RT[6*npt+i]));
         Kc_s[1*npt+i] = refC * exp((g_RT[7*npt+i]) - (g_RT[5*npt+i] + g_RT[5*npt+i]));
@@ -3839,16 +3839,16 @@ void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT)
     }
 }
 
-void vcomp_wdot(int npt, double *  wdot, double *  mixture, double *  sc,
-		double *  k_f_s, double *  Kc_s,
-		double *  tc, double *  invT, double *  T)
+void vcomp_wdot(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,
+		amrex::Real *  k_f_s, amrex::Real *  Kc_s,
+		amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T)
 {
     for (int i=0; i<npt; i++) {
-        double qdot, q_f, q_r, phi_f, phi_r, k_f, k_r, Kc;
-        double alpha;
-        double redP, F;
-        double logPred;
-        double logFcent, troe_c, troe_n, troe, F_troe;
+        amrex::Real qdot, q_f, q_r, phi_f, phi_r, k_f, k_r, Kc;
+        amrex::Real alpha;
+        amrex::Real redP, F;
+        amrex::Real logPred;
+        amrex::Real logFcent, troe_c, troe_n, troe, F_troe;
 
         /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
         phi_f = sc[1*npt+i]*sc[3*npt+i];
@@ -4174,9 +4174,9 @@ void vcomp_wdot(int npt, double *  wdot, double *  mixture, double *  sc,
 #endif
 
 /*compute an approx to the reaction Jacobian (for preconditioning) */
-AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double *  Tp, int * HP)
+AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * HP)
 {
-    double c[9];
+    amrex::Real c[9];
 
     for (int k=0; k<9; k++) {
         c[k] = 1.e6 * sc[k];
@@ -4195,9 +4195,9 @@ AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double * 
 }
 
 /*compute the reaction Jacobian */
-AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  Tp, int * consP)
+AMREX_GPU_HOST_DEVICE void DWDOT(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * consP)
 {
-    double c[9];
+    amrex::Real c[9];
 
     for (int k=0; k<9; k++) {
         c[k] = 1.e6 * sc[k];
@@ -4218,8 +4218,8 @@ AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  Tp, int * 
 /*compute the sparsity pattern of the chemistry Jacobian */
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO( int * nJdata, int * consP, int NCELLS)
 {
-    double c[9];
-    double J[100];
+    amrex::Real c[9];
+    amrex::Real J[100];
 
     for (int k=0; k<9; k++) {
         c[k] = 1.0/ 9.000000 ;
@@ -4246,8 +4246,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_INFO( int * nJdata, int * consP, int NCELLS)
 /*compute the sparsity pattern of the system Jacobian */
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST( int * nJdata, int * consP, int NCELLS)
 {
-    double c[9];
-    double J[100];
+    amrex::Real c[9];
+    amrex::Real J[100];
 
     for (int k=0; k<9; k++) {
         c[k] = 1.0/ 9.000000 ;
@@ -4278,8 +4278,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST( int * nJdata, int * consP, int NC
 /*compute the sparsity pattern of the simplified (for preconditioning) system Jacobian */
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED( int * nJdata, int * consP)
 {
-    double c[9];
-    double J[100];
+    amrex::Real c[9];
+    amrex::Real J[100];
 
     for (int k=0; k<9; k++) {
         c[k] = 1.0/ 9.000000 ;
@@ -4309,8 +4309,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED( int * nJdata, int * co
 /*compute the sparsity pattern of the chemistry Jacobian in CSC format -- base 0 */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSC(int *  rowVals, int *  colPtrs, int * consP, int NCELLS)
 {
-    double c[9];
-    double J[100];
+    amrex::Real c[9];
+    amrex::Real J[100];
     int offset_row;
     int offset_col;
 
@@ -4342,8 +4342,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSC(int *  rowVals, int *  colPtrs, 
 /*compute the sparsity pattern of the chemistry Jacobian in CSR format -- base 0 */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSR(int * colVals, int * rowPtrs, int * consP, int NCELLS, int base)
 {
-    double c[9];
-    double J[100];
+    amrex::Real c[9];
+    amrex::Real J[100];
     int offset;
 
     for (int k=0; k<9; k++) {
@@ -4391,8 +4391,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSR(int * colVals, int * rowPtrs, in
 /*CSR format BASE is user choice */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtr, int * consP, int NCELLS, int base)
 {
-    double c[9];
-    double J[100];
+    amrex::Real c[9];
+    amrex::Real J[100];
     int offset;
 
     for (int k=0; k<9; k++) {
@@ -4450,8 +4450,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtr
 /*BASE 0 */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, int * colPtrs, int * indx, int * consP)
 {
-    double c[9];
-    double J[100];
+    amrex::Real c[9];
+    amrex::Real J[100];
 
     for (int k=0; k<9; k++) {
         c[k] = 1.0/ 9.000000 ;
@@ -4485,8 +4485,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, i
 /*CSR format BASE is under choice */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, int * rowPtr, int * consP, int base)
 {
-    double c[9];
-    double J[100];
+    amrex::Real c[9];
+    amrex::Real J[100];
 
     for (int k=0; k<9; k++) {
         c[k] = 1.0/ 9.000000 ;
@@ -4537,7 +4537,7 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, i
 #ifdef AMREX_USE_CUDA
 /*compute the reaction Jacobian on GPU */
 AMREX_GPU_HOST_DEVICE
-void aJacobian(double * J, double * sc, double T, int consP)
+void aJacobian(amrex::Real * J, amrex::Real * sc, amrex::Real T, int consP)
 {
 
 
@@ -4545,43 +4545,43 @@ void aJacobian(double * J, double * sc, double T, int consP)
         J[i] = 0.0;
     }
 
-    double wdot[9];
+    amrex::Real wdot[9];
     for (int k=0; k<9; k++) {
         wdot[k] = 0.0;
     }
 
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
-    double invT2 = invT * invT;
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
+    amrex::Real invT2 = invT * invT;
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
-    double refCinv = 1.0 / refC;
+    amrex::Real refC = 101325 / 8.31446 / T;
+    amrex::Real refCinv = 1.0 / refC;
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int k = 0; k < 9; ++k) {
         mixture += sc[k];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[9];
+    amrex::Real g_RT[9];
     gibbs(g_RT, tc);
 
     /*compute the species enthalpy */
-    double h_RT[9];
+    amrex::Real h_RT[9];
     speciesEnthalpy(h_RT, tc);
 
-    double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
-    double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
-    double dqdci, dcdc_fac, dqdc[9];
-    double Pr, fPr, F, k_0, logPr;
-    double logFcent, troe_c, troe_n, troePr_den, troePr, troe;
-    double Fcent1, Fcent2, Fcent3, Fcent;
-    double dlogFdc, dlogFdn, dlogFdcn_fac;
-    double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
-    const double ln10 = log(10.0);
-    const double log10e = 1.0/log(10.0);
+    amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
+    amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
+    amrex::Real dqdci, dcdc_fac, dqdc[9];
+    amrex::Real Pr, fPr, F, k_0, logPr;
+    amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;
+    amrex::Real Fcent1, Fcent2, Fcent3, Fcent;
+    amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;
+    amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
+    const amrex::Real ln10 = log(10.0);
+    const amrex::Real log10e = 1.0/log(10.0);
     /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
     /*a pressure-fall-off reaction */
     /* also 3-body */
@@ -5762,8 +5762,8 @@ void aJacobian(double * J, double * sc, double T, int consP)
     J[96] += dqdT;                /* dwdot[HO2]/dT */
     J[97] -= dqdT;                /* dwdot[H2O2]/dT */
 
-    double c_R[9], dcRdT[9], e_RT[9];
-    double * eh_RT;
+    amrex::Real c_R[9], dcRdT[9], e_RT[9];
+    amrex::Real * eh_RT;
     if (consP) {
         cp_R(c_R, tc);
         dcvpRdT(dcRdT, tc);
@@ -5776,7 +5776,7 @@ void aJacobian(double * J, double * sc, double T, int consP)
         eh_RT = &e_RT[0];
     }
 
-    double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
+    amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
     for (int k = 0; k < 9; ++k) {
         cmix += c_R[k]*sc[k];
         dcmixdT += dcRdT[k]*sc[k];
@@ -5784,11 +5784,11 @@ void aJacobian(double * J, double * sc, double T, int consP)
         dehmixdT += invT*(c_R[k]-eh_RT[k])*wdot[k] + eh_RT[k]*J[90+k];
     }
 
-    double cmixinv = 1.0/cmix;
-    double tmp1 = ehmix*cmixinv;
-    double tmp3 = cmixinv*T;
-    double tmp2 = tmp1*tmp3;
-    double dehmixdc;
+    amrex::Real cmixinv = 1.0/cmix;
+    amrex::Real tmp1 = ehmix*cmixinv;
+    amrex::Real tmp3 = cmixinv*T;
+    amrex::Real tmp2 = tmp1*tmp3;
+    amrex::Real dehmixdc;
     /* dTdot/d[X] */
     for (int k = 0; k < 9; ++k) {
         dehmixdc = 0.0;
@@ -5807,49 +5807,49 @@ return;
 
 #ifndef AMREX_USE_CUDA
 /*compute the reaction Jacobian on CPU */
-void aJacobian(double *  J, double *  sc, double T, int consP)
+void aJacobian(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int consP)
 {
     for (int i=0; i<100; i++) {
         J[i] = 0.0;
     }
 
-    double wdot[9];
+    amrex::Real wdot[9];
     for (int k=0; k<9; k++) {
         wdot[k] = 0.0;
     }
 
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
-    double invT2 = invT * invT;
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
+    amrex::Real invT2 = invT * invT;
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
-    double refCinv = 1.0 / refC;
+    amrex::Real refC = 101325 / 8.31446 / T;
+    amrex::Real refCinv = 1.0 / refC;
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int k = 0; k < 9; ++k) {
         mixture += sc[k];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[9];
+    amrex::Real g_RT[9];
     gibbs(g_RT, tc);
 
     /*compute the species enthalpy */
-    double h_RT[9];
+    amrex::Real h_RT[9];
     speciesEnthalpy(h_RT, tc);
 
-    double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
-    double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
-    double dqdci, dcdc_fac, dqdc[9];
-    double Pr, fPr, F, k_0, logPr;
-    double logFcent, troe_c, troe_n, troePr_den, troePr, troe;
-    double Fcent1, Fcent2, Fcent3, Fcent;
-    double dlogFdc, dlogFdn, dlogFdcn_fac;
-    double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
-    const double ln10 = log(10.0);
-    const double log10e = 1.0/log(10.0);
+    amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
+    amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
+    amrex::Real dqdci, dcdc_fac, dqdc[9];
+    amrex::Real Pr, fPr, F, k_0, logPr;
+    amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;
+    amrex::Real Fcent1, Fcent2, Fcent3, Fcent;
+    amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;
+    amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
+    const amrex::Real ln10 = log(10.0);
+    const amrex::Real log10e = 1.0/log(10.0);
     /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
     /*a pressure-fall-off reaction */
     /* also 3-body */
@@ -7030,8 +7030,8 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
     J[96] += dqdT;                /* dwdot[HO2]/dT */
     J[97] -= dqdT;                /* dwdot[H2O2]/dT */
 
-    double c_R[9], dcRdT[9], e_RT[9];
-    double * eh_RT;
+    amrex::Real c_R[9], dcRdT[9], e_RT[9];
+    amrex::Real * eh_RT;
     if (consP) {
         cp_R(c_R, tc);
         dcvpRdT(dcRdT, tc);
@@ -7044,7 +7044,7 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
         eh_RT = &e_RT[0];
     }
 
-    double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
+    amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
     for (int k = 0; k < 9; ++k) {
         cmix += c_R[k]*sc[k];
         dcmixdT += dcRdT[k]*sc[k];
@@ -7052,11 +7052,11 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
         dehmixdT += invT*(c_R[k]-eh_RT[k])*wdot[k] + eh_RT[k]*J[90+k];
     }
 
-    double cmixinv = 1.0/cmix;
-    double tmp1 = ehmix*cmixinv;
-    double tmp3 = cmixinv*T;
-    double tmp2 = tmp1*tmp3;
-    double dehmixdc;
+    amrex::Real cmixinv = 1.0/cmix;
+    amrex::Real tmp1 = ehmix*cmixinv;
+    amrex::Real tmp3 = cmixinv*T;
+    amrex::Real tmp2 = tmp1*tmp3;
+    amrex::Real dehmixdc;
     /* dTdot/d[X] */
     for (int k = 0; k < 9; ++k) {
         dehmixdc = 0.0;
@@ -7072,49 +7072,49 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
 
 
 /*compute an approx to the reaction Jacobian */
-AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T, int HP)
+AMREX_GPU_HOST_DEVICE void aJacobian_precond(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int HP)
 {
     for (int i=0; i<100; i++) {
         J[i] = 0.0;
     }
 
-    double wdot[9];
+    amrex::Real wdot[9];
     for (int k=0; k<9; k++) {
         wdot[k] = 0.0;
     }
 
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
-    double invT2 = invT * invT;
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
+    amrex::Real invT2 = invT * invT;
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
-    double refCinv = 1.0 / refC;
+    amrex::Real refC = 101325 / 8.31446 / T;
+    amrex::Real refCinv = 1.0 / refC;
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int k = 0; k < 9; ++k) {
         mixture += sc[k];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[9];
+    amrex::Real g_RT[9];
     gibbs(g_RT, tc);
 
     /*compute the species enthalpy */
-    double h_RT[9];
+    amrex::Real h_RT[9];
     speciesEnthalpy(h_RT, tc);
 
-    double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
-    double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
-    double dqdci, dcdc_fac, dqdc[9];
-    double Pr, fPr, F, k_0, logPr;
-    double logFcent, troe_c, troe_n, troePr_den, troePr, troe;
-    double Fcent1, Fcent2, Fcent3, Fcent;
-    double dlogFdc, dlogFdn, dlogFdcn_fac;
-    double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
-    const double ln10 = log(10.0);
-    const double log10e = 1.0/log(10.0);
+    amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
+    amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
+    amrex::Real dqdci, dcdc_fac, dqdc[9];
+    amrex::Real Pr, fPr, F, k_0, logPr;
+    amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;
+    amrex::Real Fcent1, Fcent2, Fcent3, Fcent;
+    amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;
+    amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
+    const amrex::Real ln10 = log(10.0);
+    const amrex::Real log10e = 1.0/log(10.0);
     /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
     /*a pressure-fall-off reaction */
     /* also 3-body */
@@ -8157,8 +8157,8 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
     J[96] += dqdT;                /* dwdot[HO2]/dT */
     J[97] -= dqdT;                /* dwdot[H2O2]/dT */
 
-    double c_R[9], dcRdT[9], e_RT[9];
-    double * eh_RT;
+    amrex::Real c_R[9], dcRdT[9], e_RT[9];
+    amrex::Real * eh_RT;
     if (HP) {
         cp_R(c_R, tc);
         dcvpRdT(dcRdT, tc);
@@ -8171,7 +8171,7 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
         eh_RT = &e_RT[0];
     }
 
-    double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
+    amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
     for (int k = 0; k < 9; ++k) {
         cmix += c_R[k]*sc[k];
         dcmixdT += dcRdT[k]*sc[k];
@@ -8179,11 +8179,11 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
         dehmixdT += invT*(c_R[k]-eh_RT[k])*wdot[k] + eh_RT[k]*J[90+k];
     }
 
-    double cmixinv = 1.0/cmix;
-    double tmp1 = ehmix*cmixinv;
-    double tmp3 = cmixinv*T;
-    double tmp2 = tmp1*tmp3;
-    double dehmixdc;
+    amrex::Real cmixinv = 1.0/cmix;
+    amrex::Real tmp1 = ehmix*cmixinv;
+    amrex::Real tmp3 = cmixinv*T;
+    amrex::Real tmp2 = tmp1*tmp3;
+    amrex::Real dehmixdc;
     /* dTdot/d[X] */
     for (int k = 0; k < 9; ++k) {
         dehmixdc = 0.0;
@@ -8199,11 +8199,11 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
 
 /*compute d(Cp/R)/dT and d(Cv/R)/dT at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void dcvpRdT(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void dcvpRdT(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -8322,10 +8322,10 @@ AMREX_GPU_HOST_DEVICE void dcvpRdT(double * species, double *  tc)
 
 
 /*compute the progress rate for each reaction */
-AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  sc, double T)
+AMREX_GPU_HOST_DEVICE void progressRate(amrex::Real *  qdot, amrex::Real *  sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 
 #ifndef AMREX_USE_CUDA
     if (T != T_save)
@@ -8336,7 +8336,7 @@ AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  sc, double T)
     }
 #endif
 
-    double q_f[21], q_r[21];
+    amrex::Real q_f[21], q_r[21];
     comp_qfqr(q_f, q_r, sc, tc, invT);
 
     for (int i = 0; i < 21; ++i) {
@@ -8348,10 +8348,10 @@ AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  sc, double T)
 
 
 /*compute the progress rate for each reaction */
-AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *  sc, double T)
+AMREX_GPU_HOST_DEVICE void progressRateFR(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 #ifndef AMREX_USE_CUDA
 
     if (T != T_save)
@@ -8369,10 +8369,10 @@ AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *
 
 
 /*compute the equilibrium constants for each reaction */
-void equilibriumConstants(double *  kc, double *  g_RT, double T)
+void equilibriumConstants(amrex::Real *  kc, amrex::Real *  g_RT, amrex::Real T)
 {
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
+    amrex::Real refC = 101325 / 8.31446 / T;
 
     /*reaction 1: H + O2 (+M) <=> HO2 (+M) */
     kc[0] = 1.0 / (refC) * exp((g_RT[3] + g_RT[1]) - (g_RT[6]));
@@ -8443,12 +8443,12 @@ void equilibriumConstants(double *  kc, double *  g_RT, double T)
 
 /*compute the g/(RT) at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void gibbs(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void gibbs(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -8622,12 +8622,12 @@ AMREX_GPU_HOST_DEVICE void gibbs(double * species, double *  tc)
 
 /*compute the a/(RT) at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void helmholtz(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void helmholtz(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -8801,11 +8801,11 @@ AMREX_GPU_HOST_DEVICE void helmholtz(double * species, double *  tc)
 
 /*compute Cv/R at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void cv_R(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void cv_R(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -8943,11 +8943,11 @@ AMREX_GPU_HOST_DEVICE void cv_R(double * species, double *  tc)
 
 /*compute Cp/R at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void cp_R(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void cp_R(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -9085,12 +9085,12 @@ AMREX_GPU_HOST_DEVICE void cp_R(double * species, double *  tc)
 
 /*compute the e/(RT) at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -9246,12 +9246,12 @@ AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double * species, double *  tc)
 
 /*compute the h/(RT) at the given temperature (Eq 20) */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void speciesEnthalpy(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -9407,11 +9407,11 @@ AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double * species, double *  tc)
 
 /*compute the S/R at the given temperature (Eq 21) */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void speciesEntropy(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void speciesEntropy(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -9566,7 +9566,7 @@ AMREX_GPU_HOST_DEVICE void speciesEntropy(double * species, double *  tc)
 
 
 /*save atomic weights into array */
-void atomicWeight(double *  awt)
+void atomicWeight(amrex::Real *  awt)
 {
     awt[0] = 1.007970; /*H */
     awt[1] = 15.999400; /*O */
@@ -9577,19 +9577,19 @@ void atomicWeight(double *  awt)
 
 
 /* get temperature given internal energy in mass units and mass fracs */
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t, int * ierr)
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(amrex::Real *  e, amrex::Real *  y, amrex::Real *  t, int * ierr)
 {
 #ifdef CONVERGENCE
     const int maxiter = 5000;
-    const double tol  = 1.e-12;
+    const amrex::Real tol  = 1.e-12;
 #else
     const int maxiter = 200;
-    const double tol  = 1.e-6;
+    const amrex::Real tol  = 1.e-6;
 #endif
-    double ein  = *e;
-    double tmin = 90;/*max lower bound for thermo def */
-    double tmax = 4000;/*min upper bound for thermo def */
-    double e1,emin,emax,cv,t1,dt;
+    amrex::Real ein  = *e;
+    amrex::Real tmin = 90;/*max lower bound for thermo def */
+    amrex::Real tmax = 4000;/*min upper bound for thermo def */
+    amrex::Real e1,emin,emax,cv,t1,dt;
     int i;/* loop counter */
     CKUBMS(&tmin, y, &emin);
     CKUBMS(&tmax, y, &emax);
@@ -9627,19 +9627,19 @@ AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t,
 }
 
 /* get temperature given enthalpy in mass units and mass fracs */
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t, int * ierr)
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(amrex::Real *  h, amrex::Real *  y, amrex::Real *  t, int * ierr)
 {
 #ifdef CONVERGENCE
     const int maxiter = 5000;
-    const double tol  = 1.e-12;
+    const amrex::Real tol  = 1.e-12;
 #else
     const int maxiter = 200;
-    const double tol  = 1.e-6;
+    const amrex::Real tol  = 1.e-6;
 #endif
-    double hin  = *h;
-    double tmin = 90;/*max lower bound for thermo def */
-    double tmax = 4000;/*min upper bound for thermo def */
-    double h1,hmin,hmax,cp,t1,dt;
+    amrex::Real hin  = *h;
+    amrex::Real tmin = 90;/*max lower bound for thermo def */
+    amrex::Real tmax = 4000;/*min upper bound for thermo def */
+    amrex::Real h1,hmin,hmax,cp,t1,dt;
     int i;/* loop counter */
     CKHBMS(&tmin, y, &hmin);
     CKHBMS(&tmax, y, &hmax);
@@ -9678,15 +9678,15 @@ AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t,
 
 
 /*compute the critical parameters for each species */
-void GET_CRITPARAMS(double *  Tci, double *  ai, double *  bi, double *  acentric_i)
+void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i)
 {
 
-    double   EPS[9];
-    double   SIG[9];
-    double    wt[9];
-    double avogadro = 6.02214199e23;
-    double boltzmann = 1.3806503e-16; //we work in CGS
-    double Rcst = 83.144598; //in bar [CGS] !
+    amrex::Real   EPS[9];
+    amrex::Real   SIG[9];
+    amrex::Real    wt[9];
+    amrex::Real avogadro = 6.02214199e23;
+    amrex::Real boltzmann = 1.3806503e-16; //we work in CGS
+    amrex::Real Rcst = 83.144598; //in bar [CGS] !
 
     egtransetEPS(EPS);
     egtransetSIG(SIG);
@@ -9775,12 +9775,12 @@ void egtransetNLITE(int* NLITE ) {
 
 
 /*Patm in ergs/cm3 */
-void egtransetPATM(double* PATM) {
+void egtransetPATM(amrex::Real* PATM) {
     *PATM =   0.1013250000000000E+07;}
 
 
 /*the molecular weights in g/mol */
-void egtransetWT(double* WT ) {
+void egtransetWT(amrex::Real* WT ) {
     WT[0] = 2.01594000E+00;
     WT[1] = 3.19988000E+01;
     WT[2] = 1.80153400E+01;
@@ -9794,7 +9794,7 @@ void egtransetWT(double* WT ) {
 
 
 /*the lennard-jones potential well depth eps/kb in K */
-void egtransetEPS(double* EPS ) {
+void egtransetEPS(amrex::Real* EPS ) {
     EPS[0] = 3.80000000E+01;
     EPS[1] = 1.07400000E+02;
     EPS[2] = 5.72400000E+02;
@@ -9808,7 +9808,7 @@ void egtransetEPS(double* EPS ) {
 
 
 /*the lennard-jones collision diameter in Angstroms */
-void egtransetSIG(double* SIG ) {
+void egtransetSIG(amrex::Real* SIG ) {
     SIG[0] = 2.92000000E+00;
     SIG[1] = 3.45800000E+00;
     SIG[2] = 2.60500000E+00;
@@ -9822,7 +9822,7 @@ void egtransetSIG(double* SIG ) {
 
 
 /*the dipole moment in Debye */
-void egtransetDIP(double* DIP ) {
+void egtransetDIP(amrex::Real* DIP ) {
     DIP[0] = 0.00000000E+00;
     DIP[1] = 0.00000000E+00;
     DIP[2] = 1.84400000E+00;
@@ -9836,7 +9836,7 @@ void egtransetDIP(double* DIP ) {
 
 
 /*the polarizability in cubic Angstroms */
-void egtransetPOL(double* POL ) {
+void egtransetPOL(amrex::Real* POL ) {
     POL[0] = 7.90000000E-01;
     POL[1] = 1.60000000E+00;
     POL[2] = 0.00000000E+00;
@@ -9850,7 +9850,7 @@ void egtransetPOL(double* POL ) {
 
 
 /*the rotational relaxation collision number at 298 K */
-void egtransetZROT(double* ZROT ) {
+void egtransetZROT(amrex::Real* ZROT ) {
     ZROT[0] = 2.80000000E+02;
     ZROT[1] = 3.80000000E+00;
     ZROT[2] = 4.00000000E+00;
@@ -9878,7 +9878,7 @@ void egtransetNLIN(int* NLIN) {
 
 
 /*Poly fits for the viscosities, dim NO*KK */
-void egtransetCOFETA(double* COFETA) {
+void egtransetCOFETA(amrex::Real* COFETA) {
     COFETA[0] = -1.37549435E+01;
     COFETA[1] = 9.65530587E-01;
     COFETA[2] = -4.45720114E-02;
@@ -9919,7 +9919,7 @@ void egtransetCOFETA(double* COFETA) {
 
 
 /*Poly fits for the conductivities, dim NO*KK */
-void egtransetCOFLAM(double* COFLAM) {
+void egtransetCOFLAM(amrex::Real* COFLAM) {
     COFLAM[0] = 1.11035551E+01;
     COFLAM[1] = -1.31884089E+00;
     COFLAM[2] = 2.44042735E-01;
@@ -9960,7 +9960,7 @@ void egtransetCOFLAM(double* COFLAM) {
 
 
 /*Poly fits for the diffusion coefficients, dim NO*KK*KK */
-void egtransetCOFD(double* COFD) {
+void egtransetCOFD(amrex::Real* COFD) {
     COFD[0] = -1.02395222E+01;
     COFD[1] = 2.15403244E+00;
     COFD[2] = -6.97480266E-02;
@@ -10296,7 +10296,7 @@ void egtransetKTDIF(int* KTDIF) {
 
 
 /*Poly fits for thermal diff ratios, dim NO*NLITE*KK */
-void egtransetCOFTD(double* COFTD) {
+void egtransetCOFTD(amrex::Real* COFTD) {
     COFTD[0] = 0.00000000E+00;
     COFTD[1] = 0.00000000E+00;
     COFTD[2] = 0.00000000E+00;
@@ -10372,12 +10372,12 @@ void egtransetCOFTD(double* COFTD) {
 }
 
 /* Replace this routine with the one generated by the Gauss Jordan solver of DW */
-AMREX_GPU_HOST_DEVICE void sgjsolve(double* A, double* x, double* b) {
+AMREX_GPU_HOST_DEVICE void sgjsolve(amrex::Real* A, amrex::Real* x, amrex::Real* b) {
     amrex::Abort("sgjsolve not implemented, choose a different solver ");
 }
 
 /* Replace this routine with the one generated by the Gauss Jordan solver of DW */
-AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(double* A, double* x, double* b) {
+AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(amrex::Real* A, amrex::Real* x, amrex::Real* b) {
     amrex::Abort("sgjsolve_simplified not implemented, choose a different solver ");
 }
 

--- a/Support/Fuego/Mechanism/Models/Null/chemistry_file.H
+++ b/Support/Fuego/Mechanism/Models/Null/chemistry_file.H
@@ -3,8 +3,8 @@
 extern "C"
 {
 void CKSYMS(int * kname, int * lenkname);
-void CKRP(double *  ru, double *  ruc, double *  pa);
+void CKRP(amrex::Real *  ru, amrex::Real *  ruc, amrex::Real *  pa);
 AMREX_GPU_HOST_DEVICE void CKINIT();
 AMREX_GPU_HOST_DEVICE void CKFINALIZE();
-AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C, double *  wdot);
+AMREX_GPU_HOST_DEVICE void CKWC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  wdot);
 }

--- a/Support/Fuego/Mechanism/Models/Null/mechanism.cpp
+++ b/Support/Fuego/Mechanism/Models/Null/mechanism.cpp
@@ -3,7 +3,7 @@
 void CKSYMS(int * kname, int * plenkname) {}
 
 /* Returns R, Rc, Patm */
-void CKRP(double *  ru, double *  ruc, double *  pa)
+void CKRP(amrex::Real *  ru, amrex::Real *  ruc, amrex::Real *  pa)
 {
      *ru  = 8.31446261815324e+07; 
      *ruc = 1.98721558317399615845; 
@@ -18,7 +18,7 @@ AMREX_GPU_HOST_DEVICE void CKFINALIZE()
 {
 }
 
-AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C,  double *  wdot)
+AMREX_GPU_HOST_DEVICE void CKWC(amrex::Real *  T, amrex::Real *  C,  amrex::Real *  wdot)
 {
      wdot[0] = 0.0e0;
 }

--- a/Support/Fuego/Mechanism/Models/air/chemistry_file.H
+++ b/Support/Fuego/Mechanism/Models/air/chemistry_file.H
@@ -7,28 +7,28 @@
 
 extern "C"
 {
-AMREX_GPU_HOST_DEVICE void get_imw(double imw_new[]);
-AMREX_GPU_HOST_DEVICE void get_mw(double mw_new[]);
-void egtransetEPS(double *  EPS);
-void egtransetSIG(double* SIG);
-void atomicWeight(double *  awt);
-void molecularWeight(double *  wt);
-AMREX_GPU_HOST_DEVICE void gibbs(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void helmholtz(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void speciesEntropy(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void cp_R(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void cv_R(double *  species, double *  tc);
-void equilibriumConstants(double *  kc, double *  g_RT, double T);
-AMREX_GPU_HOST_DEVICE void productionRate(double *  wdot, double *  sc, double T);
-AMREX_GPU_HOST_DEVICE void comp_qfqr(double *  q_f, double *  q_r, double *  sc, double *  tc, double invT);
+AMREX_GPU_HOST_DEVICE void get_imw(amrex::Real imw_new[]);
+AMREX_GPU_HOST_DEVICE void get_mw(amrex::Real mw_new[]);
+void egtransetEPS(amrex::Real *  EPS);
+void egtransetSIG(amrex::Real* SIG);
+void atomicWeight(amrex::Real *  awt);
+void molecularWeight(amrex::Real *  wt);
+AMREX_GPU_HOST_DEVICE void gibbs(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void helmholtz(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void speciesEnthalpy(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void speciesEntropy(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void cp_R(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void cv_R(amrex::Real *  species, amrex::Real *  tc);
+void equilibriumConstants(amrex::Real *  kc, amrex::Real *  g_RT, amrex::Real T);
+AMREX_GPU_HOST_DEVICE void productionRate(amrex::Real *  wdot, amrex::Real *  sc, amrex::Real T);
+AMREX_GPU_HOST_DEVICE void comp_qfqr(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  sc, amrex::Real *  tc, amrex::Real invT);
 #ifndef AMREX_USE_CUDA
-void comp_k_f(double *  tc, double invT, double *  k_f);
-void comp_Kc(double *  tc, double invT, double *  Kc);
+void comp_k_f(amrex::Real *  tc, amrex::Real invT, amrex::Real *  k_f);
+void comp_Kc(amrex::Real *  tc, amrex::Real invT, amrex::Real *  Kc);
 #endif
-AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  speciesConc, double T);
-AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *  speciesConc, double T);
+AMREX_GPU_HOST_DEVICE void progressRate(amrex::Real *  qdot, amrex::Real *  speciesConc, amrex::Real T);
+AMREX_GPU_HOST_DEVICE void progressRateFR(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  speciesConc, amrex::Real T);
 AMREX_GPU_HOST_DEVICE void CKINIT();
 AMREX_GPU_HOST_DEVICE void CKFINALIZE();
 #ifndef AMREX_USE_CUDA
@@ -36,87 +36,87 @@ void GET_REACTION_MAP(int *  rmap);
 void SetAllDefaults();
 #endif
 void CKINDX(int * mm, int * kk, int * ii, int * nfit );
-void CKXNUM(char * line, int * nexp, int * lout, int * nval, double *  rval, int * kerr, int lenline);
-void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, double *  rval, int * kerr, int lenline, int lenkray);
+void CKXNUM(char * line, int * nexp, int * lout, int * nval, amrex::Real *  rval, int * kerr, int lenline);
+void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, amrex::Real *  rval, int * kerr, int lenline, int lenkray);
 void CKSYME_STR(amrex::Vector<std::string>& ename);
 void CKSYME(int * kname, int * lenkname);
 void CKSYMS_STR(amrex::Vector<std::string>& kname);
 void CKSYMS(int * kname, int * lenkname);
-void CKRP(double *  ru, double *  ruc, double *  pa);
-void CKPX(double *  rho, double *  T, double *  x, double *  P);
-AMREX_GPU_HOST_DEVICE void CKPY(double *  rho, double *  T, double *  y, double *  P);
-void CKPC(double *  rho, double *  T, double *  c, double *  P);
-void CKRHOX(double *  P, double *  T, double *  x, double *  rho);
-AMREX_GPU_HOST_DEVICE void CKRHOY(double *  P, double *  T, double *  y, double *  rho);
-void CKRHOC(double *  P, double *  T, double *  c, double *  rho);
-void CKWT(double *  wt);
-void CKAWT(double *  awt);
-AMREX_GPU_HOST_DEVICE void CKMMWY(double *  y, double *  wtm);
-void CKMMWX(double *  x, double *  wtm);
-void CKMMWC(double *  c, double *  wtm);
-AMREX_GPU_HOST_DEVICE void CKYTX(double *  y, double *  x);
-void CKYTCP(double *  P, double *  T, double *  y, double *  c);
-AMREX_GPU_HOST_DEVICE void CKYTCR(double *  rho, double *  T, double *  y, double *  c);
-AMREX_GPU_HOST_DEVICE void CKXTY(double *  x, double *  y);
-void CKXTCP(double *  P, double *  T, double *  x, double *  c);
-void CKXTCR(double *  rho, double *  T, double *  x, double *  c);
-void CKCTX(double *  c, double *  x);
-void CKCTY(double *  c, double *  y);
-void CKCPOR(double *  T, double *  cpor);
-void CKHORT(double *  T, double *  hort);
-void CKSOR(double *  T, double *  sor);
-void CKCVML(double *  T, double *  cvml);
-void CKCPML(double *  T, double *  cvml);
-void CKUML(double *  T, double *  uml);
-void CKHML(double *  T, double *  uml);
-void CKGML(double *  T, double *  gml);
-void CKAML(double *  T, double *  aml);
-void CKSML(double *  T, double *  sml);
-AMREX_GPU_HOST_DEVICE void CKCVMS(double *  T, double *  cvms);
-AMREX_GPU_HOST_DEVICE void CKCPMS(double *  T, double *  cvms);
-AMREX_GPU_HOST_DEVICE void CKUMS(double *  T, double *  ums);
-AMREX_GPU_HOST_DEVICE void CKHMS(double *  T, double *  ums);
-void CKGMS(double *  T, double *  gms);
-void CKAMS(double *  T, double *  ams);
-void CKSMS(double *  T, double *  sms);
-void CKCPBL(double *  T, double *  x, double *  cpbl);
-AMREX_GPU_HOST_DEVICE void CKCPBS(double *  T, double *  y, double *  cpbs);
-void CKCVBL(double *  T, double *  x, double *  cpbl);
-AMREX_GPU_HOST_DEVICE void CKCVBS(double *  T, double *  y, double *  cpbs);
-void CKHBML(double *  T, double *  x, double *  hbml);
-AMREX_GPU_HOST_DEVICE void CKHBMS(double *  T, double *  y, double *  hbms);
-void CKUBML(double *  T, double *  x, double *  ubml);
-AMREX_GPU_HOST_DEVICE void CKUBMS(double *  T, double *  y, double *  ubms);
-void CKSBML(double *  P, double *  T, double *  x, double *  sbml);
-void CKSBMS(double *  P, double *  T, double *  y, double *  sbms);
-void CKGBML(double *  P, double *  T, double *  x, double *  gbml);
-void CKGBMS(double *  P, double *  T, double *  y, double *  gbms);
-void CKABML(double *  P, double *  T, double *  x, double *  abml);
-void CKABMS(double *  P, double *  T, double *  y, double *  abms);
-AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C, double *  wdot);
-void CKWYP(double *  P, double *  T, double *  y, double *  wdot);
-void CKWXP(double *  P, double *  T, double *  x, double *  wdot);
-AMREX_GPU_HOST_DEVICE void CKWYR(double *  rho, double *  T, double *  y, double *  wdot);
-void CKWXR(double *  rho, double *  T, double *  x, double *  wdot);
-void CKQC(double *  T, double *  C, double *  qdot);
-void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r);
-void CKQYP(double *  P, double *  T, double *  y, double *  qdot);
-void CKQXP(double *  P, double *  T, double *  x, double *  qdot);
-void CKQYR(double *  rho, double *  T, double *  y, double *  qdot);
-void CKQXR(double *  rho, double *  T, double *  x, double *  qdot);
+void CKRP(amrex::Real *  ru, amrex::Real *  ruc, amrex::Real *  pa);
+void CKPX(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  P);
+AMREX_GPU_HOST_DEVICE void CKPY(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  P);
+void CKPC(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  c, amrex::Real *  P);
+void CKRHOX(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  rho);
+AMREX_GPU_HOST_DEVICE void CKRHOY(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  rho);
+void CKRHOC(amrex::Real *  P, amrex::Real *  T, amrex::Real *  c, amrex::Real *  rho);
+void CKWT(amrex::Real *  wt);
+void CKAWT(amrex::Real *  awt);
+AMREX_GPU_HOST_DEVICE void CKMMWY(amrex::Real *  y, amrex::Real *  wtm);
+void CKMMWX(amrex::Real *  x, amrex::Real *  wtm);
+void CKMMWC(amrex::Real *  c, amrex::Real *  wtm);
+AMREX_GPU_HOST_DEVICE void CKYTX(amrex::Real *  y, amrex::Real *  x);
+void CKYTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  c);
+AMREX_GPU_HOST_DEVICE void CKYTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  c);
+AMREX_GPU_HOST_DEVICE void CKXTY(amrex::Real *  x, amrex::Real *  y);
+void CKXTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c);
+void CKXTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c);
+void CKCTX(amrex::Real *  c, amrex::Real *  x);
+void CKCTY(amrex::Real *  c, amrex::Real *  y);
+void CKCPOR(amrex::Real *  T, amrex::Real *  cpor);
+void CKHORT(amrex::Real *  T, amrex::Real *  hort);
+void CKSOR(amrex::Real *  T, amrex::Real *  sor);
+void CKCVML(amrex::Real *  T, amrex::Real *  cvml);
+void CKCPML(amrex::Real *  T, amrex::Real *  cvml);
+void CKUML(amrex::Real *  T, amrex::Real *  uml);
+void CKHML(amrex::Real *  T, amrex::Real *  uml);
+void CKGML(amrex::Real *  T, amrex::Real *  gml);
+void CKAML(amrex::Real *  T, amrex::Real *  aml);
+void CKSML(amrex::Real *  T, amrex::Real *  sml);
+AMREX_GPU_HOST_DEVICE void CKCVMS(amrex::Real *  T, amrex::Real *  cvms);
+AMREX_GPU_HOST_DEVICE void CKCPMS(amrex::Real *  T, amrex::Real *  cvms);
+AMREX_GPU_HOST_DEVICE void CKUMS(amrex::Real *  T, amrex::Real *  ums);
+AMREX_GPU_HOST_DEVICE void CKHMS(amrex::Real *  T, amrex::Real *  ums);
+void CKGMS(amrex::Real *  T, amrex::Real *  gms);
+void CKAMS(amrex::Real *  T, amrex::Real *  ams);
+void CKSMS(amrex::Real *  T, amrex::Real *  sms);
+void CKCPBL(amrex::Real *  T, amrex::Real *  x, amrex::Real *  cpbl);
+AMREX_GPU_HOST_DEVICE void CKCPBS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  cpbs);
+void CKCVBL(amrex::Real *  T, amrex::Real *  x, amrex::Real *  cpbl);
+AMREX_GPU_HOST_DEVICE void CKCVBS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  cpbs);
+void CKHBML(amrex::Real *  T, amrex::Real *  x, amrex::Real *  hbml);
+AMREX_GPU_HOST_DEVICE void CKHBMS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  hbms);
+void CKUBML(amrex::Real *  T, amrex::Real *  x, amrex::Real *  ubml);
+AMREX_GPU_HOST_DEVICE void CKUBMS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  ubms);
+void CKSBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  sbml);
+void CKSBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  sbms);
+void CKGBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  gbml);
+void CKGBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  gbms);
+void CKABML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  abml);
+void CKABMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  abms);
+AMREX_GPU_HOST_DEVICE void CKWC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  wdot);
+void CKWYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  wdot);
+void CKWXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  wdot);
+AMREX_GPU_HOST_DEVICE void CKWYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  wdot);
+void CKWXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  wdot);
+void CKQC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  qdot);
+void CKKFKR(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  q_f, amrex::Real *  q_r);
+void CKQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot);
+void CKQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot);
+void CKQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot);
+void CKQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot);
 void CKNU(int * kdim, int * nuki);
 #ifndef AMREX_USE_CUDA
 void CKINU(int * i, int * nspec, int * ki, int * nu);
 #endif
 void CKNCF(int * ncf);
-void CKABE(double *  a, double *  b, double *  e );
-void CKEQC(double *  T, double *  C , double *  eqcon );
-void CKEQYP(double *  P, double *  T, double *  y, double *  eqcon);
-void CKEQXP(double *  P, double *  T, double *  x, double *  eqcon);
-void CKEQYR(double *  rho, double *  T, double *  y, double *  eqcon);
-void CKEQXR(double *  rho, double *  T, double *  x, double *  eqcon);
-AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  T, int * consP);
-AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double *  Tp, int * HP);
+void CKABE(amrex::Real *  a, amrex::Real *  b, amrex::Real *  e );
+void CKEQC(amrex::Real *  T, amrex::Real *  C , amrex::Real *  eqcon );
+void CKEQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon);
+void CKEQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon);
+void CKEQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon);
+void CKEQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon);
+AMREX_GPU_HOST_DEVICE void DWDOT(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  T, int * consP);
+AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * HP);
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO(int * nJdata, int * consP, int NCELLS);
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST(int * nJdata, int * consP, int NCELLS);
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED(int * nJdata, int * consP);
@@ -125,27 +125,27 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSR(int * colVals, int * rowPtrs, in
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtrs, int * consP, int NCELLS, int base);
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, int * colPtrs, int * indx, int * consP);
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, int * rowPtr, int * consP, int base);
-AMREX_GPU_HOST_DEVICE void aJacobian(double *  J, double *  sc, double T, int consP);
-AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T, int HP);
-AMREX_GPU_HOST_DEVICE void dcvpRdT(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t, int *ierr);
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t, int *ierr);
-void GET_CRITPARAMS(double *  Tci, double *  ai, double *  bi, double *  acentric_i);
+AMREX_GPU_HOST_DEVICE void aJacobian(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int consP);
+AMREX_GPU_HOST_DEVICE void aJacobian_precond(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int HP);
+AMREX_GPU_HOST_DEVICE void dcvpRdT(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(amrex::Real *  e, amrex::Real *  y, amrex::Real *  t, int *ierr);
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(amrex::Real *  h, amrex::Real *  y, amrex::Real *  t, int *ierr);
+void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i);
 /*vector version */
-void VCKYTX(int *  np, double *  y, double *  x);
-void VCKHMS(int *  np, double *  T, double *  ums);
-void VCKWYR(int *  np, double *  rho, double *  T,
-            double *  y,
-            double *  wdot);
+void VCKYTX(int *  np, amrex::Real *  y, amrex::Real *  x);
+void VCKHMS(int *  np, amrex::Real *  T, amrex::Real *  ums);
+void VCKWYR(int *  np, amrex::Real *  rho, amrex::Real *  T,
+            amrex::Real *  y,
+            amrex::Real *  wdot);
 #ifndef AMREX_USE_CUDA
-void vproductionRate(int npt, double *  wdot, double *  c, double *  T);
-void VCKPY(int *  np, double *  rho, double *  T, double *  y, double *  P);
-void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT);
-void vcomp_gibbs(int npt, double *  g_RT, double *  tc);
-void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT);
-void vcomp_wdot(int npt, double *  wdot, double *  mixture, double *  sc,
-                double *  k_f_s, double *  Kc_s,
-                double *  tc, double *  invT, double *  T);
+void vproductionRate(int npt, amrex::Real *  wdot, amrex::Real *  c, amrex::Real *  T);
+void VCKPY(int *  np, amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  P);
+void vcomp_k_f(int npt, amrex::Real *  k_f_s, amrex::Real *  tc, amrex::Real *  invT);
+void vcomp_gibbs(int npt, amrex::Real *  g_RT, amrex::Real *  tc);
+void vcomp_Kc(int npt, amrex::Real *  Kc_s, amrex::Real *  g_RT, amrex::Real *  invT);
+void vcomp_wdot(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,
+                amrex::Real *  k_f_s, amrex::Real *  Kc_s,
+                amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T);
 #endif
 /*Transport function declarations */
 void egtransetLENIMC(int* LENIMC);
@@ -153,46 +153,46 @@ void egtransetLENRMC(int* LENRMC);
 void egtransetNO(int* NO);
 void egtransetKK(int* KK);
 void egtransetNLITE(int* NLITE);
-void egtransetPATM(double* PATM);
-void egtransetWT(double* WT);
-void egtransetEPS(double* EPS);
-void egtransetSIG(double* SIG);
-void egtransetDIP(double* DIP);
-void egtransetPOL(double* POL);
-void egtransetZROT(double* ZROT);
+void egtransetPATM(amrex::Real* PATM);
+void egtransetWT(amrex::Real* WT);
+void egtransetEPS(amrex::Real* EPS);
+void egtransetSIG(amrex::Real* SIG);
+void egtransetDIP(amrex::Real* DIP);
+void egtransetPOL(amrex::Real* POL);
+void egtransetZROT(amrex::Real* ZROT);
 void egtransetNLIN(int* NLIN);
-void egtransetCOFETA(double* COFETA);
-void egtransetCOFLAM(double* COFLAM);
-void egtransetCOFD(double* COFD);
+void egtransetCOFETA(amrex::Real* COFETA);
+void egtransetCOFLAM(amrex::Real* COFLAM);
+void egtransetCOFD(amrex::Real* COFD);
 void egtransetKTDIF(int* KTDIF);
 /*gauss-jordan solver external routine */
-AMREX_GPU_HOST_DEVICE void sgjsolve(double* A, double* x, double* b);
-AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(double* A, double* x, double* b);
+AMREX_GPU_HOST_DEVICE void sgjsolve(amrex::Real* A, amrex::Real* x, amrex::Real* b);
+AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(amrex::Real* A, amrex::Real* x, amrex::Real* b);
 }
 
 #ifndef AMREX_USE_CUDA
 namespace thermo
 {
 
-    extern double fwd_A[0], fwd_beta[0], fwd_Ea[0];
-    extern double low_A[0], low_beta[0], low_Ea[0];
-    extern double rev_A[0], rev_beta[0], rev_Ea[0];
-    extern double troe_a[0],troe_Ts[0], troe_Tss[0], troe_Tsss[0];
-    extern double sri_a[0], sri_b[0], sri_c[0], sri_d[0], sri_e[0];
-    extern double activation_units[0], prefactor_units[0], phase_units[0];
+    extern amrex::Real fwd_A[0], fwd_beta[0], fwd_Ea[0];
+    extern amrex::Real low_A[0], low_beta[0], low_Ea[0];
+    extern amrex::Real rev_A[0], rev_beta[0], rev_Ea[0];
+    extern amrex::Real troe_a[0],troe_Ts[0], troe_Tss[0], troe_Tsss[0];
+    extern amrex::Real sri_a[0], sri_b[0], sri_c[0], sri_d[0], sri_e[0];
+    extern amrex::Real activation_units[0], prefactor_units[0], phase_units[0];
     extern int is_PD[0], troe_len[0], sri_len[0], nTB[0], *TBid[0];
-    extern double *TB[0];
-    extern std::vector<std::vector<double>> kiv; 
-    extern std::vector<std::vector<double>> nuv; 
+    extern amrex::Real *TB[0];
+    extern std::vector<std::vector<amrex::Real>> kiv; 
+    extern std::vector<std::vector<amrex::Real>> nuv; 
 
-    extern double fwd_A_DEF[0], fwd_beta_DEF[0], fwd_Ea_DEF[0];
-    extern double low_A_DEF[0], low_beta_DEF[0], low_Ea_DEF[0];
-    extern double rev_A_DEF[0], rev_beta_DEF[0], rev_Ea_DEF[0];
-    extern double troe_a_DEF[0],troe_Ts_DEF[0], troe_Tss_DEF[0], troe_Tsss_DEF[0];
-    extern double sri_a_DEF[0], sri_b_DEF[0], sri_c_DEF[0], sri_d_DEF[0], sri_e_DEF[0];
-    extern double activation_units_DEF[0], prefactor_units_DEF[0], phase_units_DEF[0];
+    extern amrex::Real fwd_A_DEF[0], fwd_beta_DEF[0], fwd_Ea_DEF[0];
+    extern amrex::Real low_A_DEF[0], low_beta_DEF[0], low_Ea_DEF[0];
+    extern amrex::Real rev_A_DEF[0], rev_beta_DEF[0], rev_Ea_DEF[0];
+    extern amrex::Real troe_a_DEF[0],troe_Ts_DEF[0], troe_Tss_DEF[0], troe_Tsss_DEF[0];
+    extern amrex::Real sri_a_DEF[0], sri_b_DEF[0], sri_c_DEF[0], sri_d_DEF[0], sri_e_DEF[0];
+    extern amrex::Real activation_units_DEF[0], prefactor_units_DEF[0], phase_units_DEF[0];
     extern int is_PD_DEF[0], troe_len_DEF[0], sri_len_DEF[0], nTB_DEF[0], *TBid_DEF[0];
-    extern double *TB_DEF[0];
+    extern amrex::Real *TB_DEF[0];
     extern std::vector<int> rxn_map;
 }
 #endif

--- a/Support/Fuego/Mechanism/Models/air/mechanism.cpp
+++ b/Support/Fuego/Mechanism/Models/air/mechanism.cpp
@@ -3,25 +3,25 @@
 #ifndef AMREX_USE_CUDA
 namespace thermo
 {
-    double fwd_A[0], fwd_beta[0], fwd_Ea[0];
-    double low_A[0], low_beta[0], low_Ea[0];
-    double rev_A[0], rev_beta[0], rev_Ea[0];
-    double troe_a[0],troe_Ts[0], troe_Tss[0], troe_Tsss[0];
-    double sri_a[0], sri_b[0], sri_c[0], sri_d[0], sri_e[0];
-    double activation_units[0], prefactor_units[0], phase_units[0];
+    amrex::Real fwd_A[0], fwd_beta[0], fwd_Ea[0];
+    amrex::Real low_A[0], low_beta[0], low_Ea[0];
+    amrex::Real rev_A[0], rev_beta[0], rev_Ea[0];
+    amrex::Real troe_a[0],troe_Ts[0], troe_Tss[0], troe_Tsss[0];
+    amrex::Real sri_a[0], sri_b[0], sri_c[0], sri_d[0], sri_e[0];
+    amrex::Real activation_units[0], prefactor_units[0], phase_units[0];
     int is_PD[0], troe_len[0], sri_len[0], nTB[0], *TBid[0];
-    double *TB[0];
-    std::vector<std::vector<double>> kiv(0); 
-    std::vector<std::vector<double>> nuv(0); 
+    amrex::Real *TB[0];
+    std::vector<std::vector<amrex::Real>> kiv(0); 
+    std::vector<std::vector<amrex::Real>> nuv(0); 
 
-    double fwd_A_DEF[0], fwd_beta_DEF[0], fwd_Ea_DEF[0];
-    double low_A_DEF[0], low_beta_DEF[0], low_Ea_DEF[0];
-    double rev_A_DEF[0], rev_beta_DEF[0], rev_Ea_DEF[0];
-    double troe_a_DEF[0],troe_Ts_DEF[0], troe_Tss_DEF[0], troe_Tsss_DEF[0];
-    double sri_a_DEF[0], sri_b_DEF[0], sri_c_DEF[0], sri_d_DEF[0], sri_e_DEF[0];
-    double activation_units_DEF[0], prefactor_units_DEF[0], phase_units_DEF[0];
+    amrex::Real fwd_A_DEF[0], fwd_beta_DEF[0], fwd_Ea_DEF[0];
+    amrex::Real low_A_DEF[0], low_beta_DEF[0], low_Ea_DEF[0];
+    amrex::Real rev_A_DEF[0], rev_beta_DEF[0], rev_Ea_DEF[0];
+    amrex::Real troe_a_DEF[0],troe_Ts_DEF[0], troe_Tss_DEF[0], troe_Tsss_DEF[0];
+    amrex::Real sri_a_DEF[0], sri_b_DEF[0], sri_c_DEF[0], sri_d_DEF[0], sri_e_DEF[0];
+    amrex::Real activation_units_DEF[0], prefactor_units_DEF[0], phase_units_DEF[0];
     int is_PD_DEF[0], troe_len_DEF[0], sri_len_DEF[0], nTB_DEF[0], *TBid_DEF[0];
-    double *TB_DEF[0];
+    amrex::Real *TB_DEF[0];
     std::vector<int> rxn_map;
 };
 
@@ -30,24 +30,24 @@ using namespace thermo;
 
 /* Inverse molecular weights */
 /* TODO: check necessity on CPU */
-static AMREX_GPU_DEVICE_MANAGED double imw[2] = {
+static AMREX_GPU_DEVICE_MANAGED amrex::Real imw[2] = {
     1.0 / 31.998800,  /*O2 */
     1.0 / 28.013400};  /*N2 */
 
 /* Inverse molecular weights */
 /* TODO: check necessity because redundant with molecularWeight */
-static AMREX_GPU_DEVICE_MANAGED double molecular_weights[2] = {
+static AMREX_GPU_DEVICE_MANAGED amrex::Real molecular_weights[2] = {
     31.998800,  /*O2 */
     28.013400};  /*N2 */
 
 AMREX_GPU_HOST_DEVICE
-void get_imw(double imw_new[]){
+void get_imw(amrex::Real imw_new[]){
     for(int i = 0; i<2; ++i) imw_new[i] = imw[i];
 }
 
 /* TODO: check necessity because redundant with CKWT */
 AMREX_GPU_HOST_DEVICE
-void get_mw(double mw_new[]){
+void get_mw(amrex::Real mw_new[]){
     for(int i = 0; i<2; ++i) mw_new[i] = molecular_weights[i];
 }
 
@@ -70,7 +70,7 @@ void GET_REACTION_MAP(int *rmap)
 }
 
 #include <ReactionData.H>
-double* GetParamPtr(int                reaction_id,
+amrex::Real* GetParamPtr(int                reaction_id,
                     REACTION_PARAMETER param_id,
                     int                species_id,
                     int                get_default)
@@ -122,7 +122,7 @@ void ResetAllParametersToDefault()
 
         nTB[i]  = nTB_DEF[i];
         if (nTB[i] != 0) {
-           TB[i] = (double *) malloc(sizeof(double) * nTB[i]);
+           TB[i] = (amrex::Real *) malloc(sizeof(amrex::Real) * nTB[i]);
            TBid[i] = (int *) malloc(sizeof(int) * nTB[i]);
            for (int j=0; j<nTB[i]; j++) {
              TB[i][j] = TB_DEF[i][j];
@@ -174,7 +174,7 @@ void SetAllDefaults()
 
         nTB_DEF[i]  = nTB[i];
         if (nTB_DEF[i] != 0) {
-           TB_DEF[i] = (double *) malloc(sizeof(double) * nTB_DEF[i]);
+           TB_DEF[i] = (amrex::Real *) malloc(sizeof(amrex::Real) * nTB_DEF[i]);
            TBid_DEF[i] = (int *) malloc(sizeof(int) * nTB_DEF[i]);
            for (int j=0; j<nTB_DEF[i]; j++) {
              TB_DEF[i][j] = TB[i][j];
@@ -223,7 +223,7 @@ void CKINDX(int * mm, int * kk, int * ii, int * nfit)
 
 
 /* ckxnum... for parsing strings  */
-void CKXNUM(char * line, int * nexp, int * lout, int * nval, double *  rval, int * kerr, int lenline )
+void CKXNUM(char * line, int * nexp, int * lout, int * nval, amrex::Real *  rval, int * kerr, int lenline )
 {
     int n,i; /*Loop Counters */
     char cstr[1000];
@@ -256,7 +256,7 @@ void CKXNUM(char * line, int * nexp, int * lout, int * nval, double *  rval, int
 
 
 /* cksnum... for parsing strings  */
-void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, double *  rval, int * kerr, int lenline, int lenkray)
+void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, amrex::Real *  rval, int * kerr, int lenline, int lenkray)
 {
     /*Not done yet ... */
 }
@@ -325,7 +325,7 @@ void CKSYMS(int * kname, int * plenkname )
 
 
 /* Returns R, Rc, Patm */
-void CKRP(double *  ru, double *  ruc, double *  pa)
+void CKRP(amrex::Real *  ru, amrex::Real *  ruc, amrex::Real *  pa)
 {
      *ru  = 8.31446261815324e+07; 
      *ruc = 1.98721558317399615845; 
@@ -334,9 +334,9 @@ void CKRP(double *  ru, double *  ruc, double *  pa)
 
 
 /*Compute P = rhoRT/W(x) */
-void CKPX(double *  rho, double *  T, double *  x, double *  P)
+void CKPX(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  P)
 {
-    double XW = 0;/* To hold mean molecular wt */
+    amrex::Real XW = 0;/* To hold mean molecular wt */
     XW += x[0]*31.998800; /*O2 */
     XW += x[1]*28.013400; /*N2 */
     *P = *rho * 8.31446261815324e+07 * (*T) / XW; /*P = rho*R*T/W */
@@ -346,9 +346,9 @@ void CKPX(double *  rho, double *  T, double *  x, double *  P)
 
 
 /*Compute P = rhoRT/W(y) */
-AMREX_GPU_HOST_DEVICE void CKPY(double *  rho, double *  T, double *  y,  double *  P)
+AMREX_GPU_HOST_DEVICE void CKPY(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  P)
 {
-    double YOW = 0;/* for computing mean MW */
+    amrex::Real YOW = 0;/* for computing mean MW */
     YOW += y[0]*imw[0]; /*O2 */
     YOW += y[1]*imw[1]; /*N2 */
     *P = *rho * 8.31446261815324e+07 * (*T) * YOW; /*P = rho*R*T/W */
@@ -359,9 +359,9 @@ AMREX_GPU_HOST_DEVICE void CKPY(double *  rho, double *  T, double *  y,  double
 
 #ifndef AMREX_USE_CUDA
 /*Compute P = rhoRT/W(y) */
-void VCKPY(int *  np, double *  rho, double *  T, double *  y,  double *  P)
+void VCKPY(int *  np, amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  P)
 {
-    double YOW[*np];
+    amrex::Real YOW[*np];
     for (int i=0; i<(*np); i++) {
         YOW[i] = 0.0;
     }
@@ -382,12 +382,12 @@ void VCKPY(int *  np, double *  rho, double *  T, double *  y,  double *  P)
 
 
 /*Compute P = rhoRT/W(c) */
-void CKPC(double *  rho, double *  T, double *  c,  double *  P)
+void CKPC(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  c,  amrex::Real *  P)
 {
     int id; /*loop counter */
     /*See Eq 5 in CK Manual */
-    double W = 0;
-    double sumC = 0;
+    amrex::Real W = 0;
+    amrex::Real sumC = 0;
     W += c[0]*31.998800; /*O2 */
     W += c[1]*28.013400; /*N2 */
 
@@ -401,9 +401,9 @@ void CKPC(double *  rho, double *  T, double *  c,  double *  P)
 
 
 /*Compute rho = PW(x)/RT */
-void CKRHOX(double *  P, double *  T, double *  x,  double *  rho)
+void CKRHOX(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  rho)
 {
-    double XW = 0;/* To hold mean molecular wt */
+    amrex::Real XW = 0;/* To hold mean molecular wt */
     XW += x[0]*31.998800; /*O2 */
     XW += x[1]*28.013400; /*N2 */
     *rho = *P * XW / (8.31446261815324e+07 * (*T)); /*rho = P*W/(R*T) */
@@ -413,10 +413,10 @@ void CKRHOX(double *  P, double *  T, double *  x,  double *  rho)
 
 
 /*Compute rho = P*W(y)/RT */
-AMREX_GPU_HOST_DEVICE void CKRHOY(double *  P, double *  T, double *  y,  double *  rho)
+AMREX_GPU_HOST_DEVICE void CKRHOY(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  rho)
 {
-    double YOW = 0;
-    double tmp[2];
+    amrex::Real YOW = 0;
+    amrex::Real tmp[2];
 
     for (int i = 0; i < 2; i++)
     {
@@ -433,12 +433,12 @@ AMREX_GPU_HOST_DEVICE void CKRHOY(double *  P, double *  T, double *  y,  double
 
 
 /*Compute rho = P*W(c)/(R*T) */
-void CKRHOC(double *  P, double *  T, double *  c,  double *  rho)
+void CKRHOC(amrex::Real *  P, amrex::Real *  T, amrex::Real *  c,  amrex::Real *  rho)
 {
     int id; /*loop counter */
     /*See Eq 5 in CK Manual */
-    double W = 0;
-    double sumC = 0;
+    amrex::Real W = 0;
+    amrex::Real sumC = 0;
     W += c[0]*31.998800; /*O2 */
     W += c[1]*28.013400; /*N2 */
 
@@ -452,14 +452,14 @@ void CKRHOC(double *  P, double *  T, double *  c,  double *  rho)
 
 
 /*get molecular weight for all species */
-void CKWT( double *  wt)
+void CKWT( amrex::Real *  wt)
 {
     get_mw(wt);
 }
 
 
 /*get atomic weight for all elements */
-void CKAWT( double *  awt)
+void CKAWT( amrex::Real *  awt)
 {
     atomicWeight(awt);
 }
@@ -467,10 +467,10 @@ void CKAWT( double *  awt)
 
 /*given y[species]: mass fractions */
 /*returns mean molecular weight (gm/mole) */
-AMREX_GPU_HOST_DEVICE void CKMMWY(double *  y,  double *  wtm)
+AMREX_GPU_HOST_DEVICE void CKMMWY(amrex::Real *  y,  amrex::Real *  wtm)
 {
-    double YOW = 0;
-    double tmp[2];
+    amrex::Real YOW = 0;
+    amrex::Real tmp[2];
 
     for (int i = 0; i < 2; i++)
     {
@@ -488,9 +488,9 @@ AMREX_GPU_HOST_DEVICE void CKMMWY(double *  y,  double *  wtm)
 
 /*given x[species]: mole fractions */
 /*returns mean molecular weight (gm/mole) */
-void CKMMWX(double *  x,  double *  wtm)
+void CKMMWX(amrex::Real *  x,  amrex::Real *  wtm)
 {
-    double XW = 0;/* see Eq 4 in CK Manual */
+    amrex::Real XW = 0;/* see Eq 4 in CK Manual */
     XW += x[0]*31.998800; /*O2 */
     XW += x[1]*28.013400; /*N2 */
     *wtm = XW;
@@ -501,12 +501,12 @@ void CKMMWX(double *  x,  double *  wtm)
 
 /*given c[species]: molar concentration */
 /*returns mean molecular weight (gm/mole) */
-void CKMMWC(double *  c,  double *  wtm)
+void CKMMWC(amrex::Real *  c,  amrex::Real *  wtm)
 {
     int id; /*loop counter */
     /*See Eq 5 in CK Manual */
-    double W = 0;
-    double sumC = 0;
+    amrex::Real W = 0;
+    amrex::Real sumC = 0;
     W += c[0]*31.998800; /*O2 */
     W += c[1]*28.013400; /*N2 */
 
@@ -521,10 +521,10 @@ void CKMMWC(double *  c,  double *  wtm)
 
 
 /*convert y[species] (mass fracs) to x[species] (mole fracs) */
-AMREX_GPU_HOST_DEVICE void CKYTX(double *  y,  double *  x)
+AMREX_GPU_HOST_DEVICE void CKYTX(amrex::Real *  y,  amrex::Real *  x)
 {
-    double YOW = 0;
-    double tmp[2];
+    amrex::Real YOW = 0;
+    amrex::Real tmp[2];
 
     for (int i = 0; i < 2; i++)
     {
@@ -535,7 +535,7 @@ AMREX_GPU_HOST_DEVICE void CKYTX(double *  y,  double *  x)
         YOW += tmp[i];
     }
 
-    double YOWINV = 1.0/YOW;
+    amrex::Real YOWINV = 1.0/YOW;
 
     for (int i = 0; i < 2; i++)
     {
@@ -547,9 +547,9 @@ AMREX_GPU_HOST_DEVICE void CKYTX(double *  y,  double *  x)
 
 #ifndef AMREX_USE_CUDA
 /*convert y[npoints*species] (mass fracs) to x[npoints*species] (mole fracs) */
-void VCKYTX(int *  np, double *  y,  double *  x)
+void VCKYTX(int *  np, amrex::Real *  y,  amrex::Real *  x)
 {
-    double YOW[*np];
+    amrex::Real YOW[*np];
     for (int i=0; i<(*np); i++) {
         YOW[i] = 0.0;
     }
@@ -573,17 +573,17 @@ void VCKYTX(int *  np, double *  y,  double *  x)
 }
 #else
 /*TODO: remove this on GPU */
-void VCKYTX(int *  np, double *  y,  double *  x)
+void VCKYTX(int *  np, amrex::Real *  y,  amrex::Real *  x)
 {
 }
 #endif
 
 
 /*convert y[species] (mass fracs) to c[species] (molar conc) */
-void CKYTCP(double *  P, double *  T, double *  y,  double *  c)
+void CKYTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  c)
 {
-    double YOW = 0;
-    double PWORT;
+    amrex::Real YOW = 0;
+    amrex::Real PWORT;
 
     /*Compute inverse of mean molecular wt first */
     for (int i = 0; i < 2; i++)
@@ -608,7 +608,7 @@ void CKYTCP(double *  P, double *  T, double *  y,  double *  c)
 
 
 /*convert y[species] (mass fracs) to c[species] (molar conc) */
-AMREX_GPU_HOST_DEVICE void CKYTCR(double *  rho, double *  T, double *  y,  double *  c)
+AMREX_GPU_HOST_DEVICE void CKYTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  c)
 {
     for (int i = 0; i < 2; i++)
     {
@@ -618,14 +618,14 @@ AMREX_GPU_HOST_DEVICE void CKYTCR(double *  rho, double *  T, double *  y,  doub
 
 
 /*convert x[species] (mole fracs) to y[species] (mass fracs) */
-AMREX_GPU_HOST_DEVICE void CKXTY(double *  x,  double *  y)
+AMREX_GPU_HOST_DEVICE void CKXTY(amrex::Real *  x,  amrex::Real *  y)
 {
-    double XW = 0; /*See Eq 4, 9 in CK Manual */
+    amrex::Real XW = 0; /*See Eq 4, 9 in CK Manual */
     /*Compute mean molecular wt first */
     XW += x[0]*31.998800; /*O2 */
     XW += x[1]*28.013400; /*N2 */
     /*Now compute conversion */
-    double XWinv = 1.0/XW;
+    amrex::Real XWinv = 1.0/XW;
     y[0] = x[0]*31.998800*XWinv; 
     y[1] = x[1]*28.013400*XWinv; 
 
@@ -634,10 +634,10 @@ AMREX_GPU_HOST_DEVICE void CKXTY(double *  x,  double *  y)
 
 
 /*convert x[species] (mole fracs) to c[species] (molar conc) */
-void CKXTCP(double *  P, double *  T, double *  x,  double *  c)
+void CKXTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  c)
 {
     int id; /*loop counter */
-    double PORT = (*P)/(8.31446261815324e+07 * (*T)); /*P/RT */
+    amrex::Real PORT = (*P)/(8.31446261815324e+07 * (*T)); /*P/RT */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 2; ++id) {
@@ -649,11 +649,11 @@ void CKXTCP(double *  P, double *  T, double *  x,  double *  c)
 
 
 /*convert x[species] (mole fracs) to c[species] (molar conc) */
-void CKXTCR(double *  rho, double *  T, double *  x, double *  c)
+void CKXTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c)
 {
     int id; /*loop counter */
-    double XW = 0; /*See Eq 4, 11 in CK Manual */
-    double ROW; 
+    amrex::Real XW = 0; /*See Eq 4, 11 in CK Manual */
+    amrex::Real ROW; 
     /*Compute mean molecular wt first */
     XW += x[0]*31.998800; /*O2 */
     XW += x[1]*28.013400; /*N2 */
@@ -669,10 +669,10 @@ void CKXTCR(double *  rho, double *  T, double *  x, double *  c)
 
 
 /*convert c[species] (molar conc) to x[species] (mole fracs) */
-void CKCTX(double *  c, double *  x)
+void CKCTX(amrex::Real *  c, amrex::Real *  x)
 {
     int id; /*loop counter */
-    double sumC = 0; 
+    amrex::Real sumC = 0; 
 
     /*compute sum of c  */
     for (id = 0; id < 2; ++id) {
@@ -680,7 +680,7 @@ void CKCTX(double *  c, double *  x)
     }
 
     /* See Eq 13  */
-    double sumCinv = 1.0/sumC;
+    amrex::Real sumCinv = 1.0/sumC;
     for (id = 0; id < 2; ++id) {
         x[id] = c[id]*sumCinv;
     }
@@ -690,14 +690,14 @@ void CKCTX(double *  c, double *  x)
 
 
 /*convert c[species] (molar conc) to y[species] (mass fracs) */
-void CKCTY(double *  c, double *  y)
+void CKCTY(amrex::Real *  c, amrex::Real *  y)
 {
-    double CW = 0; /*See Eq 12 in CK Manual */
+    amrex::Real CW = 0; /*See Eq 12 in CK Manual */
     /*compute denominator in eq 12 first */
     CW += c[0]*31.998800; /*O2 */
     CW += c[1]*28.013400; /*N2 */
     /*Now compute conversion */
-    double CWinv = 1.0/CW;
+    amrex::Real CWinv = 1.0/CW;
     y[0] = c[0]*31.998800*CWinv; 
     y[1] = c[1]*28.013400*CWinv; 
 
@@ -707,41 +707,41 @@ void CKCTY(double *  c, double *  y)
 
 /*get Cp/R as a function of T  */
 /*for all species (Eq 19) */
-void CKCPOR(double *  T, double *  cpor)
+void CKCPOR(amrex::Real *  T, amrex::Real *  cpor)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cp_R(cpor, tc);
 }
 
 
 /*get H/RT as a function of T  */
 /*for all species (Eq 20) */
-void CKHORT(double *  T, double *  hort)
+void CKHORT(amrex::Real *  T, amrex::Real *  hort)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEnthalpy(hort, tc);
 }
 
 
 /*get S/R as a function of T  */
 /*for all species (Eq 21) */
-void CKSOR(double *  T, double *  sor)
+void CKSOR(amrex::Real *  T, amrex::Real *  sor)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEntropy(sor, tc);
 }
 
 
 /*get specific heat at constant volume as a function  */
 /*of T for all species (molar units) */
-void CKCVML(double *  T,  double *  cvml)
+void CKCVML(amrex::Real *  T,  amrex::Real *  cvml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cv_R(cvml, tc);
 
     /*convert to chemkin units */
@@ -753,11 +753,11 @@ void CKCVML(double *  T,  double *  cvml)
 
 /*get specific heat at constant pressure as a  */
 /*function of T for all species (molar units) */
-void CKCPML(double *  T,  double *  cpml)
+void CKCPML(amrex::Real *  T,  amrex::Real *  cpml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cp_R(cpml, tc);
 
     /*convert to chemkin units */
@@ -769,12 +769,12 @@ void CKCPML(double *  T,  double *  cpml)
 
 /*get internal energy as a function  */
 /*of T for all species (molar units) */
-void CKUML(double *  T,  double *  uml)
+void CKUML(amrex::Real *  T,  amrex::Real *  uml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(uml, tc);
 
     /*convert to chemkin units */
@@ -786,12 +786,12 @@ void CKUML(double *  T,  double *  uml)
 
 /*get enthalpy as a function  */
 /*of T for all species (molar units) */
-void CKHML(double *  T,  double *  hml)
+void CKHML(amrex::Real *  T,  amrex::Real *  hml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hml, tc);
 
     /*convert to chemkin units */
@@ -803,12 +803,12 @@ void CKHML(double *  T,  double *  hml)
 
 /*get standard-state Gibbs energy as a function  */
 /*of T for all species (molar units) */
-void CKGML(double *  T,  double *  gml)
+void CKGML(amrex::Real *  T,  amrex::Real *  gml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     gibbs(gml, tc);
 
     /*convert to chemkin units */
@@ -820,12 +820,12 @@ void CKGML(double *  T,  double *  gml)
 
 /*get standard-state Helmholtz free energy as a  */
 /*function of T for all species (molar units) */
-void CKAML(double *  T,  double *  aml)
+void CKAML(amrex::Real *  T,  amrex::Real *  aml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     helmholtz(aml, tc);
 
     /*convert to chemkin units */
@@ -836,11 +836,11 @@ void CKAML(double *  T,  double *  aml)
 
 
 /*Returns the standard-state entropies in molar units */
-void CKSML(double *  T,  double *  sml)
+void CKSML(amrex::Real *  T,  amrex::Real *  sml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEntropy(sml, tc);
 
     /*convert to chemkin units */
@@ -852,10 +852,10 @@ void CKSML(double *  T,  double *  sml)
 
 /*Returns the specific heats at constant volume */
 /*in mass units (Eq. 29) */
-AMREX_GPU_HOST_DEVICE void CKCVMS(double *  T,  double *  cvms)
+AMREX_GPU_HOST_DEVICE void CKCVMS(amrex::Real *  T,  amrex::Real *  cvms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cv_R(cvms, tc);
     /*multiply by R/molecularweight */
     cvms[0] *= 2.598367006935648e+06; /*O2 */
@@ -865,10 +865,10 @@ AMREX_GPU_HOST_DEVICE void CKCVMS(double *  T,  double *  cvms)
 
 /*Returns the specific heats at constant pressure */
 /*in mass units (Eq. 26) */
-AMREX_GPU_HOST_DEVICE void CKCPMS(double *  T,  double *  cpms)
+AMREX_GPU_HOST_DEVICE void CKCPMS(amrex::Real *  T,  amrex::Real *  cpms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cp_R(cpms, tc);
     /*multiply by R/molecularweight */
     cpms[0] *= 2.598367006935648e+06; /*O2 */
@@ -877,11 +877,11 @@ AMREX_GPU_HOST_DEVICE void CKCPMS(double *  T,  double *  cpms)
 
 
 /*Returns internal energy in mass units (Eq 30.) */
-AMREX_GPU_HOST_DEVICE void CKUMS(double *  T,  double *  ums)
+AMREX_GPU_HOST_DEVICE void CKUMS(amrex::Real *  T,  amrex::Real *  ums)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(ums, tc);
     for (int i = 0; i < 2; i++)
     {
@@ -891,11 +891,11 @@ AMREX_GPU_HOST_DEVICE void CKUMS(double *  T,  double *  ums)
 
 
 /*Returns enthalpy in mass units (Eq 27.) */
-AMREX_GPU_HOST_DEVICE void CKHMS(double *  T,  double *  hms)
+AMREX_GPU_HOST_DEVICE void CKHMS(amrex::Real *  T,  amrex::Real *  hms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hms, tc);
     for (int i = 0; i < 2; i++)
     {
@@ -906,9 +906,9 @@ AMREX_GPU_HOST_DEVICE void CKHMS(double *  T,  double *  hms)
 
 #ifndef AMREX_USE_CUDA
 /*Returns enthalpy in mass units (Eq 27.) */
-void VCKHMS(int *  np, double *  T,  double *  hms)
+void VCKHMS(int *  np, amrex::Real *  T,  amrex::Real *  hms)
 {
-    double tc[5], h[2];
+    amrex::Real tc[5], h[2];
 
     for (int i=0; i<(*np); i++) {
         tc[0] = 0.0;
@@ -931,18 +931,18 @@ void VCKHMS(int *  np, double *  T,  double *  hms)
 }
 #else
 /*TODO: remove this on GPU */
-void VCKHMS(int *  np, double *  T,  double *  hms)
+void VCKHMS(int *  np, amrex::Real *  T,  amrex::Real *  hms)
 {
 }
 #endif
 
 
 /*Returns gibbs in mass units (Eq 31.) */
-void CKGMS(double *  T,  double *  gms)
+void CKGMS(amrex::Real *  T,  amrex::Real *  gms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     gibbs(gms, tc);
     for (int i = 0; i < 2; i++)
     {
@@ -952,11 +952,11 @@ void CKGMS(double *  T,  double *  gms)
 
 
 /*Returns helmholtz in mass units (Eq 32.) */
-void CKAMS(double *  T,  double *  ams)
+void CKAMS(amrex::Real *  T,  amrex::Real *  ams)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     helmholtz(ams, tc);
     for (int i = 0; i < 2; i++)
     {
@@ -966,10 +966,10 @@ void CKAMS(double *  T,  double *  ams)
 
 
 /*Returns the entropies in mass units (Eq 28.) */
-void CKSMS(double *  T,  double *  sms)
+void CKSMS(amrex::Real *  T,  amrex::Real *  sms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEntropy(sms, tc);
     /*multiply by R/molecularweight */
     sms[0] *= 2.598367006935648e+06; /*O2 */
@@ -978,13 +978,13 @@ void CKSMS(double *  T,  double *  sms)
 
 
 /*Returns the mean specific heat at CP (Eq. 33) */
-void CKCPBL(double *  T, double *  x,  double *  cpbl)
+void CKCPBL(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  cpbl)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cpor[2]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cpor[2]; /* temporary storage */
     cp_R(cpor, tc);
 
     /*perform dot product */
@@ -997,12 +997,12 @@ void CKCPBL(double *  T, double *  x,  double *  cpbl)
 
 
 /*Returns the mean specific heat at CP (Eq. 34) */
-AMREX_GPU_HOST_DEVICE void CKCPBS(double *  T, double *  y,  double *  cpbs)
+AMREX_GPU_HOST_DEVICE void CKCPBS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  cpbs)
 {
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cpor[2], tresult[2]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cpor[2], tresult[2]; /* temporary storage */
     cp_R(cpor, tc);
     for (int i = 0; i < 2; i++)
     {
@@ -1019,13 +1019,13 @@ AMREX_GPU_HOST_DEVICE void CKCPBS(double *  T, double *  y,  double *  cpbs)
 
 
 /*Returns the mean specific heat at CV (Eq. 35) */
-void CKCVBL(double *  T, double *  x,  double *  cvbl)
+void CKCVBL(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  cvbl)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cvor[2]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cvor[2]; /* temporary storage */
     cv_R(cvor, tc);
 
     /*perform dot product */
@@ -1038,12 +1038,12 @@ void CKCVBL(double *  T, double *  x,  double *  cvbl)
 
 
 /*Returns the mean specific heat at CV (Eq. 36) */
-AMREX_GPU_HOST_DEVICE void CKCVBS(double *  T, double *  y,  double *  cvbs)
+AMREX_GPU_HOST_DEVICE void CKCVBS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  cvbs)
 {
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cvor[2]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cvor[2]; /* temporary storage */
     cv_R(cvor, tc);
     /*multiply by y/molecularweight */
     result += cvor[0]*y[0]*imw[0]; /*O2 */
@@ -1054,14 +1054,14 @@ AMREX_GPU_HOST_DEVICE void CKCVBS(double *  T, double *  y,  double *  cvbs)
 
 
 /*Returns the mean enthalpy of the mixture in molar units */
-void CKHBML(double *  T, double *  x,  double *  hbml)
+void CKHBML(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  hbml)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double hml[2]; /* temporary storage */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real hml[2]; /* temporary storage */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hml, tc);
 
     /*perform dot product */
@@ -1074,13 +1074,13 @@ void CKHBML(double *  T, double *  x,  double *  hbml)
 
 
 /*Returns mean enthalpy of mixture in mass units */
-AMREX_GPU_HOST_DEVICE void CKHBMS(double *  T, double *  y,  double *  hbms)
+AMREX_GPU_HOST_DEVICE void CKHBMS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  hbms)
 {
-    double result = 0;
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double hml[2], tmp[2]; /* temporary storage */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0;
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real hml[2], tmp[2]; /* temporary storage */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hml, tc);
     int id;
     for (id = 0; id < 2; ++id) {
@@ -1095,14 +1095,14 @@ AMREX_GPU_HOST_DEVICE void CKHBMS(double *  T, double *  y,  double *  hbms)
 
 
 /*get mean internal energy in molar units */
-void CKUBML(double *  T, double *  x,  double *  ubml)
+void CKUBML(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  ubml)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double uml[2]; /* temporary energy array */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real uml[2]; /* temporary energy array */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(uml, tc);
 
     /*perform dot product */
@@ -1115,13 +1115,13 @@ void CKUBML(double *  T, double *  x,  double *  ubml)
 
 
 /*get mean internal energy in mass units */
-AMREX_GPU_HOST_DEVICE void CKUBMS(double *  T, double *  y,  double *  ubms)
+AMREX_GPU_HOST_DEVICE void CKUBMS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  ubms)
 {
-    double result = 0;
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double ums[2]; /* temporary energy array */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0;
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real ums[2]; /* temporary energy array */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(ums, tc);
     /*perform dot product + scaling by wt */
     result += y[0]*ums[0]*imw[0]; /*O2 */
@@ -1132,15 +1132,15 @@ AMREX_GPU_HOST_DEVICE void CKUBMS(double *  T, double *  y,  double *  ubms)
 
 
 /*get mixture entropy in molar units */
-void CKSBML(double *  P, double *  T, double *  x,  double *  sbml)
+void CKSBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  sbml)
 {
     int id; /*loop counter */
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double sor[2]; /* temporary storage */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real sor[2]; /* temporary storage */
     speciesEntropy(sor, tc);
 
     /*Compute Eq 42 */
@@ -1153,16 +1153,16 @@ void CKSBML(double *  P, double *  T, double *  x,  double *  sbml)
 
 
 /*get mixture entropy in mass units */
-void CKSBMS(double *  P, double *  T, double *  y,  double *  sbms)
+void CKSBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  sbms)
 {
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double sor[2]; /* temporary storage */
-    double x[2]; /* need a ytx conversion */
-    double YOW = 0; /*See Eq 4, 6 in CK Manual */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real sor[2]; /* temporary storage */
+    amrex::Real x[2]; /* need a ytx conversion */
+    amrex::Real YOW = 0; /*See Eq 4, 6 in CK Manual */
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*O2 */
     YOW += y[1]*imw[1]; /*N2 */
@@ -1179,16 +1179,16 @@ void CKSBMS(double *  P, double *  T, double *  y,  double *  sbms)
 
 
 /*Returns mean gibbs free energy in molar units */
-void CKGBML(double *  P, double *  T, double *  x,  double *  gbml)
+void CKGBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  gbml)
 {
     int id; /*loop counter */
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double gort[2]; /* temporary storage */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real gort[2]; /* temporary storage */
     /*Compute g/RT */
     gibbs(gort, tc);
 
@@ -1202,17 +1202,17 @@ void CKGBML(double *  P, double *  T, double *  x,  double *  gbml)
 
 
 /*Returns mixture gibbs free energy in mass units */
-void CKGBMS(double *  P, double *  T, double *  y,  double *  gbms)
+void CKGBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  gbms)
 {
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double gort[2]; /* temporary storage */
-    double x[2]; /* need a ytx conversion */
-    double YOW = 0; /*To hold 1/molecularweight */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real gort[2]; /* temporary storage */
+    amrex::Real x[2]; /* need a ytx conversion */
+    amrex::Real YOW = 0; /*To hold 1/molecularweight */
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*O2 */
     YOW += y[1]*imw[1]; /*N2 */
@@ -1229,16 +1229,16 @@ void CKGBMS(double *  P, double *  T, double *  y,  double *  gbms)
 
 
 /*Returns mean helmholtz free energy in molar units */
-void CKABML(double *  P, double *  T, double *  x,  double *  abml)
+void CKABML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  abml)
 {
     int id; /*loop counter */
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double aort[2]; /* temporary storage */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real aort[2]; /* temporary storage */
     /*Compute g/RT */
     helmholtz(aort, tc);
 
@@ -1252,17 +1252,17 @@ void CKABML(double *  P, double *  T, double *  x,  double *  abml)
 
 
 /*Returns mixture helmholtz free energy in mass units */
-void CKABMS(double *  P, double *  T, double *  y,  double *  abms)
+void CKABMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  abms)
 {
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double aort[2]; /* temporary storage */
-    double x[2]; /* need a ytx conversion */
-    double YOW = 0; /*To hold 1/molecularweight */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real aort[2]; /* temporary storage */
+    amrex::Real x[2]; /* need a ytx conversion */
+    amrex::Real YOW = 0; /*To hold 1/molecularweight */
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*O2 */
     YOW += y[1]*imw[1]; /*N2 */
@@ -1279,7 +1279,7 @@ void CKABMS(double *  P, double *  T, double *  y,  double *  abms)
 
 
 /*compute the production rate for each species */
-AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C,  double *  wdot)
+AMREX_GPU_HOST_DEVICE void CKWC(amrex::Real *  T, amrex::Real *  C,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
 
@@ -1301,12 +1301,12 @@ AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C,  double *  wdot)
 
 /*Returns the molar production rate of species */
 /*Given P, T, and mass fractions */
-void CKWYP(double *  P, double *  T, double *  y,  double *  wdot)
+void CKWYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[2]; /*temporary storage */
-    double YOW = 0; 
-    double PWORT; 
+    amrex::Real c[2]; /*temporary storage */
+    amrex::Real YOW = 0; 
+    amrex::Real PWORT; 
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*O2 */
     YOW += y[1]*imw[1]; /*N2 */
@@ -1330,11 +1330,11 @@ void CKWYP(double *  P, double *  T, double *  y,  double *  wdot)
 
 /*Returns the molar production rate of species */
 /*Given P, T, and mole fractions */
-void CKWXP(double *  P, double *  T, double *  x,  double *  wdot)
+void CKWXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[2]; /*temporary storage */
-    double PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
+    amrex::Real c[2]; /*temporary storage */
+    amrex::Real PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 2; ++id) {
@@ -1353,10 +1353,10 @@ void CKWXP(double *  P, double *  T, double *  x,  double *  wdot)
 
 /*Returns the molar production rate of species */
 /*Given rho, T, and mass fractions */
-AMREX_GPU_HOST_DEVICE void CKWYR(double *  rho, double *  T, double *  y,  double *  wdot)
+AMREX_GPU_HOST_DEVICE void CKWYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[2]; /*temporary storage */
+    amrex::Real c[2]; /*temporary storage */
     /*See Eq 8 with an extra 1e6 so c goes to SI */
     c[0] = 1e6 * (*rho) * y[0]*imw[0]; 
     c[1] = 1e6 * (*rho) * y[1]*imw[1]; 
@@ -1373,12 +1373,12 @@ AMREX_GPU_HOST_DEVICE void CKWYR(double *  rho, double *  T, double *  y,  doubl
 
 /*Returns the molar production rate of species */
 /*Given rho, T, and mass fractions */
-void VCKWYR(int *  np, double *  rho, double *  T,
-	    double *  y,
-	    double *  wdot)
+void VCKWYR(int *  np, amrex::Real *  rho, amrex::Real *  T,
+	    amrex::Real *  y,
+	    amrex::Real *  wdot)
 {
 #ifndef AMREX_USE_CUDA
-    double c[2*(*np)]; /*temporary storage */
+    amrex::Real c[2*(*np)]; /*temporary storage */
     /*See Eq 8 with an extra 1e6 so c goes to SI */
     for (int n=0; n<2; n++) {
         for (int i=0; i<(*np); i++) {
@@ -1399,12 +1399,12 @@ void VCKWYR(int *  np, double *  rho, double *  T,
 
 /*Returns the molar production rate of species */
 /*Given rho, T, and mole fractions */
-void CKWXR(double *  rho, double *  T, double *  x,  double *  wdot)
+void CKWXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[2]; /*temporary storage */
-    double XW = 0; /*See Eq 4, 11 in CK Manual */
-    double ROW; 
+    amrex::Real c[2]; /*temporary storage */
+    amrex::Real XW = 0; /*See Eq 4, 11 in CK Manual */
+    amrex::Real ROW; 
     /*Compute mean molecular wt first */
     XW += x[0]*31.998800; /*O2 */
     XW += x[1]*28.013400; /*N2 */
@@ -1427,7 +1427,7 @@ void CKWXR(double *  rho, double *  T, double *  x,  double *  wdot)
 
 
 /*Returns the rate of progress for each reaction */
-void CKQC(double *  T, double *  C, double *  qdot)
+void CKQC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  qdot)
 {
     int id; /*loop counter */
 
@@ -1452,11 +1452,11 @@ void CKQC(double *  T, double *  C, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given P, T, and mole fractions */
-void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r)
+void CKKFKR(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  q_f, amrex::Real *  q_r)
 {
     int id; /*loop counter */
-    double c[2]; /*temporary storage */
-    double PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
+    amrex::Real c[2]; /*temporary storage */
+    amrex::Real PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 2; ++id) {
@@ -1476,12 +1476,12 @@ void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r)
 
 /*Returns the progress rates of each reactions */
 /*Given P, T, and mass fractions */
-void CKQYP(double *  P, double *  T, double *  y, double *  qdot)
+void CKQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[2]; /*temporary storage */
-    double YOW = 0; 
-    double PWORT; 
+    amrex::Real c[2]; /*temporary storage */
+    amrex::Real YOW = 0; 
+    amrex::Real PWORT; 
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*O2 */
     YOW += y[1]*imw[1]; /*N2 */
@@ -1505,11 +1505,11 @@ void CKQYP(double *  P, double *  T, double *  y, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given P, T, and mole fractions */
-void CKQXP(double *  P, double *  T, double *  x, double *  qdot)
+void CKQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[2]; /*temporary storage */
-    double PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
+    amrex::Real c[2]; /*temporary storage */
+    amrex::Real PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 2; ++id) {
@@ -1528,10 +1528,10 @@ void CKQXP(double *  P, double *  T, double *  x, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given rho, T, and mass fractions */
-void CKQYR(double *  rho, double *  T, double *  y, double *  qdot)
+void CKQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[2]; /*temporary storage */
+    amrex::Real c[2]; /*temporary storage */
     /*See Eq 8 with an extra 1e6 so c goes to SI */
     c[0] = 1e6 * (*rho) * y[0]*imw[0]; 
     c[1] = 1e6 * (*rho) * y[1]*imw[1]; 
@@ -1548,12 +1548,12 @@ void CKQYR(double *  rho, double *  T, double *  y, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given rho, T, and mole fractions */
-void CKQXR(double *  rho, double *  T, double *  x, double *  qdot)
+void CKQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[2]; /*temporary storage */
-    double XW = 0; /*See Eq 4, 11 in CK Manual */
-    double ROW; 
+    amrex::Real c[2]; /*temporary storage */
+    amrex::Real XW = 0; /*See Eq 4, 11 in CK Manual */
+    amrex::Real ROW; 
     /*Compute mean molecular wt first */
     XW += x[0]*31.998800; /*O2 */
     XW += x[1]*28.013400; /*N2 */
@@ -1633,7 +1633,7 @@ void CKNCF(int * ncf)
 
 /*Returns the arrehenius coefficients  */
 /*for all reactions */
-void CKABE( double *  a, double *  b, double *  e)
+void CKABE( amrex::Real *  a, amrex::Real *  b, amrex::Real *  e)
 {
 
     return;
@@ -1641,11 +1641,11 @@ void CKABE( double *  a, double *  b, double *  e)
 
 
 /*Returns the equil constants for each reaction */
-void CKEQC(double *  T, double *  C, double *  eqcon)
+void CKEQC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[2]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[2]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -1657,11 +1657,11 @@ void CKEQC(double *  T, double *  C, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given P, T, and mass fractions */
-void CKEQYP(double *  P, double *  T, double *  y, double *  eqcon)
+void CKEQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[2]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[2]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -1673,11 +1673,11 @@ void CKEQYP(double *  P, double *  T, double *  y, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given P, T, and mole fractions */
-void CKEQXP(double *  P, double *  T, double *  x, double *  eqcon)
+void CKEQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[2]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[2]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -1689,11 +1689,11 @@ void CKEQXP(double *  P, double *  T, double *  x, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given rho, T, and mass fractions */
-void CKEQYR(double *  rho, double *  T, double *  y, double *  eqcon)
+void CKEQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[2]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[2]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -1705,11 +1705,11 @@ void CKEQYR(double *  rho, double *  T, double *  y, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given rho, T, and mole fractions */
-void CKEQXR(double *  rho, double *  T, double *  x, double *  eqcon)
+void CKEQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[2]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[2]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -1721,10 +1721,10 @@ void CKEQXR(double *  rho, double *  T, double *  x, double *  eqcon)
 #ifdef AMREX_USE_CUDA
 /*GPU version of productionRate: no more use of thermo namespace vectors */
 /*compute the production rate for each species */
-AMREX_GPU_HOST_DEVICE inline void  productionRate(double * wdot, double * sc, double T)
+AMREX_GPU_HOST_DEVICE inline void  productionRate(amrex::Real * wdot, amrex::Real * sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 
 
     for (int i = 0; i < 2; ++i) {
@@ -1734,7 +1734,7 @@ AMREX_GPU_HOST_DEVICE inline void  productionRate(double * wdot, double * sc, do
     return;
 }
 
-AMREX_GPU_HOST_DEVICE inline void comp_qfqr(double *  qf, double * qr, double * sc, double * tc, double invT)
+AMREX_GPU_HOST_DEVICE inline void comp_qfqr(amrex::Real *  qf, amrex::Real * qr, amrex::Real * sc, amrex::Real * tc, amrex::Real invT)
 {
 
     return;
@@ -1743,27 +1743,27 @@ AMREX_GPU_HOST_DEVICE inline void comp_qfqr(double *  qf, double * qr, double * 
 
 
 #ifndef AMREX_USE_CUDA
-static double T_save = -1;
+static amrex::Real T_save = -1;
 #ifdef _OPENMP
 #pragma omp threadprivate(T_save)
 #endif
 
-static double k_f_save[0];
+static amrex::Real k_f_save[0];
 #ifdef _OPENMP
 #pragma omp threadprivate(k_f_save)
 #endif
 
-static double Kc_save[0];
+static amrex::Real Kc_save[0];
 #ifdef _OPENMP
 #pragma omp threadprivate(Kc_save)
 #endif
 
 
 /*compute the production rate for each species pointwise on CPU */
-void productionRate(double *  wdot, double *  sc, double T)
+void productionRate(amrex::Real *  wdot, amrex::Real *  sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 
     if (T != T_save)
     {
@@ -1772,7 +1772,7 @@ void productionRate(double *  wdot, double *  sc, double T)
         comp_Kc(tc,invT,Kc_save);
     }
 
-    double qdot, q_f[0], q_r[0];
+    amrex::Real qdot, q_f[0], q_r[0];
     comp_qfqr(q_f, q_r, sc, tc, invT);
 
     for (int i = 0; i < 2; ++i) {
@@ -1782,7 +1782,7 @@ void productionRate(double *  wdot, double *  sc, double T)
     return;
 }
 
-void comp_k_f(double *  tc, double invT, double *  k_f)
+void comp_k_f(amrex::Real *  tc, amrex::Real invT, amrex::Real *  k_f)
 {
     for (int i=0; i<0; ++i) {
         k_f[i] = prefactor_units[i] * fwd_A[i]
@@ -1791,10 +1791,10 @@ void comp_k_f(double *  tc, double invT, double *  k_f)
     return;
 }
 
-void comp_Kc(double *  tc, double invT, double *  Kc)
+void comp_Kc(amrex::Real *  tc, amrex::Real invT, amrex::Real *  Kc)
 {
     /*compute the Gibbs free energy */
-    double g_RT[2];
+    amrex::Real g_RT[2];
     gibbs(g_RT, tc);
 
 
@@ -1803,25 +1803,25 @@ void comp_Kc(double *  tc, double invT, double *  Kc)
     };
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 * invT;
-    double refCinv = 1 / refC;
+    amrex::Real refC = 101325 / 8.31446 * invT;
+    amrex::Real refCinv = 1 / refC;
 
 
     return;
 }
 
-void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double invT)
+void comp_qfqr(amrex::Real *  qf, amrex::Real *  qr, amrex::Real *  sc, amrex::Real *  tc, amrex::Real invT)
 {
 
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int i = 0; i < 2; ++i) {
         mixture += sc[i];
     }
 
-    double Corr[0];
+    amrex::Real Corr[0];
     for (int i = 0; i < 0; ++i) {
         Corr[i] = 1.0;
     }
@@ -1839,10 +1839,10 @@ void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double in
 
 #ifndef AMREX_USE_CUDA
 /*compute the production rate for each species */
-void vproductionRate(int npt, double *  wdot, double *  sc, double *  T)
+void vproductionRate(int npt, amrex::Real *  wdot, amrex::Real *  sc, amrex::Real *  T)
 {
-    double k_f_s[0*npt], Kc_s[0*npt], mixture[npt], g_RT[2*npt];
-    double tc[5*npt], invT[npt];
+    amrex::Real k_f_s[0*npt], Kc_s[0*npt], mixture[npt], g_RT[2*npt];
+    amrex::Real tc[5*npt], invT[npt];
 
     for (int i=0; i<npt; i++) {
         tc[0*npt+i] = log(T[i]);
@@ -1873,17 +1873,17 @@ void vproductionRate(int npt, double *  wdot, double *  sc, double *  T)
     vcomp_wdot(npt, wdot, mixture, sc, k_f_s, Kc_s, tc, invT, T);
 }
 
-void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT)
+void vcomp_k_f(int npt, amrex::Real *  k_f_s, amrex::Real *  tc, amrex::Real *  invT)
 {
     for (int i=0; i<npt; i++) {
     }
 }
 
-void vcomp_gibbs(int npt, double *  g_RT, double *  tc)
+void vcomp_gibbs(int npt, amrex::Real *  g_RT, amrex::Real *  tc)
 {
     /*compute the Gibbs free energy */
     for (int i=0; i<npt; i++) {
-        double tg[5], g[2];
+        amrex::Real tg[5], g[2];
         tg[0] = tc[0*npt+i];
         tg[1] = tc[1*npt+i];
         tg[2] = tc[2*npt+i];
@@ -1897,31 +1897,31 @@ void vcomp_gibbs(int npt, double *  g_RT, double *  tc)
     }
 }
 
-void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT)
+void vcomp_Kc(int npt, amrex::Real *  Kc_s, amrex::Real *  g_RT, amrex::Real *  invT)
 {
     for (int i=0; i<npt; i++) {
         /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-        double refC = (101325. / 8.31451) * invT[i];
-        double refCinv = 1.0 / refC;
+        amrex::Real refC = (101325. / 8.31451) * invT[i];
+        amrex::Real refCinv = 1.0 / refC;
 
     }
 }
 
-void vcomp_wdot(int npt, double *  wdot, double *  mixture, double *  sc,
-		double *  k_f_s, double *  Kc_s,
-		double *  tc, double *  invT, double *  T)
+void vcomp_wdot(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,
+		amrex::Real *  k_f_s, amrex::Real *  Kc_s,
+		amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T)
 {
     for (int i=0; i<npt; i++) {
-        double qdot, q_f, q_r, phi_f, phi_r, k_f, k_r, Kc;
-        double alpha;
+        amrex::Real qdot, q_f, q_r, phi_f, phi_r, k_f, k_r, Kc;
+        amrex::Real alpha;
     }
 }
 #endif
 
 /*compute an approx to the reaction Jacobian (for preconditioning) */
-AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double *  Tp, int * HP)
+AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * HP)
 {
-    double c[2];
+    amrex::Real c[2];
 
     for (int k=0; k<2; k++) {
         c[k] = 1.e6 * sc[k];
@@ -1940,9 +1940,9 @@ AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double * 
 }
 
 /*compute the reaction Jacobian */
-AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  Tp, int * consP)
+AMREX_GPU_HOST_DEVICE void DWDOT(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * consP)
 {
-    double c[2];
+    amrex::Real c[2];
 
     for (int k=0; k<2; k++) {
         c[k] = 1.e6 * sc[k];
@@ -1963,8 +1963,8 @@ AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  Tp, int * 
 /*compute the sparsity pattern of the chemistry Jacobian */
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO( int * nJdata, int * consP, int NCELLS)
 {
-    double c[2];
-    double J[9];
+    amrex::Real c[2];
+    amrex::Real J[9];
 
     for (int k=0; k<2; k++) {
         c[k] = 1.0/ 2.000000 ;
@@ -1991,8 +1991,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_INFO( int * nJdata, int * consP, int NCELLS)
 /*compute the sparsity pattern of the system Jacobian */
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST( int * nJdata, int * consP, int NCELLS)
 {
-    double c[2];
-    double J[9];
+    amrex::Real c[2];
+    amrex::Real J[9];
 
     for (int k=0; k<2; k++) {
         c[k] = 1.0/ 2.000000 ;
@@ -2023,8 +2023,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST( int * nJdata, int * consP, int NC
 /*compute the sparsity pattern of the simplified (for preconditioning) system Jacobian */
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED( int * nJdata, int * consP)
 {
-    double c[2];
-    double J[9];
+    amrex::Real c[2];
+    amrex::Real J[9];
 
     for (int k=0; k<2; k++) {
         c[k] = 1.0/ 2.000000 ;
@@ -2054,8 +2054,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED( int * nJdata, int * co
 /*compute the sparsity pattern of the chemistry Jacobian in CSC format -- base 0 */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSC(int *  rowVals, int *  colPtrs, int * consP, int NCELLS)
 {
-    double c[2];
-    double J[9];
+    amrex::Real c[2];
+    amrex::Real J[9];
     int offset_row;
     int offset_col;
 
@@ -2087,8 +2087,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSC(int *  rowVals, int *  colPtrs, 
 /*compute the sparsity pattern of the chemistry Jacobian in CSR format -- base 0 */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSR(int * colVals, int * rowPtrs, int * consP, int NCELLS, int base)
 {
-    double c[2];
-    double J[9];
+    amrex::Real c[2];
+    amrex::Real J[9];
     int offset;
 
     for (int k=0; k<2; k++) {
@@ -2136,8 +2136,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSR(int * colVals, int * rowPtrs, in
 /*CSR format BASE is user choice */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtr, int * consP, int NCELLS, int base)
 {
-    double c[2];
-    double J[9];
+    amrex::Real c[2];
+    amrex::Real J[9];
     int offset;
 
     for (int k=0; k<2; k++) {
@@ -2195,8 +2195,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtr
 /*BASE 0 */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, int * colPtrs, int * indx, int * consP)
 {
-    double c[2];
-    double J[9];
+    amrex::Real c[2];
+    amrex::Real J[9];
 
     for (int k=0; k<2; k++) {
         c[k] = 1.0/ 2.000000 ;
@@ -2230,8 +2230,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, i
 /*CSR format BASE is under choice */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, int * rowPtr, int * consP, int base)
 {
-    double c[2];
-    double J[9];
+    amrex::Real c[2];
+    amrex::Real J[9];
 
     for (int k=0; k<2; k++) {
         c[k] = 1.0/ 2.000000 ;
@@ -2282,7 +2282,7 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, i
 #ifdef AMREX_USE_CUDA
 /*compute the reaction Jacobian on GPU */
 AMREX_GPU_HOST_DEVICE
-void aJacobian(double * J, double * sc, double T, int consP)
+void aJacobian(amrex::Real * J, amrex::Real * sc, amrex::Real T, int consP)
 {
 
 
@@ -2290,45 +2290,45 @@ void aJacobian(double * J, double * sc, double T, int consP)
         J[i] = 0.0;
     }
 
-    double wdot[2];
+    amrex::Real wdot[2];
     for (int k=0; k<2; k++) {
         wdot[k] = 0.0;
     }
 
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
-    double invT2 = invT * invT;
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
+    amrex::Real invT2 = invT * invT;
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
-    double refCinv = 1.0 / refC;
+    amrex::Real refC = 101325 / 8.31446 / T;
+    amrex::Real refCinv = 1.0 / refC;
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int k = 0; k < 2; ++k) {
         mixture += sc[k];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[2];
+    amrex::Real g_RT[2];
     gibbs(g_RT, tc);
 
     /*compute the species enthalpy */
-    double h_RT[2];
+    amrex::Real h_RT[2];
     speciesEnthalpy(h_RT, tc);
 
-    double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
-    double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
-    double dqdci, dcdc_fac, dqdc[2];
-    double Pr, fPr, F, k_0, logPr;
-    double logFcent, troe_c, troe_n, troePr_den, troePr, troe;
-    double Fcent1, Fcent2, Fcent3, Fcent;
-    double dlogFdc, dlogFdn, dlogFdcn_fac;
-    double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
-    const double ln10 = log(10.0);
-    const double log10e = 1.0/log(10.0);
-    double c_R[2], dcRdT[2], e_RT[2];
-    double * eh_RT;
+    amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
+    amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
+    amrex::Real dqdci, dcdc_fac, dqdc[2];
+    amrex::Real Pr, fPr, F, k_0, logPr;
+    amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;
+    amrex::Real Fcent1, Fcent2, Fcent3, Fcent;
+    amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;
+    amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
+    const amrex::Real ln10 = log(10.0);
+    const amrex::Real log10e = 1.0/log(10.0);
+    amrex::Real c_R[2], dcRdT[2], e_RT[2];
+    amrex::Real * eh_RT;
     if (consP) {
         cp_R(c_R, tc);
         dcvpRdT(dcRdT, tc);
@@ -2341,7 +2341,7 @@ void aJacobian(double * J, double * sc, double T, int consP)
         eh_RT = &e_RT[0];
     }
 
-    double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
+    amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
     for (int k = 0; k < 2; ++k) {
         cmix += c_R[k]*sc[k];
         dcmixdT += dcRdT[k]*sc[k];
@@ -2349,11 +2349,11 @@ void aJacobian(double * J, double * sc, double T, int consP)
         dehmixdT += invT*(c_R[k]-eh_RT[k])*wdot[k] + eh_RT[k]*J[6+k];
     }
 
-    double cmixinv = 1.0/cmix;
-    double tmp1 = ehmix*cmixinv;
-    double tmp3 = cmixinv*T;
-    double tmp2 = tmp1*tmp3;
-    double dehmixdc;
+    amrex::Real cmixinv = 1.0/cmix;
+    amrex::Real tmp1 = ehmix*cmixinv;
+    amrex::Real tmp3 = cmixinv*T;
+    amrex::Real tmp2 = tmp1*tmp3;
+    amrex::Real dehmixdc;
     /* dTdot/d[X] */
     for (int k = 0; k < 2; ++k) {
         dehmixdc = 0.0;
@@ -2372,51 +2372,51 @@ return;
 
 #ifndef AMREX_USE_CUDA
 /*compute the reaction Jacobian on CPU */
-void aJacobian(double *  J, double *  sc, double T, int consP)
+void aJacobian(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int consP)
 {
     for (int i=0; i<9; i++) {
         J[i] = 0.0;
     }
 
-    double wdot[2];
+    amrex::Real wdot[2];
     for (int k=0; k<2; k++) {
         wdot[k] = 0.0;
     }
 
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
-    double invT2 = invT * invT;
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
+    amrex::Real invT2 = invT * invT;
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
-    double refCinv = 1.0 / refC;
+    amrex::Real refC = 101325 / 8.31446 / T;
+    amrex::Real refCinv = 1.0 / refC;
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int k = 0; k < 2; ++k) {
         mixture += sc[k];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[2];
+    amrex::Real g_RT[2];
     gibbs(g_RT, tc);
 
     /*compute the species enthalpy */
-    double h_RT[2];
+    amrex::Real h_RT[2];
     speciesEnthalpy(h_RT, tc);
 
-    double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
-    double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
-    double dqdci, dcdc_fac, dqdc[2];
-    double Pr, fPr, F, k_0, logPr;
-    double logFcent, troe_c, troe_n, troePr_den, troePr, troe;
-    double Fcent1, Fcent2, Fcent3, Fcent;
-    double dlogFdc, dlogFdn, dlogFdcn_fac;
-    double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
-    const double ln10 = log(10.0);
-    const double log10e = 1.0/log(10.0);
-    double c_R[2], dcRdT[2], e_RT[2];
-    double * eh_RT;
+    amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
+    amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
+    amrex::Real dqdci, dcdc_fac, dqdc[2];
+    amrex::Real Pr, fPr, F, k_0, logPr;
+    amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;
+    amrex::Real Fcent1, Fcent2, Fcent3, Fcent;
+    amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;
+    amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
+    const amrex::Real ln10 = log(10.0);
+    const amrex::Real log10e = 1.0/log(10.0);
+    amrex::Real c_R[2], dcRdT[2], e_RT[2];
+    amrex::Real * eh_RT;
     if (consP) {
         cp_R(c_R, tc);
         dcvpRdT(dcRdT, tc);
@@ -2429,7 +2429,7 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
         eh_RT = &e_RT[0];
     }
 
-    double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
+    amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
     for (int k = 0; k < 2; ++k) {
         cmix += c_R[k]*sc[k];
         dcmixdT += dcRdT[k]*sc[k];
@@ -2437,11 +2437,11 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
         dehmixdT += invT*(c_R[k]-eh_RT[k])*wdot[k] + eh_RT[k]*J[6+k];
     }
 
-    double cmixinv = 1.0/cmix;
-    double tmp1 = ehmix*cmixinv;
-    double tmp3 = cmixinv*T;
-    double tmp2 = tmp1*tmp3;
-    double dehmixdc;
+    amrex::Real cmixinv = 1.0/cmix;
+    amrex::Real tmp1 = ehmix*cmixinv;
+    amrex::Real tmp3 = cmixinv*T;
+    amrex::Real tmp2 = tmp1*tmp3;
+    amrex::Real dehmixdc;
     /* dTdot/d[X] */
     for (int k = 0; k < 2; ++k) {
         dehmixdc = 0.0;
@@ -2457,51 +2457,51 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
 
 
 /*compute an approx to the reaction Jacobian */
-AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T, int HP)
+AMREX_GPU_HOST_DEVICE void aJacobian_precond(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int HP)
 {
     for (int i=0; i<9; i++) {
         J[i] = 0.0;
     }
 
-    double wdot[2];
+    amrex::Real wdot[2];
     for (int k=0; k<2; k++) {
         wdot[k] = 0.0;
     }
 
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
-    double invT2 = invT * invT;
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
+    amrex::Real invT2 = invT * invT;
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
-    double refCinv = 1.0 / refC;
+    amrex::Real refC = 101325 / 8.31446 / T;
+    amrex::Real refCinv = 1.0 / refC;
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int k = 0; k < 2; ++k) {
         mixture += sc[k];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[2];
+    amrex::Real g_RT[2];
     gibbs(g_RT, tc);
 
     /*compute the species enthalpy */
-    double h_RT[2];
+    amrex::Real h_RT[2];
     speciesEnthalpy(h_RT, tc);
 
-    double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
-    double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
-    double dqdci, dcdc_fac, dqdc[2];
-    double Pr, fPr, F, k_0, logPr;
-    double logFcent, troe_c, troe_n, troePr_den, troePr, troe;
-    double Fcent1, Fcent2, Fcent3, Fcent;
-    double dlogFdc, dlogFdn, dlogFdcn_fac;
-    double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
-    const double ln10 = log(10.0);
-    const double log10e = 1.0/log(10.0);
-    double c_R[2], dcRdT[2], e_RT[2];
-    double * eh_RT;
+    amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
+    amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
+    amrex::Real dqdci, dcdc_fac, dqdc[2];
+    amrex::Real Pr, fPr, F, k_0, logPr;
+    amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;
+    amrex::Real Fcent1, Fcent2, Fcent3, Fcent;
+    amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;
+    amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
+    const amrex::Real ln10 = log(10.0);
+    const amrex::Real log10e = 1.0/log(10.0);
+    amrex::Real c_R[2], dcRdT[2], e_RT[2];
+    amrex::Real * eh_RT;
     if (HP) {
         cp_R(c_R, tc);
         dcvpRdT(dcRdT, tc);
@@ -2514,7 +2514,7 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
         eh_RT = &e_RT[0];
     }
 
-    double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
+    amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
     for (int k = 0; k < 2; ++k) {
         cmix += c_R[k]*sc[k];
         dcmixdT += dcRdT[k]*sc[k];
@@ -2522,11 +2522,11 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
         dehmixdT += invT*(c_R[k]-eh_RT[k])*wdot[k] + eh_RT[k]*J[6+k];
     }
 
-    double cmixinv = 1.0/cmix;
-    double tmp1 = ehmix*cmixinv;
-    double tmp3 = cmixinv*T;
-    double tmp2 = tmp1*tmp3;
-    double dehmixdc;
+    amrex::Real cmixinv = 1.0/cmix;
+    amrex::Real tmp1 = ehmix*cmixinv;
+    amrex::Real tmp3 = cmixinv*T;
+    amrex::Real tmp2 = tmp1*tmp3;
+    amrex::Real dehmixdc;
     /* dTdot/d[X] */
     for (int k = 0; k < 2; ++k) {
         dehmixdc = 0.0;
@@ -2542,11 +2542,11 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
 
 /*compute d(Cp/R)/dT and d(Cv/R)/dT at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void dcvpRdT(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void dcvpRdT(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -2581,10 +2581,10 @@ AMREX_GPU_HOST_DEVICE void dcvpRdT(double * species, double *  tc)
 
 
 /*compute the progress rate for each reaction */
-AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  sc, double T)
+AMREX_GPU_HOST_DEVICE void progressRate(amrex::Real *  qdot, amrex::Real *  sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 
 #ifndef AMREX_USE_CUDA
     if (T != T_save)
@@ -2601,17 +2601,17 @@ AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  sc, double T)
 
 
 /*compute the progress rate for each reaction */
-AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *  sc, double T)
+AMREX_GPU_HOST_DEVICE void progressRateFR(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  sc, amrex::Real T)
 {
     return;
 }
 
 
 /*compute the equilibrium constants for each reaction */
-void equilibriumConstants(double *  kc, double *  g_RT, double T)
+void equilibriumConstants(amrex::Real *  kc, amrex::Real *  g_RT, amrex::Real T)
 {
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
+    amrex::Real refC = 101325 / 8.31446 / T;
 
     return;
 }
@@ -2619,12 +2619,12 @@ void equilibriumConstants(double *  kc, double *  g_RT, double T)
 
 /*compute the g/(RT) at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void gibbs(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void gibbs(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -2672,12 +2672,12 @@ AMREX_GPU_HOST_DEVICE void gibbs(double * species, double *  tc)
 
 /*compute the a/(RT) at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void helmholtz(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void helmholtz(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -2725,11 +2725,11 @@ AMREX_GPU_HOST_DEVICE void helmholtz(double * species, double *  tc)
 
 /*compute Cv/R at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void cv_R(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void cv_R(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -2769,11 +2769,11 @@ AMREX_GPU_HOST_DEVICE void cv_R(double * species, double *  tc)
 
 /*compute Cp/R at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void cp_R(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void cp_R(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -2813,12 +2813,12 @@ AMREX_GPU_HOST_DEVICE void cp_R(double * species, double *  tc)
 
 /*compute the e/(RT) at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -2862,12 +2862,12 @@ AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double * species, double *  tc)
 
 /*compute the h/(RT) at the given temperature (Eq 20) */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void speciesEnthalpy(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -2911,11 +2911,11 @@ AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double * species, double *  tc)
 
 /*compute the S/R at the given temperature (Eq 21) */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void speciesEntropy(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void speciesEntropy(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -2958,7 +2958,7 @@ AMREX_GPU_HOST_DEVICE void speciesEntropy(double * species, double *  tc)
 
 
 /*save atomic weights into array */
-void atomicWeight(double *  awt)
+void atomicWeight(amrex::Real *  awt)
 {
     awt[0] = 15.999400; /*O */
     awt[1] = 14.006700; /*N */
@@ -2968,19 +2968,19 @@ void atomicWeight(double *  awt)
 
 
 /* get temperature given internal energy in mass units and mass fracs */
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t, int * ierr)
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(amrex::Real *  e, amrex::Real *  y, amrex::Real *  t, int * ierr)
 {
 #ifdef CONVERGENCE
     const int maxiter = 5000;
-    const double tol  = 1.e-12;
+    const amrex::Real tol  = 1.e-12;
 #else
     const int maxiter = 200;
-    const double tol  = 1.e-6;
+    const amrex::Real tol  = 1.e-6;
 #endif
-    double ein  = *e;
-    double tmin = 90;/*max lower bound for thermo def */
-    double tmax = 4000;/*min upper bound for thermo def */
-    double e1,emin,emax,cv,t1,dt;
+    amrex::Real ein  = *e;
+    amrex::Real tmin = 90;/*max lower bound for thermo def */
+    amrex::Real tmax = 4000;/*min upper bound for thermo def */
+    amrex::Real e1,emin,emax,cv,t1,dt;
     int i;/* loop counter */
     CKUBMS(&tmin, y, &emin);
     CKUBMS(&tmax, y, &emax);
@@ -3018,19 +3018,19 @@ AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t,
 }
 
 /* get temperature given enthalpy in mass units and mass fracs */
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t, int * ierr)
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(amrex::Real *  h, amrex::Real *  y, amrex::Real *  t, int * ierr)
 {
 #ifdef CONVERGENCE
     const int maxiter = 5000;
-    const double tol  = 1.e-12;
+    const amrex::Real tol  = 1.e-12;
 #else
     const int maxiter = 200;
-    const double tol  = 1.e-6;
+    const amrex::Real tol  = 1.e-6;
 #endif
-    double hin  = *h;
-    double tmin = 90;/*max lower bound for thermo def */
-    double tmax = 4000;/*min upper bound for thermo def */
-    double h1,hmin,hmax,cp,t1,dt;
+    amrex::Real hin  = *h;
+    amrex::Real tmin = 90;/*max lower bound for thermo def */
+    amrex::Real tmax = 4000;/*min upper bound for thermo def */
+    amrex::Real h1,hmin,hmax,cp,t1,dt;
     int i;/* loop counter */
     CKHBMS(&tmin, y, &hmin);
     CKHBMS(&tmax, y, &hmax);
@@ -3069,15 +3069,15 @@ AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t,
 
 
 /*compute the critical parameters for each species */
-void GET_CRITPARAMS(double *  Tci, double *  ai, double *  bi, double *  acentric_i)
+void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i)
 {
 
-    double   EPS[2];
-    double   SIG[2];
-    double    wt[2];
-    double avogadro = 6.02214199e23;
-    double boltzmann = 1.3806503e-16; //we work in CGS
-    double Rcst = 83.144598; //in bar [CGS] !
+    amrex::Real   EPS[2];
+    amrex::Real   SIG[2];
+    amrex::Real    wt[2];
+    amrex::Real avogadro = 6.02214199e23;
+    amrex::Real boltzmann = 1.3806503e-16; //we work in CGS
+    amrex::Real Rcst = 83.144598; //in bar [CGS] !
 
     egtransetEPS(EPS);
     egtransetSIG(SIG);
@@ -3122,47 +3122,47 @@ void egtransetNLITE(int* NLITE ) {
 
 
 /*Patm in ergs/cm3 */
-void egtransetPATM(double* PATM) {
+void egtransetPATM(amrex::Real* PATM) {
     *PATM =   0.1013250000000000E+07;}
 
 
 /*the molecular weights in g/mol */
-void egtransetWT(double* WT ) {
+void egtransetWT(amrex::Real* WT ) {
     WT[0] = 3.19988000E+01;
     WT[1] = 2.80134000E+01;
 }
 
 
 /*the lennard-jones potential well depth eps/kb in K */
-void egtransetEPS(double* EPS ) {
+void egtransetEPS(amrex::Real* EPS ) {
     EPS[0] = 1.07400000E+02;
     EPS[1] = 9.75300000E+01;
 }
 
 
 /*the lennard-jones collision diameter in Angstroms */
-void egtransetSIG(double* SIG ) {
+void egtransetSIG(amrex::Real* SIG ) {
     SIG[0] = 3.45800000E+00;
     SIG[1] = 3.62100000E+00;
 }
 
 
 /*the dipole moment in Debye */
-void egtransetDIP(double* DIP ) {
+void egtransetDIP(amrex::Real* DIP ) {
     DIP[0] = 0.00000000E+00;
     DIP[1] = 0.00000000E+00;
 }
 
 
 /*the polarizability in cubic Angstroms */
-void egtransetPOL(double* POL ) {
+void egtransetPOL(amrex::Real* POL ) {
     POL[0] = 1.60000000E+00;
     POL[1] = 1.76000000E+00;
 }
 
 
 /*the rotational relaxation collision number at 298 K */
-void egtransetZROT(double* ZROT ) {
+void egtransetZROT(amrex::Real* ZROT ) {
     ZROT[0] = 3.80000000E+00;
     ZROT[1] = 4.00000000E+00;
 }
@@ -3176,7 +3176,7 @@ void egtransetNLIN(int* NLIN) {
 
 
 /*Poly fits for the viscosities, dim NO*KK */
-void egtransetCOFETA(double* COFETA) {
+void egtransetCOFETA(amrex::Real* COFETA) {
     COFETA[0] = -1.60066324E+01;
     COFETA[1] = 2.16753735E+00;
     COFETA[2] = -1.97226850E-01;
@@ -3189,7 +3189,7 @@ void egtransetCOFETA(double* COFETA) {
 
 
 /*Poly fits for the conductivities, dim NO*KK */
-void egtransetCOFLAM(double* COFLAM) {
+void egtransetCOFLAM(amrex::Real* COFLAM) {
     COFLAM[0] = -2.11869892E+00;
     COFLAM[1] = 2.98568651E+00;
     COFLAM[2] = -2.86879123E-01;
@@ -3202,7 +3202,7 @@ void egtransetCOFLAM(double* COFLAM) {
 
 
 /*Poly fits for the diffusion coefficients, dim NO*KK*KK */
-void egtransetCOFD(double* COFD) {
+void egtransetCOFD(amrex::Real* COFD) {
     COFD[0] = -1.47079646E+01;
     COFD[1] = 3.10657376E+00;
     COFD[2] = -1.85922460E-01;
@@ -3228,16 +3228,16 @@ void egtransetKTDIF(int* KTDIF) {
 
 
 /*Poly fits for thermal diff ratios, dim NO*NLITE*KK */
-void egtransetCOFTD(double* COFTD) {
+void egtransetCOFTD(amrex::Real* COFTD) {
 }
 
 /* Replace this routine with the one generated by the Gauss Jordan solver of DW */
-AMREX_GPU_HOST_DEVICE void sgjsolve(double* A, double* x, double* b) {
+AMREX_GPU_HOST_DEVICE void sgjsolve(amrex::Real* A, amrex::Real* x, amrex::Real* b) {
     amrex::Abort("sgjsolve not implemented, choose a different solver ");
 }
 
 /* Replace this routine with the one generated by the Gauss Jordan solver of DW */
-AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(double* A, double* x, double* b) {
+AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(amrex::Real* A, amrex::Real* x, amrex::Real* b) {
     amrex::Abort("sgjsolve_simplified not implemented, choose a different solver ");
 }
 

--- a/Support/Fuego/Mechanism/Models/drm19/chemistry_file.H
+++ b/Support/Fuego/Mechanism/Models/drm19/chemistry_file.H
@@ -7,28 +7,28 @@
 
 extern "C"
 {
-AMREX_GPU_HOST_DEVICE void get_imw(double imw_new[]);
-AMREX_GPU_HOST_DEVICE void get_mw(double mw_new[]);
-void egtransetEPS(double *  EPS);
-void egtransetSIG(double* SIG);
-void atomicWeight(double *  awt);
-void molecularWeight(double *  wt);
-AMREX_GPU_HOST_DEVICE void gibbs(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void helmholtz(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void speciesEntropy(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void cp_R(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void cv_R(double *  species, double *  tc);
-void equilibriumConstants(double *  kc, double *  g_RT, double T);
-AMREX_GPU_HOST_DEVICE void productionRate(double *  wdot, double *  sc, double T);
-AMREX_GPU_HOST_DEVICE void comp_qfqr(double *  q_f, double *  q_r, double *  sc, double *  tc, double invT);
+AMREX_GPU_HOST_DEVICE void get_imw(amrex::Real imw_new[]);
+AMREX_GPU_HOST_DEVICE void get_mw(amrex::Real mw_new[]);
+void egtransetEPS(amrex::Real *  EPS);
+void egtransetSIG(amrex::Real* SIG);
+void atomicWeight(amrex::Real *  awt);
+void molecularWeight(amrex::Real *  wt);
+AMREX_GPU_HOST_DEVICE void gibbs(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void helmholtz(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void speciesEnthalpy(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void speciesEntropy(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void cp_R(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void cv_R(amrex::Real *  species, amrex::Real *  tc);
+void equilibriumConstants(amrex::Real *  kc, amrex::Real *  g_RT, amrex::Real T);
+AMREX_GPU_HOST_DEVICE void productionRate(amrex::Real *  wdot, amrex::Real *  sc, amrex::Real T);
+AMREX_GPU_HOST_DEVICE void comp_qfqr(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  sc, amrex::Real *  tc, amrex::Real invT);
 #ifndef AMREX_USE_CUDA
-void comp_k_f(double *  tc, double invT, double *  k_f);
-void comp_Kc(double *  tc, double invT, double *  Kc);
+void comp_k_f(amrex::Real *  tc, amrex::Real invT, amrex::Real *  k_f);
+void comp_Kc(amrex::Real *  tc, amrex::Real invT, amrex::Real *  Kc);
 #endif
-AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  speciesConc, double T);
-AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *  speciesConc, double T);
+AMREX_GPU_HOST_DEVICE void progressRate(amrex::Real *  qdot, amrex::Real *  speciesConc, amrex::Real T);
+AMREX_GPU_HOST_DEVICE void progressRateFR(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  speciesConc, amrex::Real T);
 AMREX_GPU_HOST_DEVICE void CKINIT();
 AMREX_GPU_HOST_DEVICE void CKFINALIZE();
 #ifndef AMREX_USE_CUDA
@@ -36,87 +36,87 @@ void GET_REACTION_MAP(int *  rmap);
 void SetAllDefaults();
 #endif
 void CKINDX(int * mm, int * kk, int * ii, int * nfit );
-void CKXNUM(char * line, int * nexp, int * lout, int * nval, double *  rval, int * kerr, int lenline);
-void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, double *  rval, int * kerr, int lenline, int lenkray);
+void CKXNUM(char * line, int * nexp, int * lout, int * nval, amrex::Real *  rval, int * kerr, int lenline);
+void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, amrex::Real *  rval, int * kerr, int lenline, int lenkray);
 void CKSYME_STR(amrex::Vector<std::string>& ename);
 void CKSYME(int * kname, int * lenkname);
 void CKSYMS_STR(amrex::Vector<std::string>& kname);
 void CKSYMS(int * kname, int * lenkname);
-void CKRP(double *  ru, double *  ruc, double *  pa);
-void CKPX(double *  rho, double *  T, double *  x, double *  P);
-AMREX_GPU_HOST_DEVICE void CKPY(double *  rho, double *  T, double *  y, double *  P);
-void CKPC(double *  rho, double *  T, double *  c, double *  P);
-void CKRHOX(double *  P, double *  T, double *  x, double *  rho);
-AMREX_GPU_HOST_DEVICE void CKRHOY(double *  P, double *  T, double *  y, double *  rho);
-void CKRHOC(double *  P, double *  T, double *  c, double *  rho);
-void CKWT(double *  wt);
-void CKAWT(double *  awt);
-AMREX_GPU_HOST_DEVICE void CKMMWY(double *  y, double *  wtm);
-void CKMMWX(double *  x, double *  wtm);
-void CKMMWC(double *  c, double *  wtm);
-AMREX_GPU_HOST_DEVICE void CKYTX(double *  y, double *  x);
-void CKYTCP(double *  P, double *  T, double *  y, double *  c);
-AMREX_GPU_HOST_DEVICE void CKYTCR(double *  rho, double *  T, double *  y, double *  c);
-AMREX_GPU_HOST_DEVICE void CKXTY(double *  x, double *  y);
-void CKXTCP(double *  P, double *  T, double *  x, double *  c);
-void CKXTCR(double *  rho, double *  T, double *  x, double *  c);
-void CKCTX(double *  c, double *  x);
-void CKCTY(double *  c, double *  y);
-void CKCPOR(double *  T, double *  cpor);
-void CKHORT(double *  T, double *  hort);
-void CKSOR(double *  T, double *  sor);
-void CKCVML(double *  T, double *  cvml);
-void CKCPML(double *  T, double *  cvml);
-void CKUML(double *  T, double *  uml);
-void CKHML(double *  T, double *  uml);
-void CKGML(double *  T, double *  gml);
-void CKAML(double *  T, double *  aml);
-void CKSML(double *  T, double *  sml);
-AMREX_GPU_HOST_DEVICE void CKCVMS(double *  T, double *  cvms);
-AMREX_GPU_HOST_DEVICE void CKCPMS(double *  T, double *  cvms);
-AMREX_GPU_HOST_DEVICE void CKUMS(double *  T, double *  ums);
-AMREX_GPU_HOST_DEVICE void CKHMS(double *  T, double *  ums);
-void CKGMS(double *  T, double *  gms);
-void CKAMS(double *  T, double *  ams);
-void CKSMS(double *  T, double *  sms);
-void CKCPBL(double *  T, double *  x, double *  cpbl);
-AMREX_GPU_HOST_DEVICE void CKCPBS(double *  T, double *  y, double *  cpbs);
-void CKCVBL(double *  T, double *  x, double *  cpbl);
-AMREX_GPU_HOST_DEVICE void CKCVBS(double *  T, double *  y, double *  cpbs);
-void CKHBML(double *  T, double *  x, double *  hbml);
-AMREX_GPU_HOST_DEVICE void CKHBMS(double *  T, double *  y, double *  hbms);
-void CKUBML(double *  T, double *  x, double *  ubml);
-AMREX_GPU_HOST_DEVICE void CKUBMS(double *  T, double *  y, double *  ubms);
-void CKSBML(double *  P, double *  T, double *  x, double *  sbml);
-void CKSBMS(double *  P, double *  T, double *  y, double *  sbms);
-void CKGBML(double *  P, double *  T, double *  x, double *  gbml);
-void CKGBMS(double *  P, double *  T, double *  y, double *  gbms);
-void CKABML(double *  P, double *  T, double *  x, double *  abml);
-void CKABMS(double *  P, double *  T, double *  y, double *  abms);
-AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C, double *  wdot);
-void CKWYP(double *  P, double *  T, double *  y, double *  wdot);
-void CKWXP(double *  P, double *  T, double *  x, double *  wdot);
-AMREX_GPU_HOST_DEVICE void CKWYR(double *  rho, double *  T, double *  y, double *  wdot);
-void CKWXR(double *  rho, double *  T, double *  x, double *  wdot);
-void CKQC(double *  T, double *  C, double *  qdot);
-void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r);
-void CKQYP(double *  P, double *  T, double *  y, double *  qdot);
-void CKQXP(double *  P, double *  T, double *  x, double *  qdot);
-void CKQYR(double *  rho, double *  T, double *  y, double *  qdot);
-void CKQXR(double *  rho, double *  T, double *  x, double *  qdot);
+void CKRP(amrex::Real *  ru, amrex::Real *  ruc, amrex::Real *  pa);
+void CKPX(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  P);
+AMREX_GPU_HOST_DEVICE void CKPY(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  P);
+void CKPC(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  c, amrex::Real *  P);
+void CKRHOX(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  rho);
+AMREX_GPU_HOST_DEVICE void CKRHOY(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  rho);
+void CKRHOC(amrex::Real *  P, amrex::Real *  T, amrex::Real *  c, amrex::Real *  rho);
+void CKWT(amrex::Real *  wt);
+void CKAWT(amrex::Real *  awt);
+AMREX_GPU_HOST_DEVICE void CKMMWY(amrex::Real *  y, amrex::Real *  wtm);
+void CKMMWX(amrex::Real *  x, amrex::Real *  wtm);
+void CKMMWC(amrex::Real *  c, amrex::Real *  wtm);
+AMREX_GPU_HOST_DEVICE void CKYTX(amrex::Real *  y, amrex::Real *  x);
+void CKYTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  c);
+AMREX_GPU_HOST_DEVICE void CKYTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  c);
+AMREX_GPU_HOST_DEVICE void CKXTY(amrex::Real *  x, amrex::Real *  y);
+void CKXTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c);
+void CKXTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c);
+void CKCTX(amrex::Real *  c, amrex::Real *  x);
+void CKCTY(amrex::Real *  c, amrex::Real *  y);
+void CKCPOR(amrex::Real *  T, amrex::Real *  cpor);
+void CKHORT(amrex::Real *  T, amrex::Real *  hort);
+void CKSOR(amrex::Real *  T, amrex::Real *  sor);
+void CKCVML(amrex::Real *  T, amrex::Real *  cvml);
+void CKCPML(amrex::Real *  T, amrex::Real *  cvml);
+void CKUML(amrex::Real *  T, amrex::Real *  uml);
+void CKHML(amrex::Real *  T, amrex::Real *  uml);
+void CKGML(amrex::Real *  T, amrex::Real *  gml);
+void CKAML(amrex::Real *  T, amrex::Real *  aml);
+void CKSML(amrex::Real *  T, amrex::Real *  sml);
+AMREX_GPU_HOST_DEVICE void CKCVMS(amrex::Real *  T, amrex::Real *  cvms);
+AMREX_GPU_HOST_DEVICE void CKCPMS(amrex::Real *  T, amrex::Real *  cvms);
+AMREX_GPU_HOST_DEVICE void CKUMS(amrex::Real *  T, amrex::Real *  ums);
+AMREX_GPU_HOST_DEVICE void CKHMS(amrex::Real *  T, amrex::Real *  ums);
+void CKGMS(amrex::Real *  T, amrex::Real *  gms);
+void CKAMS(amrex::Real *  T, amrex::Real *  ams);
+void CKSMS(amrex::Real *  T, amrex::Real *  sms);
+void CKCPBL(amrex::Real *  T, amrex::Real *  x, amrex::Real *  cpbl);
+AMREX_GPU_HOST_DEVICE void CKCPBS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  cpbs);
+void CKCVBL(amrex::Real *  T, amrex::Real *  x, amrex::Real *  cpbl);
+AMREX_GPU_HOST_DEVICE void CKCVBS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  cpbs);
+void CKHBML(amrex::Real *  T, amrex::Real *  x, amrex::Real *  hbml);
+AMREX_GPU_HOST_DEVICE void CKHBMS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  hbms);
+void CKUBML(amrex::Real *  T, amrex::Real *  x, amrex::Real *  ubml);
+AMREX_GPU_HOST_DEVICE void CKUBMS(amrex::Real *  T, amrex::Real *  y, amrex::Real *  ubms);
+void CKSBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  sbml);
+void CKSBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  sbms);
+void CKGBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  gbml);
+void CKGBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  gbms);
+void CKABML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  abml);
+void CKABMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  abms);
+AMREX_GPU_HOST_DEVICE void CKWC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  wdot);
+void CKWYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  wdot);
+void CKWXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  wdot);
+AMREX_GPU_HOST_DEVICE void CKWYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  wdot);
+void CKWXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  wdot);
+void CKQC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  qdot);
+void CKKFKR(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  q_f, amrex::Real *  q_r);
+void CKQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot);
+void CKQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot);
+void CKQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot);
+void CKQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot);
 void CKNU(int * kdim, int * nuki);
 #ifndef AMREX_USE_CUDA
 void CKINU(int * i, int * nspec, int * ki, int * nu);
 #endif
 void CKNCF(int * ncf);
-void CKABE(double *  a, double *  b, double *  e );
-void CKEQC(double *  T, double *  C , double *  eqcon );
-void CKEQYP(double *  P, double *  T, double *  y, double *  eqcon);
-void CKEQXP(double *  P, double *  T, double *  x, double *  eqcon);
-void CKEQYR(double *  rho, double *  T, double *  y, double *  eqcon);
-void CKEQXR(double *  rho, double *  T, double *  x, double *  eqcon);
-AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  T, int * consP);
-AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double *  Tp, int * HP);
+void CKABE(amrex::Real *  a, amrex::Real *  b, amrex::Real *  e );
+void CKEQC(amrex::Real *  T, amrex::Real *  C , amrex::Real *  eqcon );
+void CKEQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon);
+void CKEQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon);
+void CKEQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon);
+void CKEQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon);
+AMREX_GPU_HOST_DEVICE void DWDOT(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  T, int * consP);
+AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * HP);
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO(int * nJdata, int * consP, int NCELLS);
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST(int * nJdata, int * consP, int NCELLS);
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED(int * nJdata, int * consP);
@@ -125,30 +125,30 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSR(int * colVals, int * rowPtrs, in
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtrs, int * consP, int NCELLS, int base);
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, int * colPtrs, int * indx, int * consP);
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, int * rowPtr, int * consP, int base);
-AMREX_GPU_HOST_DEVICE void aJacobian(double *  J, double *  sc, double T, int consP);
-AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T, int HP);
-AMREX_GPU_HOST_DEVICE void dcvpRdT(double *  species, double *  tc);
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t, int *ierr);
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t, int *ierr);
-void GET_CRITPARAMS(double *  Tci, double *  ai, double *  bi, double *  acentric_i);
+AMREX_GPU_HOST_DEVICE void aJacobian(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int consP);
+AMREX_GPU_HOST_DEVICE void aJacobian_precond(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int HP);
+AMREX_GPU_HOST_DEVICE void dcvpRdT(amrex::Real *  species, amrex::Real *  tc);
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(amrex::Real *  e, amrex::Real *  y, amrex::Real *  t, int *ierr);
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(amrex::Real *  h, amrex::Real *  y, amrex::Real *  t, int *ierr);
+void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i);
 /*vector version */
-void VCKYTX(int *  np, double *  y, double *  x);
-void VCKHMS(int *  np, double *  T, double *  ums);
-void VCKWYR(int *  np, double *  rho, double *  T,
-            double *  y,
-            double *  wdot);
+void VCKYTX(int *  np, amrex::Real *  y, amrex::Real *  x);
+void VCKHMS(int *  np, amrex::Real *  T, amrex::Real *  ums);
+void VCKWYR(int *  np, amrex::Real *  rho, amrex::Real *  T,
+            amrex::Real *  y,
+            amrex::Real *  wdot);
 #ifndef AMREX_USE_CUDA
-void vproductionRate(int npt, double *  wdot, double *  c, double *  T);
-void VCKPY(int *  np, double *  rho, double *  T, double *  y, double *  P);
-void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT);
-void vcomp_gibbs(int npt, double *  g_RT, double *  tc);
-void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT);
-void vcomp_wdot_1_50(int npt, double *  wdot, double *  mixture, double *  sc,
-                double *  k_f_s, double *  Kc_s,
-                double *  tc, double *  invT, double *  T);
-void vcomp_wdot_51_84(int npt, double *  wdot, double *  mixture, double *  sc,
-                double *  k_f_s, double *  Kc_s,
-                double *  tc, double *  invT, double *  T);
+void vproductionRate(int npt, amrex::Real *  wdot, amrex::Real *  c, amrex::Real *  T);
+void VCKPY(int *  np, amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  P);
+void vcomp_k_f(int npt, amrex::Real *  k_f_s, amrex::Real *  tc, amrex::Real *  invT);
+void vcomp_gibbs(int npt, amrex::Real *  g_RT, amrex::Real *  tc);
+void vcomp_Kc(int npt, amrex::Real *  Kc_s, amrex::Real *  g_RT, amrex::Real *  invT);
+void vcomp_wdot_1_50(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,
+                amrex::Real *  k_f_s, amrex::Real *  Kc_s,
+                amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T);
+void vcomp_wdot_51_84(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,
+                amrex::Real *  k_f_s, amrex::Real *  Kc_s,
+                amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T);
 #endif
 /*Transport function declarations */
 void egtransetLENIMC(int* LENIMC);
@@ -156,46 +156,46 @@ void egtransetLENRMC(int* LENRMC);
 void egtransetNO(int* NO);
 void egtransetKK(int* KK);
 void egtransetNLITE(int* NLITE);
-void egtransetPATM(double* PATM);
-void egtransetWT(double* WT);
-void egtransetEPS(double* EPS);
-void egtransetSIG(double* SIG);
-void egtransetDIP(double* DIP);
-void egtransetPOL(double* POL);
-void egtransetZROT(double* ZROT);
+void egtransetPATM(amrex::Real* PATM);
+void egtransetWT(amrex::Real* WT);
+void egtransetEPS(amrex::Real* EPS);
+void egtransetSIG(amrex::Real* SIG);
+void egtransetDIP(amrex::Real* DIP);
+void egtransetPOL(amrex::Real* POL);
+void egtransetZROT(amrex::Real* ZROT);
 void egtransetNLIN(int* NLIN);
-void egtransetCOFETA(double* COFETA);
-void egtransetCOFLAM(double* COFLAM);
-void egtransetCOFD(double* COFD);
+void egtransetCOFETA(amrex::Real* COFETA);
+void egtransetCOFLAM(amrex::Real* COFLAM);
+void egtransetCOFD(amrex::Real* COFD);
 void egtransetKTDIF(int* KTDIF);
 /*gauss-jordan solver external routine */
-AMREX_GPU_HOST_DEVICE void sgjsolve(double* A, double* x, double* b);
-AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(double* A, double* x, double* b);
+AMREX_GPU_HOST_DEVICE void sgjsolve(amrex::Real* A, amrex::Real* x, amrex::Real* b);
+AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(amrex::Real* A, amrex::Real* x, amrex::Real* b);
 }
 
 #ifndef AMREX_USE_CUDA
 namespace thermo
 {
 
-    extern double fwd_A[84], fwd_beta[84], fwd_Ea[84];
-    extern double low_A[84], low_beta[84], low_Ea[84];
-    extern double rev_A[84], rev_beta[84], rev_Ea[84];
-    extern double troe_a[84],troe_Ts[84], troe_Tss[84], troe_Tsss[84];
-    extern double sri_a[84], sri_b[84], sri_c[84], sri_d[84], sri_e[84];
-    extern double activation_units[84], prefactor_units[84], phase_units[84];
+    extern amrex::Real fwd_A[84], fwd_beta[84], fwd_Ea[84];
+    extern amrex::Real low_A[84], low_beta[84], low_Ea[84];
+    extern amrex::Real rev_A[84], rev_beta[84], rev_Ea[84];
+    extern amrex::Real troe_a[84],troe_Ts[84], troe_Tss[84], troe_Tsss[84];
+    extern amrex::Real sri_a[84], sri_b[84], sri_c[84], sri_d[84], sri_e[84];
+    extern amrex::Real activation_units[84], prefactor_units[84], phase_units[84];
     extern int is_PD[84], troe_len[84], sri_len[84], nTB[84], *TBid[84];
-    extern double *TB[84];
-    extern std::vector<std::vector<double>> kiv; 
-    extern std::vector<std::vector<double>> nuv; 
+    extern amrex::Real *TB[84];
+    extern std::vector<std::vector<amrex::Real>> kiv; 
+    extern std::vector<std::vector<amrex::Real>> nuv; 
 
-    extern double fwd_A_DEF[84], fwd_beta_DEF[84], fwd_Ea_DEF[84];
-    extern double low_A_DEF[84], low_beta_DEF[84], low_Ea_DEF[84];
-    extern double rev_A_DEF[84], rev_beta_DEF[84], rev_Ea_DEF[84];
-    extern double troe_a_DEF[84],troe_Ts_DEF[84], troe_Tss_DEF[84], troe_Tsss_DEF[84];
-    extern double sri_a_DEF[84], sri_b_DEF[84], sri_c_DEF[84], sri_d_DEF[84], sri_e_DEF[84];
-    extern double activation_units_DEF[84], prefactor_units_DEF[84], phase_units_DEF[84];
+    extern amrex::Real fwd_A_DEF[84], fwd_beta_DEF[84], fwd_Ea_DEF[84];
+    extern amrex::Real low_A_DEF[84], low_beta_DEF[84], low_Ea_DEF[84];
+    extern amrex::Real rev_A_DEF[84], rev_beta_DEF[84], rev_Ea_DEF[84];
+    extern amrex::Real troe_a_DEF[84],troe_Ts_DEF[84], troe_Tss_DEF[84], troe_Tsss_DEF[84];
+    extern amrex::Real sri_a_DEF[84], sri_b_DEF[84], sri_c_DEF[84], sri_d_DEF[84], sri_e_DEF[84];
+    extern amrex::Real activation_units_DEF[84], prefactor_units_DEF[84], phase_units_DEF[84];
     extern int is_PD_DEF[84], troe_len_DEF[84], sri_len_DEF[84], nTB_DEF[84], *TBid_DEF[84];
-    extern double *TB_DEF[84];
+    extern amrex::Real *TB_DEF[84];
     extern std::vector<int> rxn_map;
 }
 #endif

--- a/Support/Fuego/Mechanism/Models/drm19/mechanism.cpp
+++ b/Support/Fuego/Mechanism/Models/drm19/mechanism.cpp
@@ -3,25 +3,25 @@
 #ifndef AMREX_USE_CUDA
 namespace thermo
 {
-    double fwd_A[84], fwd_beta[84], fwd_Ea[84];
-    double low_A[84], low_beta[84], low_Ea[84];
-    double rev_A[84], rev_beta[84], rev_Ea[84];
-    double troe_a[84],troe_Ts[84], troe_Tss[84], troe_Tsss[84];
-    double sri_a[84], sri_b[84], sri_c[84], sri_d[84], sri_e[84];
-    double activation_units[84], prefactor_units[84], phase_units[84];
+    amrex::Real fwd_A[84], fwd_beta[84], fwd_Ea[84];
+    amrex::Real low_A[84], low_beta[84], low_Ea[84];
+    amrex::Real rev_A[84], rev_beta[84], rev_Ea[84];
+    amrex::Real troe_a[84],troe_Ts[84], troe_Tss[84], troe_Tsss[84];
+    amrex::Real sri_a[84], sri_b[84], sri_c[84], sri_d[84], sri_e[84];
+    amrex::Real activation_units[84], prefactor_units[84], phase_units[84];
     int is_PD[84], troe_len[84], sri_len[84], nTB[84], *TBid[84];
-    double *TB[84];
-    std::vector<std::vector<double>> kiv(84); 
-    std::vector<std::vector<double>> nuv(84); 
+    amrex::Real *TB[84];
+    std::vector<std::vector<amrex::Real>> kiv(84); 
+    std::vector<std::vector<amrex::Real>> nuv(84); 
 
-    double fwd_A_DEF[84], fwd_beta_DEF[84], fwd_Ea_DEF[84];
-    double low_A_DEF[84], low_beta_DEF[84], low_Ea_DEF[84];
-    double rev_A_DEF[84], rev_beta_DEF[84], rev_Ea_DEF[84];
-    double troe_a_DEF[84],troe_Ts_DEF[84], troe_Tss_DEF[84], troe_Tsss_DEF[84];
-    double sri_a_DEF[84], sri_b_DEF[84], sri_c_DEF[84], sri_d_DEF[84], sri_e_DEF[84];
-    double activation_units_DEF[84], prefactor_units_DEF[84], phase_units_DEF[84];
+    amrex::Real fwd_A_DEF[84], fwd_beta_DEF[84], fwd_Ea_DEF[84];
+    amrex::Real low_A_DEF[84], low_beta_DEF[84], low_Ea_DEF[84];
+    amrex::Real rev_A_DEF[84], rev_beta_DEF[84], rev_Ea_DEF[84];
+    amrex::Real troe_a_DEF[84],troe_Ts_DEF[84], troe_Tss_DEF[84], troe_Tsss_DEF[84];
+    amrex::Real sri_a_DEF[84], sri_b_DEF[84], sri_c_DEF[84], sri_d_DEF[84], sri_e_DEF[84];
+    amrex::Real activation_units_DEF[84], prefactor_units_DEF[84], phase_units_DEF[84];
     int is_PD_DEF[84], troe_len_DEF[84], sri_len_DEF[84], nTB_DEF[84], *TBid_DEF[84];
-    double *TB_DEF[84];
+    amrex::Real *TB_DEF[84];
     std::vector<int> rxn_map;
 };
 
@@ -30,7 +30,7 @@ using namespace thermo;
 
 /* Inverse molecular weights */
 /* TODO: check necessity on CPU */
-static AMREX_GPU_DEVICE_MANAGED double imw[21] = {
+static AMREX_GPU_DEVICE_MANAGED amrex::Real imw[21] = {
     1.0 / 2.015940,  /*H2 */
     1.0 / 1.007970,  /*H */
     1.0 / 15.999400,  /*O */
@@ -55,7 +55,7 @@ static AMREX_GPU_DEVICE_MANAGED double imw[21] = {
 
 /* Inverse molecular weights */
 /* TODO: check necessity because redundant with molecularWeight */
-static AMREX_GPU_DEVICE_MANAGED double molecular_weights[21] = {
+static AMREX_GPU_DEVICE_MANAGED amrex::Real molecular_weights[21] = {
     2.015940,  /*H2 */
     1.007970,  /*H */
     15.999400,  /*O */
@@ -79,13 +79,13 @@ static AMREX_GPU_DEVICE_MANAGED double molecular_weights[21] = {
     39.948000};  /*AR */
 
 AMREX_GPU_HOST_DEVICE
-void get_imw(double imw_new[]){
+void get_imw(amrex::Real imw_new[]){
     for(int i = 0; i<21; ++i) imw_new[i] = imw[i];
 }
 
 /* TODO: check necessity because redundant with CKWT */
 AMREX_GPU_HOST_DEVICE
-void get_mw(double mw_new[]){
+void get_mw(amrex::Real mw_new[]){
     for(int i = 0; i<21; ++i) mw_new[i] = molecular_weights[i];
 }
 
@@ -109,7 +109,7 @@ void CKINIT()
     phase_units[8]      = pow(10,-12.000000);
     is_PD[8] = 0;
     nTB[8] = 7;
-    TB[8] = (double *) malloc(7 * sizeof(double));
+    TB[8] = (amrex::Real *) malloc(7 * sizeof(amrex::Real));
     TBid[8] = (int *) malloc(7 * sizeof(int));
     TBid[8][0] = 0; TB[8][0] = 2; // H2
     TBid[8][1] = 5; TB[8][1] = 6; // H2O
@@ -209,7 +209,7 @@ void CKINIT()
     phase_units[9]      = pow(10,-12.000000);
     is_PD[9] = 0;
     nTB[9] = 8;
-    TB[9] = (double *) malloc(8 * sizeof(double));
+    TB[9] = (amrex::Real *) malloc(8 * sizeof(amrex::Real));
     TBid[9] = (int *) malloc(8 * sizeof(int));
     TBid[9][0] = 0; TB[9][0] = 2; // H2
     TBid[9][1] = 3; TB[9][1] = 6; // O2
@@ -336,7 +336,7 @@ void CKINIT()
     phase_units[10]      = pow(10,-12.000000);
     is_PD[10] = 0;
     nTB[10] = 7;
-    TB[10] = (double *) malloc(7 * sizeof(double));
+    TB[10] = (amrex::Real *) malloc(7 * sizeof(amrex::Real));
     TBid[10] = (int *) malloc(7 * sizeof(int));
     TBid[10][0] = 3; TB[10][0] = 0; // O2
     TBid[10][1] = 5; TB[10][1] = 0; // H2O
@@ -423,7 +423,7 @@ void CKINIT()
     phase_units[11]      = pow(10,-12.000000);
     is_PD[11] = 0;
     nTB[11] = 6;
-    TB[11] = (double *) malloc(6 * sizeof(double));
+    TB[11] = (amrex::Real *) malloc(6 * sizeof(amrex::Real));
     TBid[11] = (int *) malloc(6 * sizeof(int));
     TBid[11][0] = 0; TB[11][0] = 0; // H2
     TBid[11][1] = 5; TB[11][1] = 0; // H2O
@@ -483,7 +483,7 @@ void CKINIT()
     phase_units[12]      = pow(10,-12.000000);
     is_PD[12] = 0;
     nTB[12] = 5;
-    TB[12] = (double *) malloc(5 * sizeof(double));
+    TB[12] = (amrex::Real *) malloc(5 * sizeof(amrex::Real));
     TBid[12] = (int *) malloc(5 * sizeof(int));
     TBid[12][0] = 0; TB[12][0] = 0.72999999999999998; // H2
     TBid[12][1] = 5; TB[12][1] = 3.6499999999999999; // H2O
@@ -537,7 +537,7 @@ void CKINIT()
     phase_units[0]      = pow(10,-12.000000);
     is_PD[0] = 1;
     nTB[0] = 7;
-    TB[0] = (double *) malloc(7 * sizeof(double));
+    TB[0] = (amrex::Real *) malloc(7 * sizeof(amrex::Real));
     TBid[0] = (int *) malloc(7 * sizeof(int));
     TBid[0][0] = 0; TB[0][0] = 2; // H2
     TBid[0][1] = 5; TB[0][1] = 6; // H2O
@@ -567,7 +567,7 @@ void CKINIT()
     phase_units[1]      = pow(10,-12.000000);
     is_PD[1] = 1;
     nTB[1] = 7;
-    TB[1] = (double *) malloc(7 * sizeof(double));
+    TB[1] = (amrex::Real *) malloc(7 * sizeof(amrex::Real));
     TBid[1] = (int *) malloc(7 * sizeof(int));
     TBid[1][0] = 0; TB[1][0] = 2; // H2
     TBid[1][1] = 5; TB[1][1] = 6; // H2O
@@ -610,7 +610,7 @@ void CKINIT()
     phase_units[2]      = pow(10,-12.000000);
     is_PD[2] = 1;
     nTB[2] = 7;
-    TB[2] = (double *) malloc(7 * sizeof(double));
+    TB[2] = (amrex::Real *) malloc(7 * sizeof(amrex::Real));
     TBid[2] = (int *) malloc(7 * sizeof(int));
     TBid[2][0] = 0; TB[2][0] = 2; // H2
     TBid[2][1] = 5; TB[2][1] = 6; // H2O
@@ -653,7 +653,7 @@ void CKINIT()
     phase_units[3]      = pow(10,-12.000000);
     is_PD[3] = 1;
     nTB[3] = 6;
-    TB[3] = (double *) malloc(6 * sizeof(double));
+    TB[3] = (amrex::Real *) malloc(6 * sizeof(amrex::Real));
     TBid[3] = (int *) malloc(6 * sizeof(int));
     TBid[3][0] = 0; TB[3][0] = 2; // H2
     TBid[3][1] = 5; TB[3][1] = 6; // H2O
@@ -708,7 +708,7 @@ void CKINIT()
     phase_units[4]      = pow(10,-12.000000);
     is_PD[4] = 1;
     nTB[4] = 7;
-    TB[4] = (double *) malloc(7 * sizeof(double));
+    TB[4] = (amrex::Real *) malloc(7 * sizeof(amrex::Real));
     TBid[4] = (int *) malloc(7 * sizeof(int));
     TBid[4][0] = 0; TB[4][0] = 2; // H2
     TBid[4][1] = 5; TB[4][1] = 6; // H2O
@@ -738,7 +738,7 @@ void CKINIT()
     phase_units[5]      = pow(10,-12.000000);
     is_PD[5] = 1;
     nTB[5] = 7;
-    TB[5] = (double *) malloc(7 * sizeof(double));
+    TB[5] = (amrex::Real *) malloc(7 * sizeof(amrex::Real));
     TBid[5] = (int *) malloc(7 * sizeof(int));
     TBid[5][0] = 0; TB[5][0] = 2; // H2
     TBid[5][1] = 5; TB[5][1] = 6; // H2O
@@ -781,7 +781,7 @@ void CKINIT()
     phase_units[6]      = pow(10,-12.000000);
     is_PD[6] = 1;
     nTB[6] = 7;
-    TB[6] = (double *) malloc(7 * sizeof(double));
+    TB[6] = (amrex::Real *) malloc(7 * sizeof(amrex::Real));
     TBid[6] = (int *) malloc(7 * sizeof(int));
     TBid[6][0] = 0; TB[6][0] = 2; // H2
     TBid[6][1] = 5; TB[6][1] = 6; // H2O
@@ -1240,7 +1240,7 @@ void CKINIT()
     phase_units[7]      = pow(10,-12.000000);
     is_PD[7] = 1;
     nTB[7] = 7;
-    TB[7] = (double *) malloc(7 * sizeof(double));
+    TB[7] = (amrex::Real *) malloc(7 * sizeof(amrex::Real));
     TBid[7] = (int *) malloc(7 * sizeof(int));
     TBid[7][0] = 0; TB[7][0] = 2; // H2
     TBid[7][1] = 5; TB[7][1] = 6; // H2O
@@ -1327,7 +1327,7 @@ void CKINIT()
     phase_units[13]      = pow(10,-6.000000);
     is_PD[13] = 0;
     nTB[13] = 6;
-    TB[13] = (double *) malloc(6 * sizeof(double));
+    TB[13] = (amrex::Real *) malloc(6 * sizeof(amrex::Real));
     TBid[13] = (int *) malloc(6 * sizeof(int));
     TBid[13][0] = 0; TB[13][0] = 2; // H2
     TBid[13][1] = 5; TB[13][1] = 0; // H2O
@@ -1386,12 +1386,12 @@ void GET_REACTION_MAP(int *rmap)
 }
 
 #include <ReactionData.H>
-double* GetParamPtr(int                reaction_id,
+amrex::Real* GetParamPtr(int                reaction_id,
                     REACTION_PARAMETER param_id,
                     int                species_id,
                     int                get_default)
 {
-  double* ret = 0;
+  amrex::Real* ret = 0;
   if (reaction_id<0 || reaction_id>=84) {
     printf("Bad reaction id = %d",reaction_id);
     abort();
@@ -1491,7 +1491,7 @@ void ResetAllParametersToDefault()
 
         nTB[i]  = nTB_DEF[i];
         if (nTB[i] != 0) {
-           TB[i] = (double *) malloc(sizeof(double) * nTB[i]);
+           TB[i] = (amrex::Real *) malloc(sizeof(amrex::Real) * nTB[i]);
            TBid[i] = (int *) malloc(sizeof(int) * nTB[i]);
            for (int j=0; j<nTB[i]; j++) {
              TB[i][j] = TB_DEF[i][j];
@@ -1543,7 +1543,7 @@ void SetAllDefaults()
 
         nTB_DEF[i]  = nTB[i];
         if (nTB_DEF[i] != 0) {
-           TB_DEF[i] = (double *) malloc(sizeof(double) * nTB_DEF[i]);
+           TB_DEF[i] = (amrex::Real *) malloc(sizeof(amrex::Real) * nTB_DEF[i]);
            TBid_DEF[i] = (int *) malloc(sizeof(int) * nTB_DEF[i]);
            for (int j=0; j<nTB_DEF[i]; j++) {
              TB_DEF[i][j] = TB[i][j];
@@ -1592,7 +1592,7 @@ void CKINDX(int * mm, int * kk, int * ii, int * nfit)
 
 
 /* ckxnum... for parsing strings  */
-void CKXNUM(char * line, int * nexp, int * lout, int * nval, double *  rval, int * kerr, int lenline )
+void CKXNUM(char * line, int * nexp, int * lout, int * nval, amrex::Real *  rval, int * kerr, int lenline )
 {
     int n,i; /*Loop Counters */
     char cstr[1000];
@@ -1625,7 +1625,7 @@ void CKXNUM(char * line, int * nexp, int * lout, int * nval, double *  rval, int
 
 
 /* cksnum... for parsing strings  */
-void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, double *  rval, int * kerr, int lenline, int lenkray)
+void CKSNUM(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, amrex::Real *  rval, int * kerr, int lenline, int lenkray)
 {
     /*Not done yet ... */
 }
@@ -1843,7 +1843,7 @@ void CKSYMS(int * kname, int * plenkname )
 
 
 /* Returns R, Rc, Patm */
-void CKRP(double *  ru, double *  ruc, double *  pa)
+void CKRP(amrex::Real *  ru, amrex::Real *  ruc, amrex::Real *  pa)
 {
      *ru  = 8.31446261815324e+07; 
      *ruc = 1.98721558317399615845; 
@@ -1852,9 +1852,9 @@ void CKRP(double *  ru, double *  ruc, double *  pa)
 
 
 /*Compute P = rhoRT/W(x) */
-void CKPX(double *  rho, double *  T, double *  x, double *  P)
+void CKPX(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  P)
 {
-    double XW = 0;/* To hold mean molecular wt */
+    amrex::Real XW = 0;/* To hold mean molecular wt */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
     XW += x[2]*15.999400; /*O */
@@ -1883,9 +1883,9 @@ void CKPX(double *  rho, double *  T, double *  x, double *  P)
 
 
 /*Compute P = rhoRT/W(y) */
-AMREX_GPU_HOST_DEVICE void CKPY(double *  rho, double *  T, double *  y,  double *  P)
+AMREX_GPU_HOST_DEVICE void CKPY(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  P)
 {
-    double YOW = 0;/* for computing mean MW */
+    amrex::Real YOW = 0;/* for computing mean MW */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*H */
     YOW += y[2]*imw[2]; /*O */
@@ -1915,9 +1915,9 @@ AMREX_GPU_HOST_DEVICE void CKPY(double *  rho, double *  T, double *  y,  double
 
 #ifndef AMREX_USE_CUDA
 /*Compute P = rhoRT/W(y) */
-void VCKPY(int *  np, double *  rho, double *  T, double *  y,  double *  P)
+void VCKPY(int *  np, amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  P)
 {
-    double YOW[*np];
+    amrex::Real YOW[*np];
     for (int i=0; i<(*np); i++) {
         YOW[i] = 0.0;
     }
@@ -1938,12 +1938,12 @@ void VCKPY(int *  np, double *  rho, double *  T, double *  y,  double *  P)
 
 
 /*Compute P = rhoRT/W(c) */
-void CKPC(double *  rho, double *  T, double *  c,  double *  P)
+void CKPC(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  c,  amrex::Real *  P)
 {
     int id; /*loop counter */
     /*See Eq 5 in CK Manual */
-    double W = 0;
-    double sumC = 0;
+    amrex::Real W = 0;
+    amrex::Real sumC = 0;
     W += c[0]*2.015940; /*H2 */
     W += c[1]*1.007970; /*H */
     W += c[2]*15.999400; /*O */
@@ -1976,9 +1976,9 @@ void CKPC(double *  rho, double *  T, double *  c,  double *  P)
 
 
 /*Compute rho = PW(x)/RT */
-void CKRHOX(double *  P, double *  T, double *  x,  double *  rho)
+void CKRHOX(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  rho)
 {
-    double XW = 0;/* To hold mean molecular wt */
+    amrex::Real XW = 0;/* To hold mean molecular wt */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
     XW += x[2]*15.999400; /*O */
@@ -2007,10 +2007,10 @@ void CKRHOX(double *  P, double *  T, double *  x,  double *  rho)
 
 
 /*Compute rho = P*W(y)/RT */
-AMREX_GPU_HOST_DEVICE void CKRHOY(double *  P, double *  T, double *  y,  double *  rho)
+AMREX_GPU_HOST_DEVICE void CKRHOY(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  rho)
 {
-    double YOW = 0;
-    double tmp[21];
+    amrex::Real YOW = 0;
+    amrex::Real tmp[21];
 
     for (int i = 0; i < 21; i++)
     {
@@ -2027,12 +2027,12 @@ AMREX_GPU_HOST_DEVICE void CKRHOY(double *  P, double *  T, double *  y,  double
 
 
 /*Compute rho = P*W(c)/(R*T) */
-void CKRHOC(double *  P, double *  T, double *  c,  double *  rho)
+void CKRHOC(amrex::Real *  P, amrex::Real *  T, amrex::Real *  c,  amrex::Real *  rho)
 {
     int id; /*loop counter */
     /*See Eq 5 in CK Manual */
-    double W = 0;
-    double sumC = 0;
+    amrex::Real W = 0;
+    amrex::Real sumC = 0;
     W += c[0]*2.015940; /*H2 */
     W += c[1]*1.007970; /*H */
     W += c[2]*15.999400; /*O */
@@ -2065,14 +2065,14 @@ void CKRHOC(double *  P, double *  T, double *  c,  double *  rho)
 
 
 /*get molecular weight for all species */
-void CKWT( double *  wt)
+void CKWT( amrex::Real *  wt)
 {
     get_mw(wt);
 }
 
 
 /*get atomic weight for all elements */
-void CKAWT( double *  awt)
+void CKAWT( amrex::Real *  awt)
 {
     atomicWeight(awt);
 }
@@ -2080,10 +2080,10 @@ void CKAWT( double *  awt)
 
 /*given y[species]: mass fractions */
 /*returns mean molecular weight (gm/mole) */
-AMREX_GPU_HOST_DEVICE void CKMMWY(double *  y,  double *  wtm)
+AMREX_GPU_HOST_DEVICE void CKMMWY(amrex::Real *  y,  amrex::Real *  wtm)
 {
-    double YOW = 0;
-    double tmp[21];
+    amrex::Real YOW = 0;
+    amrex::Real tmp[21];
 
     for (int i = 0; i < 21; i++)
     {
@@ -2101,9 +2101,9 @@ AMREX_GPU_HOST_DEVICE void CKMMWY(double *  y,  double *  wtm)
 
 /*given x[species]: mole fractions */
 /*returns mean molecular weight (gm/mole) */
-void CKMMWX(double *  x,  double *  wtm)
+void CKMMWX(amrex::Real *  x,  amrex::Real *  wtm)
 {
-    double XW = 0;/* see Eq 4 in CK Manual */
+    amrex::Real XW = 0;/* see Eq 4 in CK Manual */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
     XW += x[2]*15.999400; /*O */
@@ -2133,12 +2133,12 @@ void CKMMWX(double *  x,  double *  wtm)
 
 /*given c[species]: molar concentration */
 /*returns mean molecular weight (gm/mole) */
-void CKMMWC(double *  c,  double *  wtm)
+void CKMMWC(amrex::Real *  c,  amrex::Real *  wtm)
 {
     int id; /*loop counter */
     /*See Eq 5 in CK Manual */
-    double W = 0;
-    double sumC = 0;
+    amrex::Real W = 0;
+    amrex::Real sumC = 0;
     W += c[0]*2.015940; /*H2 */
     W += c[1]*1.007970; /*H */
     W += c[2]*15.999400; /*O */
@@ -2172,10 +2172,10 @@ void CKMMWC(double *  c,  double *  wtm)
 
 
 /*convert y[species] (mass fracs) to x[species] (mole fracs) */
-AMREX_GPU_HOST_DEVICE void CKYTX(double *  y,  double *  x)
+AMREX_GPU_HOST_DEVICE void CKYTX(amrex::Real *  y,  amrex::Real *  x)
 {
-    double YOW = 0;
-    double tmp[21];
+    amrex::Real YOW = 0;
+    amrex::Real tmp[21];
 
     for (int i = 0; i < 21; i++)
     {
@@ -2186,7 +2186,7 @@ AMREX_GPU_HOST_DEVICE void CKYTX(double *  y,  double *  x)
         YOW += tmp[i];
     }
 
-    double YOWINV = 1.0/YOW;
+    amrex::Real YOWINV = 1.0/YOW;
 
     for (int i = 0; i < 21; i++)
     {
@@ -2198,9 +2198,9 @@ AMREX_GPU_HOST_DEVICE void CKYTX(double *  y,  double *  x)
 
 #ifndef AMREX_USE_CUDA
 /*convert y[npoints*species] (mass fracs) to x[npoints*species] (mole fracs) */
-void VCKYTX(int *  np, double *  y,  double *  x)
+void VCKYTX(int *  np, amrex::Real *  y,  amrex::Real *  x)
 {
-    double YOW[*np];
+    amrex::Real YOW[*np];
     for (int i=0; i<(*np); i++) {
         YOW[i] = 0.0;
     }
@@ -2224,17 +2224,17 @@ void VCKYTX(int *  np, double *  y,  double *  x)
 }
 #else
 /*TODO: remove this on GPU */
-void VCKYTX(int *  np, double *  y,  double *  x)
+void VCKYTX(int *  np, amrex::Real *  y,  amrex::Real *  x)
 {
 }
 #endif
 
 
 /*convert y[species] (mass fracs) to c[species] (molar conc) */
-void CKYTCP(double *  P, double *  T, double *  y,  double *  c)
+void CKYTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  c)
 {
-    double YOW = 0;
-    double PWORT;
+    amrex::Real YOW = 0;
+    amrex::Real PWORT;
 
     /*Compute inverse of mean molecular wt first */
     for (int i = 0; i < 21; i++)
@@ -2259,7 +2259,7 @@ void CKYTCP(double *  P, double *  T, double *  y,  double *  c)
 
 
 /*convert y[species] (mass fracs) to c[species] (molar conc) */
-AMREX_GPU_HOST_DEVICE void CKYTCR(double *  rho, double *  T, double *  y,  double *  c)
+AMREX_GPU_HOST_DEVICE void CKYTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  c)
 {
     for (int i = 0; i < 21; i++)
     {
@@ -2269,9 +2269,9 @@ AMREX_GPU_HOST_DEVICE void CKYTCR(double *  rho, double *  T, double *  y,  doub
 
 
 /*convert x[species] (mole fracs) to y[species] (mass fracs) */
-AMREX_GPU_HOST_DEVICE void CKXTY(double *  x,  double *  y)
+AMREX_GPU_HOST_DEVICE void CKXTY(amrex::Real *  x,  amrex::Real *  y)
 {
-    double XW = 0; /*See Eq 4, 9 in CK Manual */
+    amrex::Real XW = 0; /*See Eq 4, 9 in CK Manual */
     /*Compute mean molecular wt first */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
@@ -2295,7 +2295,7 @@ AMREX_GPU_HOST_DEVICE void CKXTY(double *  x,  double *  y)
     XW += x[19]*28.013400; /*N2 */
     XW += x[20]*39.948000; /*AR */
     /*Now compute conversion */
-    double XWinv = 1.0/XW;
+    amrex::Real XWinv = 1.0/XW;
     y[0] = x[0]*2.015940*XWinv; 
     y[1] = x[1]*1.007970*XWinv; 
     y[2] = x[2]*15.999400*XWinv; 
@@ -2323,10 +2323,10 @@ AMREX_GPU_HOST_DEVICE void CKXTY(double *  x,  double *  y)
 
 
 /*convert x[species] (mole fracs) to c[species] (molar conc) */
-void CKXTCP(double *  P, double *  T, double *  x,  double *  c)
+void CKXTCP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  c)
 {
     int id; /*loop counter */
-    double PORT = (*P)/(8.31446261815324e+07 * (*T)); /*P/RT */
+    amrex::Real PORT = (*P)/(8.31446261815324e+07 * (*T)); /*P/RT */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 21; ++id) {
@@ -2338,11 +2338,11 @@ void CKXTCP(double *  P, double *  T, double *  x,  double *  c)
 
 
 /*convert x[species] (mole fracs) to c[species] (molar conc) */
-void CKXTCR(double *  rho, double *  T, double *  x, double *  c)
+void CKXTCR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c)
 {
     int id; /*loop counter */
-    double XW = 0; /*See Eq 4, 11 in CK Manual */
-    double ROW; 
+    amrex::Real XW = 0; /*See Eq 4, 11 in CK Manual */
+    amrex::Real ROW; 
     /*Compute mean molecular wt first */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
@@ -2377,10 +2377,10 @@ void CKXTCR(double *  rho, double *  T, double *  x, double *  c)
 
 
 /*convert c[species] (molar conc) to x[species] (mole fracs) */
-void CKCTX(double *  c, double *  x)
+void CKCTX(amrex::Real *  c, amrex::Real *  x)
 {
     int id; /*loop counter */
-    double sumC = 0; 
+    amrex::Real sumC = 0; 
 
     /*compute sum of c  */
     for (id = 0; id < 21; ++id) {
@@ -2388,7 +2388,7 @@ void CKCTX(double *  c, double *  x)
     }
 
     /* See Eq 13  */
-    double sumCinv = 1.0/sumC;
+    amrex::Real sumCinv = 1.0/sumC;
     for (id = 0; id < 21; ++id) {
         x[id] = c[id]*sumCinv;
     }
@@ -2398,9 +2398,9 @@ void CKCTX(double *  c, double *  x)
 
 
 /*convert c[species] (molar conc) to y[species] (mass fracs) */
-void CKCTY(double *  c, double *  y)
+void CKCTY(amrex::Real *  c, amrex::Real *  y)
 {
-    double CW = 0; /*See Eq 12 in CK Manual */
+    amrex::Real CW = 0; /*See Eq 12 in CK Manual */
     /*compute denominator in eq 12 first */
     CW += c[0]*2.015940; /*H2 */
     CW += c[1]*1.007970; /*H */
@@ -2424,7 +2424,7 @@ void CKCTY(double *  c, double *  y)
     CW += c[19]*28.013400; /*N2 */
     CW += c[20]*39.948000; /*AR */
     /*Now compute conversion */
-    double CWinv = 1.0/CW;
+    amrex::Real CWinv = 1.0/CW;
     y[0] = c[0]*2.015940*CWinv; 
     y[1] = c[1]*1.007970*CWinv; 
     y[2] = c[2]*15.999400*CWinv; 
@@ -2453,41 +2453,41 @@ void CKCTY(double *  c, double *  y)
 
 /*get Cp/R as a function of T  */
 /*for all species (Eq 19) */
-void CKCPOR(double *  T, double *  cpor)
+void CKCPOR(amrex::Real *  T, amrex::Real *  cpor)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cp_R(cpor, tc);
 }
 
 
 /*get H/RT as a function of T  */
 /*for all species (Eq 20) */
-void CKHORT(double *  T, double *  hort)
+void CKHORT(amrex::Real *  T, amrex::Real *  hort)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEnthalpy(hort, tc);
 }
 
 
 /*get S/R as a function of T  */
 /*for all species (Eq 21) */
-void CKSOR(double *  T, double *  sor)
+void CKSOR(amrex::Real *  T, amrex::Real *  sor)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEntropy(sor, tc);
 }
 
 
 /*get specific heat at constant volume as a function  */
 /*of T for all species (molar units) */
-void CKCVML(double *  T,  double *  cvml)
+void CKCVML(amrex::Real *  T,  amrex::Real *  cvml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cv_R(cvml, tc);
 
     /*convert to chemkin units */
@@ -2499,11 +2499,11 @@ void CKCVML(double *  T,  double *  cvml)
 
 /*get specific heat at constant pressure as a  */
 /*function of T for all species (molar units) */
-void CKCPML(double *  T,  double *  cpml)
+void CKCPML(amrex::Real *  T,  amrex::Real *  cpml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cp_R(cpml, tc);
 
     /*convert to chemkin units */
@@ -2515,12 +2515,12 @@ void CKCPML(double *  T,  double *  cpml)
 
 /*get internal energy as a function  */
 /*of T for all species (molar units) */
-void CKUML(double *  T,  double *  uml)
+void CKUML(amrex::Real *  T,  amrex::Real *  uml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(uml, tc);
 
     /*convert to chemkin units */
@@ -2532,12 +2532,12 @@ void CKUML(double *  T,  double *  uml)
 
 /*get enthalpy as a function  */
 /*of T for all species (molar units) */
-void CKHML(double *  T,  double *  hml)
+void CKHML(amrex::Real *  T,  amrex::Real *  hml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hml, tc);
 
     /*convert to chemkin units */
@@ -2549,12 +2549,12 @@ void CKHML(double *  T,  double *  hml)
 
 /*get standard-state Gibbs energy as a function  */
 /*of T for all species (molar units) */
-void CKGML(double *  T,  double *  gml)
+void CKGML(amrex::Real *  T,  amrex::Real *  gml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     gibbs(gml, tc);
 
     /*convert to chemkin units */
@@ -2566,12 +2566,12 @@ void CKGML(double *  T,  double *  gml)
 
 /*get standard-state Helmholtz free energy as a  */
 /*function of T for all species (molar units) */
-void CKAML(double *  T,  double *  aml)
+void CKAML(amrex::Real *  T,  amrex::Real *  aml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     helmholtz(aml, tc);
 
     /*convert to chemkin units */
@@ -2582,11 +2582,11 @@ void CKAML(double *  T,  double *  aml)
 
 
 /*Returns the standard-state entropies in molar units */
-void CKSML(double *  T,  double *  sml)
+void CKSML(amrex::Real *  T,  amrex::Real *  sml)
 {
     int id; /*loop counter */
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEntropy(sml, tc);
 
     /*convert to chemkin units */
@@ -2598,10 +2598,10 @@ void CKSML(double *  T,  double *  sml)
 
 /*Returns the specific heats at constant volume */
 /*in mass units (Eq. 29) */
-AMREX_GPU_HOST_DEVICE void CKCVMS(double *  T,  double *  cvms)
+AMREX_GPU_HOST_DEVICE void CKCVMS(amrex::Real *  T,  amrex::Real *  cvms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cv_R(cvms, tc);
     /*multiply by R/molecularweight */
     cvms[0] *= 4.124360158612479e+07; /*H2 */
@@ -2630,10 +2630,10 @@ AMREX_GPU_HOST_DEVICE void CKCVMS(double *  T,  double *  cvms)
 
 /*Returns the specific heats at constant pressure */
 /*in mass units (Eq. 26) */
-AMREX_GPU_HOST_DEVICE void CKCPMS(double *  T,  double *  cpms)
+AMREX_GPU_HOST_DEVICE void CKCPMS(amrex::Real *  T,  amrex::Real *  cpms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     cp_R(cpms, tc);
     /*multiply by R/molecularweight */
     cpms[0] *= 4.124360158612479e+07; /*H2 */
@@ -2661,11 +2661,11 @@ AMREX_GPU_HOST_DEVICE void CKCPMS(double *  T,  double *  cpms)
 
 
 /*Returns internal energy in mass units (Eq 30.) */
-AMREX_GPU_HOST_DEVICE void CKUMS(double *  T,  double *  ums)
+AMREX_GPU_HOST_DEVICE void CKUMS(amrex::Real *  T,  amrex::Real *  ums)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(ums, tc);
     for (int i = 0; i < 21; i++)
     {
@@ -2675,11 +2675,11 @@ AMREX_GPU_HOST_DEVICE void CKUMS(double *  T,  double *  ums)
 
 
 /*Returns enthalpy in mass units (Eq 27.) */
-AMREX_GPU_HOST_DEVICE void CKHMS(double *  T,  double *  hms)
+AMREX_GPU_HOST_DEVICE void CKHMS(amrex::Real *  T,  amrex::Real *  hms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hms, tc);
     for (int i = 0; i < 21; i++)
     {
@@ -2690,9 +2690,9 @@ AMREX_GPU_HOST_DEVICE void CKHMS(double *  T,  double *  hms)
 
 #ifndef AMREX_USE_CUDA
 /*Returns enthalpy in mass units (Eq 27.) */
-void VCKHMS(int *  np, double *  T,  double *  hms)
+void VCKHMS(int *  np, amrex::Real *  T,  amrex::Real *  hms)
 {
-    double tc[5], h[21];
+    amrex::Real tc[5], h[21];
 
     for (int i=0; i<(*np); i++) {
         tc[0] = 0.0;
@@ -2734,18 +2734,18 @@ void VCKHMS(int *  np, double *  T,  double *  hms)
 }
 #else
 /*TODO: remove this on GPU */
-void VCKHMS(int *  np, double *  T,  double *  hms)
+void VCKHMS(int *  np, amrex::Real *  T,  amrex::Real *  hms)
 {
 }
 #endif
 
 
 /*Returns gibbs in mass units (Eq 31.) */
-void CKGMS(double *  T,  double *  gms)
+void CKGMS(amrex::Real *  T,  amrex::Real *  gms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     gibbs(gms, tc);
     for (int i = 0; i < 21; i++)
     {
@@ -2755,11 +2755,11 @@ void CKGMS(double *  T,  double *  gms)
 
 
 /*Returns helmholtz in mass units (Eq 32.) */
-void CKAMS(double *  T,  double *  ams)
+void CKAMS(amrex::Real *  T,  amrex::Real *  ams)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     helmholtz(ams, tc);
     for (int i = 0; i < 21; i++)
     {
@@ -2769,10 +2769,10 @@ void CKAMS(double *  T,  double *  ams)
 
 
 /*Returns the entropies in mass units (Eq 28.) */
-void CKSMS(double *  T,  double *  sms)
+void CKSMS(amrex::Real *  T,  amrex::Real *  sms)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
     speciesEntropy(sms, tc);
     /*multiply by R/molecularweight */
     sms[0] *= 4.124360158612479e+07; /*H2 */
@@ -2800,13 +2800,13 @@ void CKSMS(double *  T,  double *  sms)
 
 
 /*Returns the mean specific heat at CP (Eq. 33) */
-void CKCPBL(double *  T, double *  x,  double *  cpbl)
+void CKCPBL(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  cpbl)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cpor[21]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cpor[21]; /* temporary storage */
     cp_R(cpor, tc);
 
     /*perform dot product */
@@ -2819,12 +2819,12 @@ void CKCPBL(double *  T, double *  x,  double *  cpbl)
 
 
 /*Returns the mean specific heat at CP (Eq. 34) */
-AMREX_GPU_HOST_DEVICE void CKCPBS(double *  T, double *  y,  double *  cpbs)
+AMREX_GPU_HOST_DEVICE void CKCPBS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  cpbs)
 {
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cpor[21], tresult[21]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cpor[21], tresult[21]; /* temporary storage */
     cp_R(cpor, tc);
     for (int i = 0; i < 21; i++)
     {
@@ -2841,13 +2841,13 @@ AMREX_GPU_HOST_DEVICE void CKCPBS(double *  T, double *  y,  double *  cpbs)
 
 
 /*Returns the mean specific heat at CV (Eq. 35) */
-void CKCVBL(double *  T, double *  x,  double *  cvbl)
+void CKCVBL(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  cvbl)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cvor[21]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cvor[21]; /* temporary storage */
     cv_R(cvor, tc);
 
     /*perform dot product */
@@ -2860,12 +2860,12 @@ void CKCVBL(double *  T, double *  x,  double *  cvbl)
 
 
 /*Returns the mean specific heat at CV (Eq. 36) */
-AMREX_GPU_HOST_DEVICE void CKCVBS(double *  T, double *  y,  double *  cvbs)
+AMREX_GPU_HOST_DEVICE void CKCVBS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  cvbs)
 {
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double cvor[21]; /* temporary storage */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real cvor[21]; /* temporary storage */
     cv_R(cvor, tc);
     /*multiply by y/molecularweight */
     result += cvor[0]*y[0]*imw[0]; /*H2 */
@@ -2895,14 +2895,14 @@ AMREX_GPU_HOST_DEVICE void CKCVBS(double *  T, double *  y,  double *  cvbs)
 
 
 /*Returns the mean enthalpy of the mixture in molar units */
-void CKHBML(double *  T, double *  x,  double *  hbml)
+void CKHBML(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  hbml)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double hml[21]; /* temporary storage */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real hml[21]; /* temporary storage */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hml, tc);
 
     /*perform dot product */
@@ -2915,13 +2915,13 @@ void CKHBML(double *  T, double *  x,  double *  hbml)
 
 
 /*Returns mean enthalpy of mixture in mass units */
-AMREX_GPU_HOST_DEVICE void CKHBMS(double *  T, double *  y,  double *  hbms)
+AMREX_GPU_HOST_DEVICE void CKHBMS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  hbms)
 {
-    double result = 0;
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double hml[21], tmp[21]; /* temporary storage */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0;
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real hml[21], tmp[21]; /* temporary storage */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesEnthalpy(hml, tc);
     int id;
     for (id = 0; id < 21; ++id) {
@@ -2936,14 +2936,14 @@ AMREX_GPU_HOST_DEVICE void CKHBMS(double *  T, double *  y,  double *  hbms)
 
 
 /*get mean internal energy in molar units */
-void CKUBML(double *  T, double *  x,  double *  ubml)
+void CKUBML(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  ubml)
 {
     int id; /*loop counter */
-    double result = 0; 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double uml[21]; /* temporary energy array */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0; 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real uml[21]; /* temporary energy array */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(uml, tc);
 
     /*perform dot product */
@@ -2956,13 +2956,13 @@ void CKUBML(double *  T, double *  x,  double *  ubml)
 
 
 /*get mean internal energy in mass units */
-AMREX_GPU_HOST_DEVICE void CKUBMS(double *  T, double *  y,  double *  ubms)
+AMREX_GPU_HOST_DEVICE void CKUBMS(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  ubms)
 {
-    double result = 0;
-    double tT = *T; /*temporary temperature */
-    double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double ums[21]; /* temporary energy array */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real result = 0;
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real ums[21]; /* temporary energy array */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
     speciesInternalEnergy(ums, tc);
     /*perform dot product + scaling by wt */
     result += y[0]*ums[0]*imw[0]; /*H2 */
@@ -2992,15 +2992,15 @@ AMREX_GPU_HOST_DEVICE void CKUBMS(double *  T, double *  y,  double *  ubms)
 
 
 /*get mixture entropy in molar units */
-void CKSBML(double *  P, double *  T, double *  x,  double *  sbml)
+void CKSBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  sbml)
 {
     int id; /*loop counter */
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double sor[21]; /* temporary storage */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real sor[21]; /* temporary storage */
     speciesEntropy(sor, tc);
 
     /*Compute Eq 42 */
@@ -3013,16 +3013,16 @@ void CKSBML(double *  P, double *  T, double *  x,  double *  sbml)
 
 
 /*get mixture entropy in mass units */
-void CKSBMS(double *  P, double *  T, double *  y,  double *  sbms)
+void CKSBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  sbms)
 {
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double sor[21]; /* temporary storage */
-    double x[21]; /* need a ytx conversion */
-    double YOW = 0; /*See Eq 4, 6 in CK Manual */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real sor[21]; /* temporary storage */
+    amrex::Real x[21]; /* need a ytx conversion */
+    amrex::Real YOW = 0; /*See Eq 4, 6 in CK Manual */
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*H */
@@ -3096,16 +3096,16 @@ void CKSBMS(double *  P, double *  T, double *  y,  double *  sbms)
 
 
 /*Returns mean gibbs free energy in molar units */
-void CKGBML(double *  P, double *  T, double *  x,  double *  gbml)
+void CKGBML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  gbml)
 {
     int id; /*loop counter */
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double gort[21]; /* temporary storage */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real gort[21]; /* temporary storage */
     /*Compute g/RT */
     gibbs(gort, tc);
 
@@ -3119,17 +3119,17 @@ void CKGBML(double *  P, double *  T, double *  x,  double *  gbml)
 
 
 /*Returns mixture gibbs free energy in mass units */
-void CKGBMS(double *  P, double *  T, double *  y,  double *  gbms)
+void CKGBMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  gbms)
 {
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double gort[21]; /* temporary storage */
-    double x[21]; /* need a ytx conversion */
-    double YOW = 0; /*To hold 1/molecularweight */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real gort[21]; /* temporary storage */
+    amrex::Real x[21]; /* need a ytx conversion */
+    amrex::Real YOW = 0; /*To hold 1/molecularweight */
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*H */
@@ -3203,16 +3203,16 @@ void CKGBMS(double *  P, double *  T, double *  y,  double *  gbms)
 
 
 /*Returns mean helmholtz free energy in molar units */
-void CKABML(double *  P, double *  T, double *  x,  double *  abml)
+void CKABML(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  abml)
 {
     int id; /*loop counter */
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double aort[21]; /* temporary storage */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real aort[21]; /* temporary storage */
     /*Compute g/RT */
     helmholtz(aort, tc);
 
@@ -3226,17 +3226,17 @@ void CKABML(double *  P, double *  T, double *  x,  double *  abml)
 
 
 /*Returns mixture helmholtz free energy in mass units */
-void CKABMS(double *  P, double *  T, double *  y,  double *  abms)
+void CKABMS(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  abms)
 {
-    double result = 0; 
+    amrex::Real result = 0; 
     /*Log of normalized pressure in cgs units dynes/cm^2 by Patm */
-    double logPratio = log ( *P / 1013250.0 ); 
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double RT = 8.31446261815324e+07*tT; /*R*T */
-    double aort[21]; /* temporary storage */
-    double x[21]; /* need a ytx conversion */
-    double YOW = 0; /*To hold 1/molecularweight */
+    amrex::Real logPratio = log ( *P / 1013250.0 ); 
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real RT = 8.31446261815324e+07*tT; /*R*T */
+    amrex::Real aort[21]; /* temporary storage */
+    amrex::Real x[21]; /* need a ytx conversion */
+    amrex::Real YOW = 0; /*To hold 1/molecularweight */
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*H */
@@ -3310,7 +3310,7 @@ void CKABMS(double *  P, double *  T, double *  y,  double *  abms)
 
 
 /*compute the production rate for each species */
-AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C,  double *  wdot)
+AMREX_GPU_HOST_DEVICE void CKWC(amrex::Real *  T, amrex::Real *  C,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
 
@@ -3332,12 +3332,12 @@ AMREX_GPU_HOST_DEVICE void CKWC(double *  T, double *  C,  double *  wdot)
 
 /*Returns the molar production rate of species */
 /*Given P, T, and mass fractions */
-void CKWYP(double *  P, double *  T, double *  y,  double *  wdot)
+void CKWYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[21]; /*temporary storage */
-    double YOW = 0; 
-    double PWORT; 
+    amrex::Real c[21]; /*temporary storage */
+    amrex::Real YOW = 0; 
+    amrex::Real PWORT; 
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*H */
@@ -3399,11 +3399,11 @@ void CKWYP(double *  P, double *  T, double *  y,  double *  wdot)
 
 /*Returns the molar production rate of species */
 /*Given P, T, and mole fractions */
-void CKWXP(double *  P, double *  T, double *  x,  double *  wdot)
+void CKWXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[21]; /*temporary storage */
-    double PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
+    amrex::Real c[21]; /*temporary storage */
+    amrex::Real PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 21; ++id) {
@@ -3422,10 +3422,10 @@ void CKWXP(double *  P, double *  T, double *  x,  double *  wdot)
 
 /*Returns the molar production rate of species */
 /*Given rho, T, and mass fractions */
-AMREX_GPU_HOST_DEVICE void CKWYR(double *  rho, double *  T, double *  y,  double *  wdot)
+AMREX_GPU_HOST_DEVICE void CKWYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[21]; /*temporary storage */
+    amrex::Real c[21]; /*temporary storage */
     /*See Eq 8 with an extra 1e6 so c goes to SI */
     c[0] = 1e6 * (*rho) * y[0]*imw[0]; 
     c[1] = 1e6 * (*rho) * y[1]*imw[1]; 
@@ -3461,12 +3461,12 @@ AMREX_GPU_HOST_DEVICE void CKWYR(double *  rho, double *  T, double *  y,  doubl
 
 /*Returns the molar production rate of species */
 /*Given rho, T, and mass fractions */
-void VCKWYR(int *  np, double *  rho, double *  T,
-	    double *  y,
-	    double *  wdot)
+void VCKWYR(int *  np, amrex::Real *  rho, amrex::Real *  T,
+	    amrex::Real *  y,
+	    amrex::Real *  wdot)
 {
 #ifndef AMREX_USE_CUDA
-    double c[21*(*np)]; /*temporary storage */
+    amrex::Real c[21*(*np)]; /*temporary storage */
     /*See Eq 8 with an extra 1e6 so c goes to SI */
     for (int n=0; n<21; n++) {
         for (int i=0; i<(*np); i++) {
@@ -3487,12 +3487,12 @@ void VCKWYR(int *  np, double *  rho, double *  T,
 
 /*Returns the molar production rate of species */
 /*Given rho, T, and mole fractions */
-void CKWXR(double *  rho, double *  T, double *  x,  double *  wdot)
+void CKWXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  wdot)
 {
     int id; /*loop counter */
-    double c[21]; /*temporary storage */
-    double XW = 0; /*See Eq 4, 11 in CK Manual */
-    double ROW; 
+    amrex::Real c[21]; /*temporary storage */
+    amrex::Real XW = 0; /*See Eq 4, 11 in CK Manual */
+    amrex::Real ROW; 
     /*Compute mean molecular wt first */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
@@ -3534,7 +3534,7 @@ void CKWXR(double *  rho, double *  T, double *  x,  double *  wdot)
 
 
 /*Returns the rate of progress for each reaction */
-void CKQC(double *  T, double *  C, double *  qdot)
+void CKQC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  qdot)
 {
     int id; /*loop counter */
 
@@ -3559,11 +3559,11 @@ void CKQC(double *  T, double *  C, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given P, T, and mole fractions */
-void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r)
+void CKKFKR(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  q_f, amrex::Real *  q_r)
 {
     int id; /*loop counter */
-    double c[21]; /*temporary storage */
-    double PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
+    amrex::Real c[21]; /*temporary storage */
+    amrex::Real PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 21; ++id) {
@@ -3583,12 +3583,12 @@ void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r)
 
 /*Returns the progress rates of each reactions */
 /*Given P, T, and mass fractions */
-void CKQYP(double *  P, double *  T, double *  y, double *  qdot)
+void CKQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[21]; /*temporary storage */
-    double YOW = 0; 
-    double PWORT; 
+    amrex::Real c[21]; /*temporary storage */
+    amrex::Real YOW = 0; 
+    amrex::Real PWORT; 
     /*Compute inverse of mean molecular wt first */
     YOW += y[0]*imw[0]; /*H2 */
     YOW += y[1]*imw[1]; /*H */
@@ -3650,11 +3650,11 @@ void CKQYP(double *  P, double *  T, double *  y, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given P, T, and mole fractions */
-void CKQXP(double *  P, double *  T, double *  x, double *  qdot)
+void CKQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[21]; /*temporary storage */
-    double PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
+    amrex::Real c[21]; /*temporary storage */
+    amrex::Real PORT = 1e6 * (*P)/(8.31446261815324e+07 * (*T)); /*1e6 * P/RT so c goes to SI units */
 
     /*Compute conversion, see Eq 10 */
     for (id = 0; id < 21; ++id) {
@@ -3673,10 +3673,10 @@ void CKQXP(double *  P, double *  T, double *  x, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given rho, T, and mass fractions */
-void CKQYR(double *  rho, double *  T, double *  y, double *  qdot)
+void CKQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[21]; /*temporary storage */
+    amrex::Real c[21]; /*temporary storage */
     /*See Eq 8 with an extra 1e6 so c goes to SI */
     c[0] = 1e6 * (*rho) * y[0]*imw[0]; 
     c[1] = 1e6 * (*rho) * y[1]*imw[1]; 
@@ -3712,12 +3712,12 @@ void CKQYR(double *  rho, double *  T, double *  y, double *  qdot)
 
 /*Returns the progress rates of each reactions */
 /*Given rho, T, and mole fractions */
-void CKQXR(double *  rho, double *  T, double *  x, double *  qdot)
+void CKQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot)
 {
     int id; /*loop counter */
-    double c[21]; /*temporary storage */
-    double XW = 0; /*See Eq 4, 11 in CK Manual */
-    double ROW; 
+    amrex::Real c[21]; /*temporary storage */
+    amrex::Real XW = 0; /*See Eq 4, 11 in CK Manual */
+    amrex::Real ROW; 
     /*Compute mean molecular wt first */
     XW += x[0]*2.015940; /*H2 */
     XW += x[1]*1.007970; /*H */
@@ -4378,7 +4378,7 @@ void CKNCF(int * ncf)
 
 /*Returns the arrehenius coefficients  */
 /*for all reactions */
-void CKABE( double *  a, double *  b, double *  e)
+void CKABE( amrex::Real *  a, amrex::Real *  b, amrex::Real *  e)
 {
     // (29):  H + CH2 (+M) <=> CH3 (+M)
     a[0] = 25000000000000000;
@@ -4806,11 +4806,11 @@ void CKABE( double *  a, double *  b, double *  e)
 
 
 /*Returns the equil constants for each reaction */
-void CKEQC(double *  T, double *  C, double *  eqcon)
+void CKEQC(amrex::Real *  T, amrex::Real *  C, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[21]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[21]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -5074,11 +5074,11 @@ void CKEQC(double *  T, double *  C, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given P, T, and mass fractions */
-void CKEQYP(double *  P, double *  T, double *  y, double *  eqcon)
+void CKEQYP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[21]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[21]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -5342,11 +5342,11 @@ void CKEQYP(double *  P, double *  T, double *  y, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given P, T, and mole fractions */
-void CKEQXP(double *  P, double *  T, double *  x, double *  eqcon)
+void CKEQXP(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[21]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[21]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -5610,11 +5610,11 @@ void CKEQXP(double *  P, double *  T, double *  x, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given rho, T, and mass fractions */
-void CKEQYR(double *  rho, double *  T, double *  y, double *  eqcon)
+void CKEQYR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[21]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[21]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -5878,11 +5878,11 @@ void CKEQYR(double *  rho, double *  T, double *  y, double *  eqcon)
 
 /*Returns the equil constants for each reaction */
 /*Given rho, T, and mole fractions */
-void CKEQXR(double *  rho, double *  T, double *  x, double *  eqcon)
+void CKEQXR(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon)
 {
-    double tT = *T; /*temporary temperature */
-    double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
-    double gort[21]; /* temporary storage */
+    amrex::Real tT = *T; /*temporary temperature */
+    amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; /*temperature cache */
+    amrex::Real gort[21]; /* temporary storage */
 
     /*compute the Gibbs free energy */
     gibbs(gort, tc);
@@ -6146,12 +6146,12 @@ void CKEQXR(double *  rho, double *  T, double *  x, double *  eqcon)
 #ifdef AMREX_USE_CUDA
 /*GPU version of productionRate: no more use of thermo namespace vectors */
 /*compute the production rate for each species */
-AMREX_GPU_HOST_DEVICE inline void  productionRate(double * wdot, double * sc, double T)
+AMREX_GPU_HOST_DEVICE inline void  productionRate(amrex::Real * wdot, amrex::Real * sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 
-    double qdot, q_f[84], q_r[84];
+    amrex::Real qdot, q_f[84], q_r[84];
     comp_qfqr(q_f, q_r, sc, tc, invT);
 
     for (int i = 0; i < 21; ++i) {
@@ -6648,7 +6648,7 @@ AMREX_GPU_HOST_DEVICE inline void  productionRate(double * wdot, double * sc, do
     return;
 }
 
-AMREX_GPU_HOST_DEVICE inline void comp_qfqr(double *  qf, double * qr, double * sc, double * tc, double invT)
+AMREX_GPU_HOST_DEVICE inline void comp_qfqr(amrex::Real *  qf, amrex::Real * qr, amrex::Real * sc, amrex::Real * tc, amrex::Real invT)
 {
 
     /*reaction 1: H + CH2 (+M) <=> CH3 (+M) */
@@ -6988,22 +6988,22 @@ AMREX_GPU_HOST_DEVICE inline void comp_qfqr(double *  qf, double * qr, double * 
     qr[83] = sc[6]*sc[16];
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int i = 0; i < 21; ++i) {
         mixture += sc[i];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[21];
+    amrex::Real g_RT[21];
     gibbs(g_RT, tc);
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 * invT;
-    double refCinv = 1 / refC;
+    amrex::Real refC = 101325 / 8.31446 * invT;
+    amrex::Real refCinv = 1 / refC;
 
     /* Evaluate the kfs */
-    double k_f, k_r, Corr;
-    double redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;
+    amrex::Real k_f, k_r, Corr;
+    amrex::Real redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;
 
     // (0):  O + H + M <=> OH + M
     k_f = 1.0000000000000002e-12 * 5e+17 
@@ -7621,27 +7621,27 @@ AMREX_GPU_HOST_DEVICE inline void comp_qfqr(double *  qf, double * qr, double * 
 
 
 #ifndef AMREX_USE_CUDA
-static double T_save = -1;
+static amrex::Real T_save = -1;
 #ifdef _OPENMP
 #pragma omp threadprivate(T_save)
 #endif
 
-static double k_f_save[84];
+static amrex::Real k_f_save[84];
 #ifdef _OPENMP
 #pragma omp threadprivate(k_f_save)
 #endif
 
-static double Kc_save[84];
+static amrex::Real Kc_save[84];
 #ifdef _OPENMP
 #pragma omp threadprivate(Kc_save)
 #endif
 
 
 /*compute the production rate for each species pointwise on CPU */
-void productionRate(double *  wdot, double *  sc, double T)
+void productionRate(amrex::Real *  wdot, amrex::Real *  sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 
     if (T != T_save)
     {
@@ -7650,7 +7650,7 @@ void productionRate(double *  wdot, double *  sc, double T)
         comp_Kc(tc,invT,Kc_save);
     }
 
-    double qdot, q_f[84], q_r[84];
+    amrex::Real qdot, q_f[84], q_r[84];
     comp_qfqr(q_f, q_r, sc, tc, invT);
 
     for (int i = 0; i < 21; ++i) {
@@ -8147,7 +8147,7 @@ void productionRate(double *  wdot, double *  sc, double T)
     return;
 }
 
-void comp_k_f(double *  tc, double invT, double *  k_f)
+void comp_k_f(amrex::Real *  tc, amrex::Real invT, amrex::Real *  k_f)
 {
     for (int i=0; i<84; ++i) {
         k_f[i] = prefactor_units[i] * fwd_A[i]
@@ -8156,10 +8156,10 @@ void comp_k_f(double *  tc, double invT, double *  k_f)
     return;
 }
 
-void comp_Kc(double *  tc, double invT, double *  Kc)
+void comp_Kc(amrex::Real *  tc, amrex::Real invT, amrex::Real *  Kc)
 {
     /*compute the Gibbs free energy */
-    double g_RT[21];
+    amrex::Real g_RT[21];
     gibbs(g_RT, tc);
 
     Kc[0] = g_RT[1] + g_RT[7] - g_RT[9];
@@ -8252,8 +8252,8 @@ void comp_Kc(double *  tc, double invT, double *  Kc)
     };
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 * invT;
-    double refCinv = 1 / refC;
+    amrex::Real refC = 101325 / 8.31446 * invT;
+    amrex::Real refCinv = 1 / refC;
 
     Kc[0] *= refCinv;
     Kc[1] *= refCinv;
@@ -8282,7 +8282,7 @@ void comp_Kc(double *  tc, double invT, double *  Kc)
     return;
 }
 
-void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double invT)
+void comp_qfqr(amrex::Real *  qf, amrex::Real *  qr, amrex::Real *  sc, amrex::Real *  tc, amrex::Real invT)
 {
 
     /*reaction 1: H + CH2 (+M) <=> CH3 (+M) */
@@ -8621,22 +8621,22 @@ void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double in
     qf[83] = sc[3]*sc[17];
     qr[83] = sc[6]*sc[16];
 
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int i = 0; i < 21; ++i) {
         mixture += sc[i];
     }
 
-    double Corr[84];
+    amrex::Real Corr[84];
     for (int i = 0; i < 84; ++i) {
         Corr[i] = 1.0;
     }
 
     /* troe */
     {
-        double alpha[8];
+        amrex::Real alpha[8];
         alpha[0] = mixture + (TB[0][0] - 1)*sc[0] + (TB[0][1] - 1)*sc[5] + (TB[0][2] - 1)*sc[10] + (TB[0][3] - 1)*sc[11] + (TB[0][4] - 1)*sc[12] + (TB[0][5] - 1)*sc[18] + (TB[0][6] - 1)*sc[20];
         alpha[1] = mixture + (TB[1][0] - 1)*sc[0] + (TB[1][1] - 1)*sc[5] + (TB[1][2] - 1)*sc[10] + (TB[1][3] - 1)*sc[11] + (TB[1][4] - 1)*sc[12] + (TB[1][5] - 1)*sc[18] + (TB[1][6] - 1)*sc[20];
         alpha[2] = mixture + (TB[2][0] - 1)*sc[0] + (TB[2][1] - 1)*sc[5] + (TB[2][2] - 1)*sc[10] + (TB[2][3] - 1)*sc[11] + (TB[2][4] - 1)*sc[12] + (TB[2][5] - 1)*sc[18] + (TB[2][6] - 1)*sc[20];
@@ -8647,7 +8647,7 @@ void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double in
         alpha[7] = mixture + (TB[7][0] - 1)*sc[0] + (TB[7][1] - 1)*sc[5] + (TB[7][2] - 1)*sc[10] + (TB[7][3] - 1)*sc[11] + (TB[7][4] - 1)*sc[12] + (TB[7][5] - 1)*sc[18] + (TB[7][6] - 1)*sc[20];
         for (int i=0; i<8; i++)
         {
-            double redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;
+            amrex::Real redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;
             redP = alpha[i-0] / k_f_save[i] * phase_units[i] * low_A[i] * exp(low_beta[i] * tc[0] - activation_units[i] * low_Ea[i] *invT);
             F = redP / (1.0 + redP);
             logPred = log10(redP);
@@ -8665,7 +8665,7 @@ void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double in
 
     /* simple three-body correction */
     {
-        double alpha;
+        amrex::Real alpha;
         alpha = mixture + (TB[8][0] - 1)*sc[0] + (TB[8][1] - 1)*sc[5] + (TB[8][2] - 1)*sc[10] + (TB[8][3] - 1)*sc[11] + (TB[8][4] - 1)*sc[12] + (TB[8][5] - 1)*sc[18] + (TB[8][6] - 1)*sc[20];
         Corr[8] = alpha;
         alpha = mixture + (TB[9][0] - 1)*sc[0] + (TB[9][1] - 1)*sc[3] + (TB[9][2] - 1)*sc[5] + (TB[9][3] - 1)*sc[10] + (TB[9][4] - 1)*sc[11] + (TB[9][5] - 1)*sc[12] + (TB[9][6] - 1)*sc[18] + (TB[9][7] - 1)*sc[20];
@@ -8693,10 +8693,10 @@ void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double in
 
 #ifndef AMREX_USE_CUDA
 /*compute the production rate for each species */
-void vproductionRate(int npt, double *  wdot, double *  sc, double *  T)
+void vproductionRate(int npt, amrex::Real *  wdot, amrex::Real *  sc, amrex::Real *  T)
 {
-    double k_f_s[84*npt], Kc_s[84*npt], mixture[npt], g_RT[21*npt];
-    double tc[5*npt], invT[npt];
+    amrex::Real k_f_s[84*npt], Kc_s[84*npt], mixture[npt], g_RT[21*npt];
+    amrex::Real tc[5*npt], invT[npt];
 
     for (int i=0; i<npt; i++) {
         tc[0*npt+i] = log(T[i]);
@@ -8728,7 +8728,7 @@ void vproductionRate(int npt, double *  wdot, double *  sc, double *  T)
     vcomp_wdot_51_84(npt, wdot, mixture, sc, k_f_s, Kc_s, tc, invT, T);
 }
 
-void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT)
+void vcomp_k_f(int npt, amrex::Real *  k_f_s, amrex::Real *  tc, amrex::Real *  invT)
 {
     for (int i=0; i<npt; i++) {
         k_f_s[0*npt+i] = prefactor_units[0] * fwd_A[0] * exp(fwd_beta[0] * tc[i] - activation_units[0] * fwd_Ea[0] * invT[i]);
@@ -8818,11 +8818,11 @@ void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT)
     }
 }
 
-void vcomp_gibbs(int npt, double *  g_RT, double *  tc)
+void vcomp_gibbs(int npt, amrex::Real *  g_RT, amrex::Real *  tc)
 {
     /*compute the Gibbs free energy */
     for (int i=0; i<npt; i++) {
-        double tg[5], g[21];
+        amrex::Real tg[5], g[21];
         tg[0] = tc[0*npt+i];
         tg[1] = tc[1*npt+i];
         tg[2] = tc[2*npt+i];
@@ -8855,12 +8855,12 @@ void vcomp_gibbs(int npt, double *  g_RT, double *  tc)
     }
 }
 
-void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT)
+void vcomp_Kc(int npt, amrex::Real *  Kc_s, amrex::Real *  g_RT, amrex::Real *  invT)
 {
     for (int i=0; i<npt; i++) {
         /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-        double refC = (101325. / 8.31451) * invT[i];
-        double refCinv = 1.0 / refC;
+        amrex::Real refC = (101325. / 8.31451) * invT[i];
+        amrex::Real refCinv = 1.0 / refC;
 
         Kc_s[0*npt+i] = refCinv * exp((g_RT[1*npt+i] + g_RT[7*npt+i]) - (g_RT[9*npt+i]));
         Kc_s[1*npt+i] = refCinv * exp((g_RT[1*npt+i] + g_RT[9*npt+i]) - (g_RT[10*npt+i]));
@@ -8949,16 +8949,16 @@ void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT)
     }
 }
 
-void vcomp_wdot_1_50(int npt, double *  wdot, double *  mixture, double *  sc,
-		double *  k_f_s, double *  Kc_s,
-		double *  tc, double *  invT, double *  T)
+void vcomp_wdot_1_50(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,
+		amrex::Real *  k_f_s, amrex::Real *  Kc_s,
+		amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T)
 {
     for (int i=0; i<npt; i++) {
-        double qdot, q_f, q_r, phi_f, phi_r, k_f, k_r, Kc;
-        double alpha;
-        double redP, F;
-        double logPred;
-        double logFcent, troe_c, troe_n, troe, F_troe;
+        amrex::Real qdot, q_f, q_r, phi_f, phi_r, k_f, k_r, Kc;
+        amrex::Real alpha;
+        amrex::Real redP, F;
+        amrex::Real logPred;
+        amrex::Real logFcent, troe_c, troe_n, troe, F_troe;
 
         /*reaction 1: H + CH2 (+M) <=> CH3 (+M) */
         phi_f = sc[1*npt+i]*sc[7*npt+i];
@@ -9764,13 +9764,13 @@ void vcomp_wdot_1_50(int npt, double *  wdot, double *  mixture, double *  sc,
     }
 }
 
-void vcomp_wdot_51_84(int npt, double *  wdot, double *  mixture, double *  sc,
-		double *  k_f_s, double *  Kc_s,
-		double *  tc, double *  invT, double *  T)
+void vcomp_wdot_51_84(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,
+		amrex::Real *  k_f_s, amrex::Real *  Kc_s,
+		amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T)
 {
     for (int i=0; i<npt; i++) {
-        double qdot, q_f, q_r, phi_f, phi_r, k_f, k_r, Kc;
-        double alpha;
+        amrex::Real qdot, q_f, q_r, phi_f, phi_r, k_f, k_r, Kc;
+        amrex::Real alpha;
 
         /*reaction 51: OH + CH4 <=> CH3 + H2O */
         phi_f = sc[4*npt+i]*sc[10*npt+i];
@@ -10252,9 +10252,9 @@ void vcomp_wdot_51_84(int npt, double *  wdot, double *  mixture, double *  sc,
 #endif
 
 /*compute an approx to the reaction Jacobian (for preconditioning) */
-AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double *  Tp, int * HP)
+AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * HP)
 {
-    double c[21];
+    amrex::Real c[21];
 
     for (int k=0; k<21; k++) {
         c[k] = 1.e6 * sc[k];
@@ -10273,9 +10273,9 @@ AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double * 
 }
 
 /*compute the reaction Jacobian */
-AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  Tp, int * consP)
+AMREX_GPU_HOST_DEVICE void DWDOT(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * consP)
 {
-    double c[21];
+    amrex::Real c[21];
 
     for (int k=0; k<21; k++) {
         c[k] = 1.e6 * sc[k];
@@ -10296,8 +10296,8 @@ AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  Tp, int * 
 /*compute the sparsity pattern of the chemistry Jacobian */
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO( int * nJdata, int * consP, int NCELLS)
 {
-    double c[21];
-    double J[484];
+    amrex::Real c[21];
+    amrex::Real J[484];
 
     for (int k=0; k<21; k++) {
         c[k] = 1.0/ 21.000000 ;
@@ -10324,8 +10324,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_INFO( int * nJdata, int * consP, int NCELLS)
 /*compute the sparsity pattern of the system Jacobian */
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST( int * nJdata, int * consP, int NCELLS)
 {
-    double c[21];
-    double J[484];
+    amrex::Real c[21];
+    amrex::Real J[484];
 
     for (int k=0; k<21; k++) {
         c[k] = 1.0/ 21.000000 ;
@@ -10356,8 +10356,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST( int * nJdata, int * consP, int NC
 /*compute the sparsity pattern of the simplified (for preconditioning) system Jacobian */
 AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED( int * nJdata, int * consP)
 {
-    double c[21];
-    double J[484];
+    amrex::Real c[21];
+    amrex::Real J[484];
 
     for (int k=0; k<21; k++) {
         c[k] = 1.0/ 21.000000 ;
@@ -10387,8 +10387,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED( int * nJdata, int * co
 /*compute the sparsity pattern of the chemistry Jacobian in CSC format -- base 0 */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSC(int *  rowVals, int *  colPtrs, int * consP, int NCELLS)
 {
-    double c[21];
-    double J[484];
+    amrex::Real c[21];
+    amrex::Real J[484];
     int offset_row;
     int offset_col;
 
@@ -10420,8 +10420,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSC(int *  rowVals, int *  colPtrs, 
 /*compute the sparsity pattern of the chemistry Jacobian in CSR format -- base 0 */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSR(int * colVals, int * rowPtrs, int * consP, int NCELLS, int base)
 {
-    double c[21];
-    double J[484];
+    amrex::Real c[21];
+    amrex::Real J[484];
     int offset;
 
     for (int k=0; k<21; k++) {
@@ -10469,8 +10469,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_CSR(int * colVals, int * rowPtrs, in
 /*CSR format BASE is user choice */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtr, int * consP, int NCELLS, int base)
 {
-    double c[21];
-    double J[484];
+    amrex::Real c[21];
+    amrex::Real J[484];
     int offset;
 
     for (int k=0; k<21; k++) {
@@ -10528,8 +10528,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtr
 /*BASE 0 */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, int * colPtrs, int * indx, int * consP)
 {
-    double c[21];
-    double J[484];
+    amrex::Real c[21];
+    amrex::Real J[484];
 
     for (int k=0; k<21; k++) {
         c[k] = 1.0/ 21.000000 ;
@@ -10563,8 +10563,8 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, i
 /*CSR format BASE is under choice */
 AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, int * rowPtr, int * consP, int base)
 {
-    double c[21];
-    double J[484];
+    amrex::Real c[21];
+    amrex::Real J[484];
 
     for (int k=0; k<21; k++) {
         c[k] = 1.0/ 21.000000 ;
@@ -10615,7 +10615,7 @@ AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, i
 #ifdef AMREX_USE_CUDA
 /*compute the reaction Jacobian on GPU */
 AMREX_GPU_HOST_DEVICE
-void aJacobian(double * J, double * sc, double T, int consP)
+void aJacobian(amrex::Real * J, amrex::Real * sc, amrex::Real T, int consP)
 {
 
 
@@ -10623,43 +10623,43 @@ void aJacobian(double * J, double * sc, double T, int consP)
         J[i] = 0.0;
     }
 
-    double wdot[21];
+    amrex::Real wdot[21];
     for (int k=0; k<21; k++) {
         wdot[k] = 0.0;
     }
 
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
-    double invT2 = invT * invT;
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
+    amrex::Real invT2 = invT * invT;
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
-    double refCinv = 1.0 / refC;
+    amrex::Real refC = 101325 / 8.31446 / T;
+    amrex::Real refCinv = 1.0 / refC;
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int k = 0; k < 21; ++k) {
         mixture += sc[k];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[21];
+    amrex::Real g_RT[21];
     gibbs(g_RT, tc);
 
     /*compute the species enthalpy */
-    double h_RT[21];
+    amrex::Real h_RT[21];
     speciesEnthalpy(h_RT, tc);
 
-    double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
-    double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
-    double dqdci, dcdc_fac, dqdc[21];
-    double Pr, fPr, F, k_0, logPr;
-    double logFcent, troe_c, troe_n, troePr_den, troePr, troe;
-    double Fcent1, Fcent2, Fcent3, Fcent;
-    double dlogFdc, dlogFdn, dlogFdcn_fac;
-    double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
-    const double ln10 = log(10.0);
-    const double log10e = 1.0/log(10.0);
+    amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
+    amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
+    amrex::Real dqdci, dcdc_fac, dqdc[21];
+    amrex::Real Pr, fPr, F, k_0, logPr;
+    amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;
+    amrex::Real Fcent1, Fcent2, Fcent3, Fcent;
+    amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;
+    amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
+    const amrex::Real ln10 = log(10.0);
+    const amrex::Real log10e = 1.0/log(10.0);
     /*reaction 1: H + CH2 (+M) <=> CH3 (+M) */
     /*a pressure-fall-off reaction */
     /* also 3-body */
@@ -15713,8 +15713,8 @@ void aJacobian(double * J, double * sc, double T, int consP)
     J[478] += dqdT;               /* dwdot[C2H4]/dT */
     J[479] -= dqdT;               /* dwdot[C2H5]/dT */
 
-    double c_R[21], dcRdT[21], e_RT[21];
-    double * eh_RT;
+    amrex::Real c_R[21], dcRdT[21], e_RT[21];
+    amrex::Real * eh_RT;
     if (consP) {
         cp_R(c_R, tc);
         dcvpRdT(dcRdT, tc);
@@ -15727,7 +15727,7 @@ void aJacobian(double * J, double * sc, double T, int consP)
         eh_RT = &e_RT[0];
     }
 
-    double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
+    amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
     for (int k = 0; k < 21; ++k) {
         cmix += c_R[k]*sc[k];
         dcmixdT += dcRdT[k]*sc[k];
@@ -15735,11 +15735,11 @@ void aJacobian(double * J, double * sc, double T, int consP)
         dehmixdT += invT*(c_R[k]-eh_RT[k])*wdot[k] + eh_RT[k]*J[462+k];
     }
 
-    double cmixinv = 1.0/cmix;
-    double tmp1 = ehmix*cmixinv;
-    double tmp3 = cmixinv*T;
-    double tmp2 = tmp1*tmp3;
-    double dehmixdc;
+    amrex::Real cmixinv = 1.0/cmix;
+    amrex::Real tmp1 = ehmix*cmixinv;
+    amrex::Real tmp3 = cmixinv*T;
+    amrex::Real tmp2 = tmp1*tmp3;
+    amrex::Real dehmixdc;
     /* dTdot/d[X] */
     for (int k = 0; k < 21; ++k) {
         dehmixdc = 0.0;
@@ -15758,49 +15758,49 @@ return;
 
 #ifndef AMREX_USE_CUDA
 /*compute the reaction Jacobian on CPU */
-void aJacobian(double *  J, double *  sc, double T, int consP)
+void aJacobian(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int consP)
 {
     for (int i=0; i<484; i++) {
         J[i] = 0.0;
     }
 
-    double wdot[21];
+    amrex::Real wdot[21];
     for (int k=0; k<21; k++) {
         wdot[k] = 0.0;
     }
 
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
-    double invT2 = invT * invT;
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
+    amrex::Real invT2 = invT * invT;
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
-    double refCinv = 1.0 / refC;
+    amrex::Real refC = 101325 / 8.31446 / T;
+    amrex::Real refCinv = 1.0 / refC;
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int k = 0; k < 21; ++k) {
         mixture += sc[k];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[21];
+    amrex::Real g_RT[21];
     gibbs(g_RT, tc);
 
     /*compute the species enthalpy */
-    double h_RT[21];
+    amrex::Real h_RT[21];
     speciesEnthalpy(h_RT, tc);
 
-    double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
-    double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
-    double dqdci, dcdc_fac, dqdc[21];
-    double Pr, fPr, F, k_0, logPr;
-    double logFcent, troe_c, troe_n, troePr_den, troePr, troe;
-    double Fcent1, Fcent2, Fcent3, Fcent;
-    double dlogFdc, dlogFdn, dlogFdcn_fac;
-    double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
-    const double ln10 = log(10.0);
-    const double log10e = 1.0/log(10.0);
+    amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
+    amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
+    amrex::Real dqdci, dcdc_fac, dqdc[21];
+    amrex::Real Pr, fPr, F, k_0, logPr;
+    amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;
+    amrex::Real Fcent1, Fcent2, Fcent3, Fcent;
+    amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;
+    amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
+    const amrex::Real ln10 = log(10.0);
+    const amrex::Real log10e = 1.0/log(10.0);
     /*reaction 1: H + CH2 (+M) <=> CH3 (+M) */
     /*a pressure-fall-off reaction */
     /* also 3-body */
@@ -20860,8 +20860,8 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
     J[478] += dqdT;               /* dwdot[C2H4]/dT */
     J[479] -= dqdT;               /* dwdot[C2H5]/dT */
 
-    double c_R[21], dcRdT[21], e_RT[21];
-    double * eh_RT;
+    amrex::Real c_R[21], dcRdT[21], e_RT[21];
+    amrex::Real * eh_RT;
     if (consP) {
         cp_R(c_R, tc);
         dcvpRdT(dcRdT, tc);
@@ -20874,7 +20874,7 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
         eh_RT = &e_RT[0];
     }
 
-    double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
+    amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
     for (int k = 0; k < 21; ++k) {
         cmix += c_R[k]*sc[k];
         dcmixdT += dcRdT[k]*sc[k];
@@ -20882,11 +20882,11 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
         dehmixdT += invT*(c_R[k]-eh_RT[k])*wdot[k] + eh_RT[k]*J[462+k];
     }
 
-    double cmixinv = 1.0/cmix;
-    double tmp1 = ehmix*cmixinv;
-    double tmp3 = cmixinv*T;
-    double tmp2 = tmp1*tmp3;
-    double dehmixdc;
+    amrex::Real cmixinv = 1.0/cmix;
+    amrex::Real tmp1 = ehmix*cmixinv;
+    amrex::Real tmp3 = cmixinv*T;
+    amrex::Real tmp2 = tmp1*tmp3;
+    amrex::Real dehmixdc;
     /* dTdot/d[X] */
     for (int k = 0; k < 21; ++k) {
         dehmixdc = 0.0;
@@ -20902,49 +20902,49 @@ void aJacobian(double *  J, double *  sc, double T, int consP)
 
 
 /*compute an approx to the reaction Jacobian */
-AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T, int HP)
+AMREX_GPU_HOST_DEVICE void aJacobian_precond(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int HP)
 {
     for (int i=0; i<484; i++) {
         J[i] = 0.0;
     }
 
-    double wdot[21];
+    amrex::Real wdot[21];
     for (int k=0; k<21; k++) {
         wdot[k] = 0.0;
     }
 
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
-    double invT2 = invT * invT;
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
+    amrex::Real invT2 = invT * invT;
 
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
-    double refCinv = 1.0 / refC;
+    amrex::Real refC = 101325 / 8.31446 / T;
+    amrex::Real refCinv = 1.0 / refC;
 
     /*compute the mixture concentration */
-    double mixture = 0.0;
+    amrex::Real mixture = 0.0;
     for (int k = 0; k < 21; ++k) {
         mixture += sc[k];
     }
 
     /*compute the Gibbs free energy */
-    double g_RT[21];
+    amrex::Real g_RT[21];
     gibbs(g_RT, tc);
 
     /*compute the species enthalpy */
-    double h_RT[21];
+    amrex::Real h_RT[21];
     speciesEnthalpy(h_RT, tc);
 
-    double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
-    double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
-    double dqdci, dcdc_fac, dqdc[21];
-    double Pr, fPr, F, k_0, logPr;
-    double logFcent, troe_c, troe_n, troePr_den, troePr, troe;
-    double Fcent1, Fcent2, Fcent3, Fcent;
-    double dlogFdc, dlogFdn, dlogFdcn_fac;
-    double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
-    const double ln10 = log(10.0);
-    const double log10e = 1.0/log(10.0);
+    amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;
+    amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;
+    amrex::Real dqdci, dcdc_fac, dqdc[21];
+    amrex::Real Pr, fPr, F, k_0, logPr;
+    amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;
+    amrex::Real Fcent1, Fcent2, Fcent3, Fcent;
+    amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;
+    amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;
+    const amrex::Real ln10 = log(10.0);
+    const amrex::Real log10e = 1.0/log(10.0);
     /*reaction 1: H + CH2 (+M) <=> CH3 (+M) */
     /*a pressure-fall-off reaction */
     /* also 3-body */
@@ -25348,8 +25348,8 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
     J[478] += dqdT;               /* dwdot[C2H4]/dT */
     J[479] -= dqdT;               /* dwdot[C2H5]/dT */
 
-    double c_R[21], dcRdT[21], e_RT[21];
-    double * eh_RT;
+    amrex::Real c_R[21], dcRdT[21], e_RT[21];
+    amrex::Real * eh_RT;
     if (HP) {
         cp_R(c_R, tc);
         dcvpRdT(dcRdT, tc);
@@ -25362,7 +25362,7 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
         eh_RT = &e_RT[0];
     }
 
-    double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
+    amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;
     for (int k = 0; k < 21; ++k) {
         cmix += c_R[k]*sc[k];
         dcmixdT += dcRdT[k]*sc[k];
@@ -25370,11 +25370,11 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
         dehmixdT += invT*(c_R[k]-eh_RT[k])*wdot[k] + eh_RT[k]*J[462+k];
     }
 
-    double cmixinv = 1.0/cmix;
-    double tmp1 = ehmix*cmixinv;
-    double tmp3 = cmixinv*T;
-    double tmp2 = tmp1*tmp3;
-    double dehmixdc;
+    amrex::Real cmixinv = 1.0/cmix;
+    amrex::Real tmp1 = ehmix*cmixinv;
+    amrex::Real tmp3 = cmixinv*T;
+    amrex::Real tmp2 = tmp1*tmp3;
+    amrex::Real dehmixdc;
     /* dTdot/d[X] */
     for (int k = 0; k < 21; ++k) {
         dehmixdc = 0.0;
@@ -25390,11 +25390,11 @@ AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T
 
 /*compute d(Cp/R)/dT and d(Cv/R)/dT at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void dcvpRdT(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void dcvpRdT(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -25657,10 +25657,10 @@ AMREX_GPU_HOST_DEVICE void dcvpRdT(double * species, double *  tc)
 
 
 /*compute the progress rate for each reaction */
-AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  sc, double T)
+AMREX_GPU_HOST_DEVICE void progressRate(amrex::Real *  qdot, amrex::Real *  sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 
 #ifndef AMREX_USE_CUDA
     if (T != T_save)
@@ -25671,7 +25671,7 @@ AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  sc, double T)
     }
 #endif
 
-    double q_f[84], q_r[84];
+    amrex::Real q_f[84], q_r[84];
     comp_qfqr(q_f, q_r, sc, tc, invT);
 
     for (int i = 0; i < 84; ++i) {
@@ -25683,10 +25683,10 @@ AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  sc, double T)
 
 
 /*compute the progress rate for each reaction */
-AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *  sc, double T)
+AMREX_GPU_HOST_DEVICE void progressRateFR(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  sc, amrex::Real T)
 {
-    double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
-    double invT = 1.0 / tc[1];
+    amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */
+    amrex::Real invT = 1.0 / tc[1];
 #ifndef AMREX_USE_CUDA
 
     if (T != T_save)
@@ -25704,10 +25704,10 @@ AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *
 
 
 /*compute the equilibrium constants for each reaction */
-void equilibriumConstants(double *  kc, double *  g_RT, double T)
+void equilibriumConstants(amrex::Real *  kc, amrex::Real *  g_RT, amrex::Real T)
 {
     /*reference concentration: P_atm / (RT) in inverse mol/m^3 */
-    double refC = 101325 / 8.31446 / T;
+    amrex::Real refC = 101325 / 8.31446 / T;
 
     /*reaction 1: H + CH2 (+M) <=> CH3 (+M) */
     kc[0] = 1.0 / (refC) * exp((g_RT[1] + g_RT[7]) - (g_RT[9]));
@@ -25967,12 +25967,12 @@ void equilibriumConstants(double *  kc, double *  g_RT, double T)
 
 /*compute the g/(RT) at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void gibbs(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void gibbs(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -26362,12 +26362,12 @@ AMREX_GPU_HOST_DEVICE void gibbs(double * species, double *  tc)
 
 /*compute the a/(RT) at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void helmholtz(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void helmholtz(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -26757,11 +26757,11 @@ AMREX_GPU_HOST_DEVICE void helmholtz(double * species, double *  tc)
 
 /*compute Cv/R at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void cv_R(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void cv_R(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -27067,11 +27067,11 @@ AMREX_GPU_HOST_DEVICE void cv_R(double * species, double *  tc)
 
 /*compute Cp/R at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void cp_R(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void cp_R(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -27377,12 +27377,12 @@ AMREX_GPU_HOST_DEVICE void cp_R(double * species, double *  tc)
 
 /*compute the e/(RT) at the given temperature */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -27730,12 +27730,12 @@ AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double * species, double *  tc)
 
 /*compute the h/(RT) at the given temperature (Eq 20) */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void speciesEnthalpy(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
-    double invT = 1 / T;
+    amrex::Real T = tc[1];
+    amrex::Real invT = 1 / T;
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -28083,11 +28083,11 @@ AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double * species, double *  tc)
 
 /*compute the S/R at the given temperature (Eq 21) */
 /*tc contains precomputed powers of T, tc[0] = log(T) */
-AMREX_GPU_HOST_DEVICE void speciesEntropy(double * species, double *  tc)
+AMREX_GPU_HOST_DEVICE void speciesEntropy(amrex::Real * species, amrex::Real *  tc)
 {
 
     /*temperature */
-    double T = tc[1];
+    amrex::Real T = tc[1];
 
     /*species with midpoint at T=1000 kelvin */
     if (T < 1000) {
@@ -28434,7 +28434,7 @@ AMREX_GPU_HOST_DEVICE void speciesEntropy(double * species, double *  tc)
 
 
 /*save atomic weights into array */
-void atomicWeight(double *  awt)
+void atomicWeight(amrex::Real *  awt)
 {
     awt[0] = 15.999400; /*O */
     awt[1] = 1.007970; /*H */
@@ -28447,19 +28447,19 @@ void atomicWeight(double *  awt)
 
 
 /* get temperature given internal energy in mass units and mass fracs */
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t, int * ierr)
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(amrex::Real *  e, amrex::Real *  y, amrex::Real *  t, int * ierr)
 {
 #ifdef CONVERGENCE
     const int maxiter = 5000;
-    const double tol  = 1.e-12;
+    const amrex::Real tol  = 1.e-12;
 #else
     const int maxiter = 200;
-    const double tol  = 1.e-6;
+    const amrex::Real tol  = 1.e-6;
 #endif
-    double ein  = *e;
-    double tmin = 90;/*max lower bound for thermo def */
-    double tmax = 4000;/*min upper bound for thermo def */
-    double e1,emin,emax,cv,t1,dt;
+    amrex::Real ein  = *e;
+    amrex::Real tmin = 90;/*max lower bound for thermo def */
+    amrex::Real tmax = 4000;/*min upper bound for thermo def */
+    amrex::Real e1,emin,emax,cv,t1,dt;
     int i;/* loop counter */
     CKUBMS(&tmin, y, &emin);
     CKUBMS(&tmax, y, &emax);
@@ -28497,19 +28497,19 @@ AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t,
 }
 
 /* get temperature given enthalpy in mass units and mass fracs */
-AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t, int * ierr)
+AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(amrex::Real *  h, amrex::Real *  y, amrex::Real *  t, int * ierr)
 {
 #ifdef CONVERGENCE
     const int maxiter = 5000;
-    const double tol  = 1.e-12;
+    const amrex::Real tol  = 1.e-12;
 #else
     const int maxiter = 200;
-    const double tol  = 1.e-6;
+    const amrex::Real tol  = 1.e-6;
 #endif
-    double hin  = *h;
-    double tmin = 90;/*max lower bound for thermo def */
-    double tmax = 4000;/*min upper bound for thermo def */
-    double h1,hmin,hmax,cp,t1,dt;
+    amrex::Real hin  = *h;
+    amrex::Real tmin = 90;/*max lower bound for thermo def */
+    amrex::Real tmax = 4000;/*min upper bound for thermo def */
+    amrex::Real h1,hmin,hmax,cp,t1,dt;
     int i;/* loop counter */
     CKHBMS(&tmin, y, &hmin);
     CKHBMS(&tmax, y, &hmax);
@@ -28548,15 +28548,15 @@ AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t,
 
 
 /*compute the critical parameters for each species */
-void GET_CRITPARAMS(double *  Tci, double *  ai, double *  bi, double *  acentric_i)
+void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i)
 {
 
-    double   EPS[21];
-    double   SIG[21];
-    double    wt[21];
-    double avogadro = 6.02214199e23;
-    double boltzmann = 1.3806503e-16; //we work in CGS
-    double Rcst = 83.144598; //in bar [CGS] !
+    amrex::Real   EPS[21];
+    amrex::Real   SIG[21];
+    amrex::Real    wt[21];
+    amrex::Real avogadro = 6.02214199e23;
+    amrex::Real boltzmann = 1.3806503e-16; //we work in CGS
+    amrex::Real Rcst = 83.144598; //in bar [CGS] !
 
     egtransetEPS(EPS);
     egtransetSIG(SIG);
@@ -28723,12 +28723,12 @@ void egtransetNLITE(int* NLITE ) {
 
 
 /*Patm in ergs/cm3 */
-void egtransetPATM(double* PATM) {
+void egtransetPATM(amrex::Real* PATM) {
     *PATM =   0.1013250000000000E+07;}
 
 
 /*the molecular weights in g/mol */
-void egtransetWT(double* WT ) {
+void egtransetWT(amrex::Real* WT ) {
     WT[0] = 2.01594000E+00;
     WT[1] = 1.00797000E+00;
     WT[2] = 1.59994000E+01;
@@ -28754,7 +28754,7 @@ void egtransetWT(double* WT ) {
 
 
 /*the lennard-jones potential well depth eps/kb in K */
-void egtransetEPS(double* EPS ) {
+void egtransetEPS(amrex::Real* EPS ) {
     EPS[0] = 3.80000000E+01;
     EPS[1] = 1.45000000E+02;
     EPS[2] = 8.00000000E+01;
@@ -28780,7 +28780,7 @@ void egtransetEPS(double* EPS ) {
 
 
 /*the lennard-jones collision diameter in Angstroms */
-void egtransetSIG(double* SIG ) {
+void egtransetSIG(amrex::Real* SIG ) {
     SIG[0] = 2.92000000E+00;
     SIG[1] = 2.05000000E+00;
     SIG[2] = 2.75000000E+00;
@@ -28806,7 +28806,7 @@ void egtransetSIG(double* SIG ) {
 
 
 /*the dipole moment in Debye */
-void egtransetDIP(double* DIP ) {
+void egtransetDIP(amrex::Real* DIP ) {
     DIP[0] = 0.00000000E+00;
     DIP[1] = 0.00000000E+00;
     DIP[2] = 0.00000000E+00;
@@ -28832,7 +28832,7 @@ void egtransetDIP(double* DIP ) {
 
 
 /*the polarizability in cubic Angstroms */
-void egtransetPOL(double* POL ) {
+void egtransetPOL(amrex::Real* POL ) {
     POL[0] = 7.90000000E-01;
     POL[1] = 0.00000000E+00;
     POL[2] = 0.00000000E+00;
@@ -28858,7 +28858,7 @@ void egtransetPOL(double* POL ) {
 
 
 /*the rotational relaxation collision number at 298 K */
-void egtransetZROT(double* ZROT ) {
+void egtransetZROT(amrex::Real* ZROT ) {
     ZROT[0] = 2.80000000E+02;
     ZROT[1] = 0.00000000E+00;
     ZROT[2] = 0.00000000E+00;
@@ -28910,7 +28910,7 @@ void egtransetNLIN(int* NLIN) {
 
 
 /*Poly fits for the viscosities, dim NO*KK */
-void egtransetCOFETA(double* COFETA) {
+void egtransetCOFETA(amrex::Real* COFETA) {
     COFETA[0] = -1.38347699E+01;
     COFETA[1] = 1.00106621E+00;
     COFETA[2] = -4.98105694E-02;
@@ -28999,7 +28999,7 @@ void egtransetCOFETA(double* COFETA) {
 
 
 /*Poly fits for the conductivities, dim NO*KK */
-void egtransetCOFLAM(double* COFLAM) {
+void egtransetCOFLAM(amrex::Real* COFLAM) {
     COFLAM[0] = 9.24084392E+00;
     COFLAM[1] = -4.69568931E-01;
     COFLAM[2] = 1.15980279E-01;
@@ -29088,7 +29088,7 @@ void egtransetCOFLAM(double* COFLAM) {
 
 
 /*Poly fits for the diffusion coefficients, dim NO*KK*KK */
-void egtransetCOFD(double* COFD) {
+void egtransetCOFD(amrex::Real* COFD) {
     COFD[0] = -1.03270606E+01;
     COFD[1] = 2.19285409E+00;
     COFD[2] = -7.54492786E-02;
@@ -30864,7 +30864,7 @@ void egtransetKTDIF(int* KTDIF) {
 
 
 /*Poly fits for thermal diff ratios, dim NO*NLITE*KK */
-void egtransetCOFTD(double* COFTD) {
+void egtransetCOFTD(amrex::Real* COFTD) {
     COFTD[0] = 0.00000000E+00;
     COFTD[1] = 0.00000000E+00;
     COFTD[2] = 0.00000000E+00;
@@ -31034,3 +31034,14 @@ void egtransetCOFTD(double* COFTD) {
     COFTD[166] = -3.64844875E-07;
     COFTD[167] = 6.03054876E-11;
 }
+
+/* Replace this routine with the one generated by the Gauss Jordan solver of DW */
+AMREX_GPU_HOST_DEVICE void sgjsolve(amrex::Real* A, amrex::Real* x, amrex::Real* b) {
+    amrex::Abort("sgjsolve not implemented, choose a different solver ");
+}
+
+/* Replace this routine with the one generated by the Gauss Jordan solver of DW */
+AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(amrex::Real* A, amrex::Real* x, amrex::Real* b) {
+    amrex::Abort("sgjsolve_simplified not implemented, choose a different solver ");
+}
+

--- a/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/c/CPickler.py
+++ b/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/c/CPickler.py
@@ -296,28 +296,28 @@ class CPickler(CMill):
             '',
             'extern "C"',
             '{',
-            'AMREX_GPU_HOST_DEVICE void get_imw(double imw_new[]);',
-            'AMREX_GPU_HOST_DEVICE void get_mw(double mw_new[]);',
-            'void egtransetEPS(double *  EPS);',
-            'void egtransetSIG(double* SIG);',
-            'void atomicWeight(double *  awt);',
-            'void molecularWeight(double *  wt);',
-            'AMREX_GPU_HOST_DEVICE void gibbs(double *  species, double *  tc);',
-            'AMREX_GPU_HOST_DEVICE void helmholtz(double *  species, double *  tc);',
-            'AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(double *  species, double *  tc);',
-            'AMREX_GPU_HOST_DEVICE void speciesEnthalpy(double *  species, double *  tc);',
-            'AMREX_GPU_HOST_DEVICE void speciesEntropy(double *  species, double *  tc);',
-            'AMREX_GPU_HOST_DEVICE void cp_R(double *  species, double *  tc);',
-            'AMREX_GPU_HOST_DEVICE void cv_R(double *  species, double *  tc);',
-            'void equilibriumConstants(double *  kc, double *  g_RT, double T);',
-            'AMREX_GPU_HOST_DEVICE void productionRate(double *  wdot, double *  sc, double T);',
-            'AMREX_GPU_HOST_DEVICE void comp_qfqr(double *  q_f, double *  q_r, double *  sc, double *  tc, double invT);',
+            'AMREX_GPU_HOST_DEVICE void get_imw(amrex::Real imw_new[]);',
+            'AMREX_GPU_HOST_DEVICE void get_mw(amrex::Real mw_new[]);',
+            'void egtransetEPS(amrex::Real *  EPS);',
+            'void egtransetSIG(amrex::Real* SIG);',
+            'void atomicWeight(amrex::Real *  awt);',
+            'void molecularWeight(amrex::Real *  wt);',
+            'AMREX_GPU_HOST_DEVICE void gibbs(amrex::Real *  species, amrex::Real *  tc);',
+            'AMREX_GPU_HOST_DEVICE void helmholtz(amrex::Real *  species, amrex::Real *  tc);',
+            'AMREX_GPU_HOST_DEVICE void speciesInternalEnergy(amrex::Real *  species, amrex::Real *  tc);',
+            'AMREX_GPU_HOST_DEVICE void speciesEnthalpy(amrex::Real *  species, amrex::Real *  tc);',
+            'AMREX_GPU_HOST_DEVICE void speciesEntropy(amrex::Real *  species, amrex::Real *  tc);',
+            'AMREX_GPU_HOST_DEVICE void cp_R(amrex::Real *  species, amrex::Real *  tc);',
+            'AMREX_GPU_HOST_DEVICE void cv_R(amrex::Real *  species, amrex::Real *  tc);',
+            'void equilibriumConstants(amrex::Real *  kc, amrex::Real *  g_RT, amrex::Real T);',
+            'AMREX_GPU_HOST_DEVICE void productionRate(amrex::Real *  wdot, amrex::Real *  sc, amrex::Real T);',
+            'AMREX_GPU_HOST_DEVICE void comp_qfqr(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  sc, amrex::Real *  tc, amrex::Real invT);',
             '#ifndef AMREX_USE_CUDA',
-            'void comp_k_f(double *  tc, double invT, double *  k_f);',
-            'void comp_Kc(double *  tc, double invT, double *  Kc);',
+            'void comp_k_f(amrex::Real *  tc, amrex::Real invT, amrex::Real *  k_f);',
+            'void comp_Kc(amrex::Real *  tc, amrex::Real invT, amrex::Real *  Kc);',
             '#endif',
-            'AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  speciesConc, double T);',
-            'AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *  speciesConc, double T);',
+            'AMREX_GPU_HOST_DEVICE void progressRate(amrex::Real *  qdot, amrex::Real *  speciesConc, amrex::Real T);',
+            'AMREX_GPU_HOST_DEVICE void progressRateFR(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  speciesConc, amrex::Real T);',
             ##'#ifndef AMREX_USE_CUDA',
             'AMREX_GPU_HOST_DEVICE void CKINIT'+sym+'();',
             'AMREX_GPU_HOST_DEVICE void CKFINALIZE'+sym+'();',
@@ -326,82 +326,82 @@ class CPickler(CMill):
             'void SetAllDefaults();',
             '#endif',
             'void CKINDX'+sym+'(int * mm, int * kk, int * ii, int * nfit );',
-            'void CKXNUM'+sym+'(char * line, int * nexp, int * lout, int * nval, double *  rval, int * kerr, int lenline);',
-            'void CKSNUM'+sym+'(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, double *  rval, int * kerr, int lenline, int lenkray);',
+            'void CKXNUM'+sym+'(char * line, int * nexp, int * lout, int * nval, amrex::Real *  rval, int * kerr, int lenline);',
+            'void CKSNUM'+sym+'(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, amrex::Real *  rval, int * kerr, int lenline, int lenkray);',
             'void CKSYME_STR(amrex::Vector<std::string>& ename);',
             'void CKSYME(int * kname, int * lenkname);',
             'void CKSYMS_STR(amrex::Vector<std::string>& kname);',
             'void CKSYMS(int * kname, int * lenkname);',
-            'void CKRP'+sym+'(double *  ru, double *  ruc, double *  pa);',
-            'void CKPX'+sym+'(double *  rho, double *  T, double *  x, double *  P);',
-            'AMREX_GPU_HOST_DEVICE void CKPY'+sym+'(double *  rho, double *  T, double *  y, double *  P);',
-            'void CKPC'+sym+'(double *  rho, double *  T, double *  c, double *  P);',
-            'void CKRHOX'+sym+'(double *  P, double *  T, double *  x, double *  rho);',
-            'AMREX_GPU_HOST_DEVICE void CKRHOY'+sym+'(double *  P, double *  T, double *  y, double *  rho);',
-            'void CKRHOC'+sym+'(double *  P, double *  T, double *  c, double *  rho);',
-            'void CKWT'+sym+'(double *  wt);',
-            'void CKAWT'+sym+'(double *  awt);',
-            'AMREX_GPU_HOST_DEVICE void CKMMWY'+sym+'(double *  y, double *  wtm);',
-            'void CKMMWX'+sym+'(double *  x, double *  wtm);',
-            'void CKMMWC'+sym+'(double *  c, double *  wtm);',
-            'AMREX_GPU_HOST_DEVICE void CKYTX'+sym+'(double *  y, double *  x);',
-            'void CKYTCP'+sym+'(double *  P, double *  T, double *  y, double *  c);',
-            'AMREX_GPU_HOST_DEVICE void CKYTCR'+sym+'(double *  rho, double *  T, double *  y, double *  c);',
-            'AMREX_GPU_HOST_DEVICE void CKXTY'+sym+'(double *  x, double *  y);',
-            'void CKXTCP'+sym+'(double *  P, double *  T, double *  x, double *  c);',
-            'void CKXTCR'+sym+'(double *  rho, double *  T, double *  x, double *  c);',
-            'void CKCTX'+sym+'(double *  c, double *  x);',
-            'void CKCTY'+sym+'(double *  c, double *  y);',
-            'void CKCPOR'+sym+'(double *  T, double *  cpor);',
-            'void CKHORT'+sym+'(double *  T, double *  hort);',
-            'void CKSOR'+sym+'(double *  T, double *  sor);',
+            'void CKRP'+sym+'(amrex::Real *  ru, amrex::Real *  ruc, amrex::Real *  pa);',
+            'void CKPX'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  P);',
+            'AMREX_GPU_HOST_DEVICE void CKPY'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  P);',
+            'void CKPC'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  c, amrex::Real *  P);',
+            'void CKRHOX'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  rho);',
+            'AMREX_GPU_HOST_DEVICE void CKRHOY'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  rho);',
+            'void CKRHOC'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  c, amrex::Real *  rho);',
+            'void CKWT'+sym+'(amrex::Real *  wt);',
+            'void CKAWT'+sym+'(amrex::Real *  awt);',
+            'AMREX_GPU_HOST_DEVICE void CKMMWY'+sym+'(amrex::Real *  y, amrex::Real *  wtm);',
+            'void CKMMWX'+sym+'(amrex::Real *  x, amrex::Real *  wtm);',
+            'void CKMMWC'+sym+'(amrex::Real *  c, amrex::Real *  wtm);',
+            'AMREX_GPU_HOST_DEVICE void CKYTX'+sym+'(amrex::Real *  y, amrex::Real *  x);',
+            'void CKYTCP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  c);',
+            'AMREX_GPU_HOST_DEVICE void CKYTCR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  c);',
+            'AMREX_GPU_HOST_DEVICE void CKXTY'+sym+'(amrex::Real *  x, amrex::Real *  y);',
+            'void CKXTCP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c);',
+            'void CKXTCR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c);',
+            'void CKCTX'+sym+'(amrex::Real *  c, amrex::Real *  x);',
+            'void CKCTY'+sym+'(amrex::Real *  c, amrex::Real *  y);',
+            'void CKCPOR'+sym+'(amrex::Real *  T, amrex::Real *  cpor);',
+            'void CKHORT'+sym+'(amrex::Real *  T, amrex::Real *  hort);',
+            'void CKSOR'+sym+'(amrex::Real *  T, amrex::Real *  sor);',
             
-            'void CKCVML'+sym+'(double *  T, double *  cvml);',
-            'void CKCPML'+sym+'(double *  T, double *  cvml);',
-            'void CKUML'+sym+'(double *  T, double *  uml);',
-            'void CKHML'+sym+'(double *  T, double *  uml);',
-            'void CKGML'+sym+'(double *  T, double *  gml);',
-            'void CKAML'+sym+'(double *  T, double *  aml);',
-            'void CKSML'+sym+'(double *  T, double *  sml);',
+            'void CKCVML'+sym+'(amrex::Real *  T, amrex::Real *  cvml);',
+            'void CKCPML'+sym+'(amrex::Real *  T, amrex::Real *  cvml);',
+            'void CKUML'+sym+'(amrex::Real *  T, amrex::Real *  uml);',
+            'void CKHML'+sym+'(amrex::Real *  T, amrex::Real *  uml);',
+            'void CKGML'+sym+'(amrex::Real *  T, amrex::Real *  gml);',
+            'void CKAML'+sym+'(amrex::Real *  T, amrex::Real *  aml);',
+            'void CKSML'+sym+'(amrex::Real *  T, amrex::Real *  sml);',
             
-            'AMREX_GPU_HOST_DEVICE void CKCVMS'+sym+'(double *  T, double *  cvms);',
-            'AMREX_GPU_HOST_DEVICE void CKCPMS'+sym+'(double *  T, double *  cvms);',
-            'AMREX_GPU_HOST_DEVICE void CKUMS'+sym+'(double *  T, double *  ums);',
-            'AMREX_GPU_HOST_DEVICE void CKHMS'+sym+'(double *  T, double *  ums);',
-            'void CKGMS'+sym+'(double *  T, double *  gms);',
-            'void CKAMS'+sym+'(double *  T, double *  ams);',
-            'void CKSMS'+sym+'(double *  T, double *  sms);',
+            'AMREX_GPU_HOST_DEVICE void CKCVMS'+sym+'(amrex::Real *  T, amrex::Real *  cvms);',
+            'AMREX_GPU_HOST_DEVICE void CKCPMS'+sym+'(amrex::Real *  T, amrex::Real *  cvms);',
+            'AMREX_GPU_HOST_DEVICE void CKUMS'+sym+'(amrex::Real *  T, amrex::Real *  ums);',
+            'AMREX_GPU_HOST_DEVICE void CKHMS'+sym+'(amrex::Real *  T, amrex::Real *  ums);',
+            'void CKGMS'+sym+'(amrex::Real *  T, amrex::Real *  gms);',
+            'void CKAMS'+sym+'(amrex::Real *  T, amrex::Real *  ams);',
+            'void CKSMS'+sym+'(amrex::Real *  T, amrex::Real *  sms);',
             
-            'void CKCPBL'+sym+'(double *  T, double *  x, double *  cpbl);',
-            'AMREX_GPU_HOST_DEVICE void CKCPBS'+sym+'(double *  T, double *  y, double *  cpbs);',
-            'void CKCVBL'+sym+'(double *  T, double *  x, double *  cpbl);',
-            'AMREX_GPU_HOST_DEVICE void CKCVBS'+sym+'(double *  T, double *  y, double *  cpbs);',
+            'void CKCPBL'+sym+'(amrex::Real *  T, amrex::Real *  x, amrex::Real *  cpbl);',
+            'AMREX_GPU_HOST_DEVICE void CKCPBS'+sym+'(amrex::Real *  T, amrex::Real *  y, amrex::Real *  cpbs);',
+            'void CKCVBL'+sym+'(amrex::Real *  T, amrex::Real *  x, amrex::Real *  cpbl);',
+            'AMREX_GPU_HOST_DEVICE void CKCVBS'+sym+'(amrex::Real *  T, amrex::Real *  y, amrex::Real *  cpbs);',
             
-            'void CKHBML'+sym+'(double *  T, double *  x, double *  hbml);',
-            'AMREX_GPU_HOST_DEVICE void CKHBMS'+sym+'(double *  T, double *  y, double *  hbms);',
-            'void CKUBML'+sym+'(double *  T, double *  x, double *  ubml);',
-            'AMREX_GPU_HOST_DEVICE void CKUBMS'+sym+'(double *  T, double *  y, double *  ubms);',
-            'void CKSBML'+sym+'(double *  P, double *  T, double *  x, double *  sbml);',
-            'void CKSBMS'+sym+'(double *  P, double *  T, double *  y, double *  sbms);',
-            'void CKGBML'+sym+'(double *  P, double *  T, double *  x, double *  gbml);',
-            'void CKGBMS'+sym+'(double *  P, double *  T, double *  y, double *  gbms);',
-            'void CKABML'+sym+'(double *  P, double *  T, double *  x, double *  abml);',
-            'void CKABMS'+sym+'(double *  P, double *  T, double *  y, double *  abms);',
+            'void CKHBML'+sym+'(amrex::Real *  T, amrex::Real *  x, amrex::Real *  hbml);',
+            'AMREX_GPU_HOST_DEVICE void CKHBMS'+sym+'(amrex::Real *  T, amrex::Real *  y, amrex::Real *  hbms);',
+            'void CKUBML'+sym+'(amrex::Real *  T, amrex::Real *  x, amrex::Real *  ubml);',
+            'AMREX_GPU_HOST_DEVICE void CKUBMS'+sym+'(amrex::Real *  T, amrex::Real *  y, amrex::Real *  ubms);',
+            'void CKSBML'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  sbml);',
+            'void CKSBMS'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  sbms);',
+            'void CKGBML'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  gbml);',
+            'void CKGBMS'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  gbms);',
+            'void CKABML'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  abml);',
+            'void CKABMS'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  abms);',
 
             
-            'AMREX_GPU_HOST_DEVICE void CKWC'+sym+'(double *  T, double *  C, double *  wdot);',
-            'void CKWYP'+sym+'(double *  P, double *  T, double *  y, double *  wdot);',
-            'void CKWXP'+sym+'(double *  P, double *  T, double *  x, double *  wdot);',
-            'AMREX_GPU_HOST_DEVICE void CKWYR'+sym+'(double *  rho, double *  T, double *  y, double *  wdot);',
-            'void CKWXR'+sym+'(double *  rho, double *  T, double *  x, double *  wdot);',
+            'AMREX_GPU_HOST_DEVICE void CKWC'+sym+'(amrex::Real *  T, amrex::Real *  C, amrex::Real *  wdot);',
+            'void CKWYP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  wdot);',
+            'void CKWXP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  wdot);',
+            'AMREX_GPU_HOST_DEVICE void CKWYR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  wdot);',
+            'void CKWXR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  wdot);',
 
             
-            'void CKQC'+sym+'(double *  T, double *  C, double *  qdot);',
-            'void CKKFKR(double *  P, double *  T, double *  x, double *  q_f, double *  q_r);',
-            'void CKQYP'+sym+'(double *  P, double *  T, double *  y, double *  qdot);',
-            'void CKQXP'+sym+'(double *  P, double *  T, double *  x, double *  qdot);',
-            'void CKQYR'+sym+'(double *  rho, double *  T, double *  y, double *  qdot);',
-            'void CKQXR'+sym+'(double *  rho, double *  T, double *  x, double *  qdot);',
+            'void CKQC'+sym+'(amrex::Real *  T, amrex::Real *  C, amrex::Real *  qdot);',
+            'void CKKFKR(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  q_f, amrex::Real *  q_r);',
+            'void CKQYP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot);',
+            'void CKQXP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot);',
+            'void CKQYR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot);',
+            'void CKQXR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot);',
             
             'void CKNU'+sym+'(int * kdim, int * nuki);',
             '#ifndef AMREX_USE_CUDA',
@@ -409,15 +409,15 @@ class CPickler(CMill):
             '#endif',
             'void CKNCF'+sym+'(int * ncf);',
             
-            'void CKABE'+sym+'(double *  a, double *  b, double *  e );',
-            'void CKEQC'+sym+'(double *  T, double *  C , double *  eqcon );',
-            'void CKEQYP'+sym+'(double *  P, double *  T, double *  y, double *  eqcon);',
-            'void CKEQXP'+sym+'(double *  P, double *  T, double *  x, double *  eqcon);',
-            'void CKEQYR'+sym+'(double *  rho, double *  T, double *  y, double *  eqcon);',
-            'void CKEQXR'+sym+'(double *  rho, double *  T, double *  x, double *  eqcon);',
-            'AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  T, int * consP);',
-            'AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double *  Tp, int * HP);',
-            #'AMREX_GPU_HOST_DEVICE void SLJ_PRECOND_CSC(double *  Jsps, int * indx, int * len, double * sc, double * Tp, int * HP, double * gamma);',
+            'void CKABE'+sym+'(amrex::Real *  a, amrex::Real *  b, amrex::Real *  e );',
+            'void CKEQC'+sym+'(amrex::Real *  T, amrex::Real *  C , amrex::Real *  eqcon );',
+            'void CKEQYP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon);',
+            'void CKEQXP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon);',
+            'void CKEQYR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon);',
+            'void CKEQXR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon);',
+            'AMREX_GPU_HOST_DEVICE void DWDOT(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  T, int * consP);',
+            'AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * HP);',
+            #'AMREX_GPU_HOST_DEVICE void SLJ_PRECOND_CSC(amrex::Real *  Jsps, int * indx, int * len, amrex::Real * sc, amrex::Real * Tp, int * HP, amrex::Real * gamma);',
             'AMREX_GPU_HOST_DEVICE void SPARSITY_INFO(int * nJdata, int * consP, int NCELLS);',
             'AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST(int * nJdata, int * consP, int NCELLS);',
             'AMREX_GPU_HOST_DEVICE void SPARSITY_INFO_SYST_SIMPLIFIED(int * nJdata, int * consP);',
@@ -426,39 +426,39 @@ class CPickler(CMill):
             'AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_CSR(int * colVals, int * rowPtrs, int * consP, int NCELLS, int base);',
             'AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSC(int * rowVals, int * colPtrs, int * indx, int * consP);',
             'AMREX_GPU_HOST_DEVICE void SPARSITY_PREPROC_SYST_SIMPLIFIED_CSR(int * colVals, int * rowPtr, int * consP, int base);',
-            'AMREX_GPU_HOST_DEVICE void aJacobian(double *  J, double *  sc, double T, int consP);',
-            'AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T, int HP);',
-            'AMREX_GPU_HOST_DEVICE void dcvpRdT(double *  species, double *  tc);',
-            'AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t, int *ierr);',
-            'AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t, int *ierr);',
-            'void GET_CRITPARAMS(double *  Tci, double *  ai, double *  bi, double *  acentric_i);',
+            'AMREX_GPU_HOST_DEVICE void aJacobian(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int consP);',
+            'AMREX_GPU_HOST_DEVICE void aJacobian_precond(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int HP);',
+            'AMREX_GPU_HOST_DEVICE void dcvpRdT(amrex::Real *  species, amrex::Real *  tc);',
+            'AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(amrex::Real *  e, amrex::Real *  y, amrex::Real *  t, int *ierr);',
+            'AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(amrex::Real *  h, amrex::Real *  y, amrex::Real *  t, int *ierr);',
+            'void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i);',
             self.line('vector version'),
-            'void VCKYTX'+sym+'(int *  np, double *  y, double *  x);',
-            'void VCKHMS'+sym+'(int *  np, double *  T, double *  ums);',
-            'void VCKWYR'+sym+'(int *  np, double *  rho, double *  T,',
-            '            double *  y,',
-            '            double *  wdot);',
+            'void VCKYTX'+sym+'(int *  np, amrex::Real *  y, amrex::Real *  x);',
+            'void VCKHMS'+sym+'(int *  np, amrex::Real *  T, amrex::Real *  ums);',
+            'void VCKWYR'+sym+'(int *  np, amrex::Real *  rho, amrex::Real *  T,',
+            '            amrex::Real *  y,',
+            '            amrex::Real *  wdot);',
             '#ifndef AMREX_USE_CUDA',
-            'void vproductionRate(int npt, double *  wdot, double *  c, double *  T);',
-            'void VCKPY'+sym+'(int *  np, double *  rho, double *  T, double *  y, double *  P);',
-            'void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT);',
-            'void vcomp_gibbs(int npt, double *  g_RT, double *  tc);',
-            'void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT);',
+            'void vproductionRate(int npt, amrex::Real *  wdot, amrex::Real *  c, amrex::Real *  T);',
+            'void VCKPY'+sym+'(int *  np, amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  P);',
+            'void vcomp_k_f(int npt, amrex::Real *  k_f_s, amrex::Real *  tc, amrex::Real *  invT);',
+            'void vcomp_gibbs(int npt, amrex::Real *  g_RT, amrex::Real *  tc);',
+            'void vcomp_Kc(int npt, amrex::Real *  Kc_s, amrex::Real *  g_RT, amrex::Real *  invT);',
             
             ]
         nReactions = len(mechanism.reaction())
         if nReactions <= 50:
             self._rep += [
-                'void vcomp_wdot(int npt, double *  wdot, double *  mixture, double *  sc,',
-                '                double *  k_f_s, double *  Kc_s,',
-                '                double *  tc, double *  invT, double *  T);',
+                'void vcomp_wdot(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,',
+                '                amrex::Real *  k_f_s, amrex::Real *  Kc_s,',
+                '                amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T);',
                 ]
         else:
             for i in range(0,nReactions,50):
                 self._rep += [
-                    'void vcomp_wdot_%d_%d(int npt, double *  wdot, double *  mixture, double *  sc,' % (i+1,min(i+50,nReactions)),
-                    '                double *  k_f_s, double *  Kc_s,',
-                    '                double *  tc, double *  invT, double *  T);',
+                    'void vcomp_wdot_%d_%d(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,' % (i+1,min(i+50,nReactions)),
+                    '                amrex::Real *  k_f_s, amrex::Real *  Kc_s,',
+                    '                amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T);',
                     ]                
 
         self._rep += [
@@ -469,24 +469,24 @@ class CPickler(CMill):
                 'void egtransetNO(int* NO);',
                 'void egtransetKK(int* KK);',
                 'void egtransetNLITE(int* NLITE);',
-                'void egtransetPATM(double* PATM);',
-                'void egtransetWT(double* WT);',
-                'void egtransetEPS(double* EPS);',
-                'void egtransetSIG(double* SIG);',
-                'void egtransetDIP(double* DIP);',
-                'void egtransetPOL(double* POL);',
-                'void egtransetZROT(double* ZROT);',
+                'void egtransetPATM(amrex::Real* PATM);',
+                'void egtransetWT(amrex::Real* WT);',
+                'void egtransetEPS(amrex::Real* EPS);',
+                'void egtransetSIG(amrex::Real* SIG);',
+                'void egtransetDIP(amrex::Real* DIP);',
+                'void egtransetPOL(amrex::Real* POL);',
+                'void egtransetZROT(amrex::Real* ZROT);',
                 'void egtransetNLIN(int* NLIN);',
-                'void egtransetCOFETA(double* COFETA);',
-                'void egtransetCOFLAM(double* COFLAM);',
-                'void egtransetCOFD(double* COFD);',
+                'void egtransetCOFETA(amrex::Real* COFETA);',
+                'void egtransetCOFLAM(amrex::Real* COFLAM);',
+                'void egtransetCOFD(amrex::Real* COFD);',
                 'void egtransetKTDIF(int* KTDIF);',
             ]
 
         self._rep += [
                 self.line('gauss-jordan solver external routine'),
-                'AMREX_GPU_HOST_DEVICE void sgjsolve(double* A, double* x, double* b);',
-                'AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(double* A, double* x, double* b);',
+                'AMREX_GPU_HOST_DEVICE void sgjsolve(amrex::Real* A, amrex::Real* x, amrex::Real* b);',
+                'AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(amrex::Real* A, amrex::Real* x, amrex::Real* b);',
                 '}',
                 ]
 
@@ -503,42 +503,42 @@ class CPickler(CMill):
 
         nReactions = len(mechanism.reaction())
         self._write()
-        self._write('extern double fwd_A[%d], fwd_beta[%d], fwd_Ea[%d];' 
+        self._write('extern amrex::Real fwd_A[%d], fwd_beta[%d], fwd_Ea[%d];' 
                     % (nReactions,nReactions,nReactions))
-        self._write('extern double low_A[%d], low_beta[%d], low_Ea[%d];' 
+        self._write('extern amrex::Real low_A[%d], low_beta[%d], low_Ea[%d];' 
                     % (nReactions,nReactions,nReactions))
-        self._write('extern double rev_A[%d], rev_beta[%d], rev_Ea[%d];' 
+        self._write('extern amrex::Real rev_A[%d], rev_beta[%d], rev_Ea[%d];' 
                     % (nReactions,nReactions,nReactions))
-        self._write('extern double troe_a[%d],troe_Ts[%d], troe_Tss[%d], troe_Tsss[%d];' 
+        self._write('extern amrex::Real troe_a[%d],troe_Ts[%d], troe_Tss[%d], troe_Tsss[%d];' 
                     % (nReactions,nReactions,nReactions,nReactions))
-        self._write('extern double sri_a[%d], sri_b[%d], sri_c[%d], sri_d[%d], sri_e[%d];'
+        self._write('extern amrex::Real sri_a[%d], sri_b[%d], sri_c[%d], sri_d[%d], sri_e[%d];'
                     % (nReactions,nReactions,nReactions,nReactions,nReactions))
-        self._write('extern double activation_units[%d], prefactor_units[%d], phase_units[%d];'
+        self._write('extern amrex::Real activation_units[%d], prefactor_units[%d], phase_units[%d];'
                     % (nReactions,nReactions,nReactions))
         self._write('extern int is_PD[%d], troe_len[%d], sri_len[%d], nTB[%d], *TBid[%d];' 
                     % (nReactions,nReactions,nReactions,nReactions,nReactions))
-        self._write('extern double *TB[%d];' 
+        self._write('extern amrex::Real *TB[%d];' 
                     % (nReactions))
 
-        self._write('extern std::vector<std::vector<double>> kiv; ')
-        self._write('extern std::vector<std::vector<double>> nuv; ')
+        self._write('extern std::vector<std::vector<amrex::Real>> kiv; ')
+        self._write('extern std::vector<std::vector<amrex::Real>> nuv; ')
 
         self._write()
-        self._write('extern double fwd_A_DEF[%d], fwd_beta_DEF[%d], fwd_Ea_DEF[%d];' 
+        self._write('extern amrex::Real fwd_A_DEF[%d], fwd_beta_DEF[%d], fwd_Ea_DEF[%d];' 
                     % (nReactions,nReactions,nReactions))
-        self._write('extern double low_A_DEF[%d], low_beta_DEF[%d], low_Ea_DEF[%d];' 
+        self._write('extern amrex::Real low_A_DEF[%d], low_beta_DEF[%d], low_Ea_DEF[%d];' 
                     % (nReactions,nReactions,nReactions))
-        self._write('extern double rev_A_DEF[%d], rev_beta_DEF[%d], rev_Ea_DEF[%d];' 
+        self._write('extern amrex::Real rev_A_DEF[%d], rev_beta_DEF[%d], rev_Ea_DEF[%d];' 
                     % (nReactions,nReactions,nReactions))
-        self._write('extern double troe_a_DEF[%d],troe_Ts_DEF[%d], troe_Tss_DEF[%d], troe_Tsss_DEF[%d];' 
+        self._write('extern amrex::Real troe_a_DEF[%d],troe_Ts_DEF[%d], troe_Tss_DEF[%d], troe_Tsss_DEF[%d];' 
                     % (nReactions,nReactions,nReactions,nReactions))
-        self._write('extern double sri_a_DEF[%d], sri_b_DEF[%d], sri_c_DEF[%d], sri_d_DEF[%d], sri_e_DEF[%d];'
+        self._write('extern amrex::Real sri_a_DEF[%d], sri_b_DEF[%d], sri_c_DEF[%d], sri_d_DEF[%d], sri_e_DEF[%d];'
                     % (nReactions,nReactions,nReactions,nReactions,nReactions))
-        self._write('extern double activation_units_DEF[%d], prefactor_units_DEF[%d], phase_units_DEF[%d];'
+        self._write('extern amrex::Real activation_units_DEF[%d], prefactor_units_DEF[%d], phase_units_DEF[%d];'
                     % (nReactions,nReactions,nReactions))
         self._write('extern int is_PD_DEF[%d], troe_len_DEF[%d], sri_len_DEF[%d], nTB_DEF[%d], *TBid_DEF[%d];' 
                     % (nReactions,nReactions,nReactions,nReactions,nReactions))
-        self._write('extern double *TB_DEF[%d];' 
+        self._write('extern amrex::Real *TB_DEF[%d];' 
                     % (nReactions))
         self._write('extern std::vector<int> rxn_map;')
 
@@ -574,46 +574,46 @@ class CPickler(CMill):
         self._write('namespace thermo')
         self._write('{')
         self._indent()
-        self._write('double fwd_A[%d], fwd_beta[%d], fwd_Ea[%d];' 
+        self._write('amrex::Real fwd_A[%d], fwd_beta[%d], fwd_Ea[%d];' 
                     % (nReactions,nReactions,nReactions))
-        self._write('double low_A[%d], low_beta[%d], low_Ea[%d];' 
+        self._write('amrex::Real low_A[%d], low_beta[%d], low_Ea[%d];' 
                     % (nReactions,nReactions,nReactions))
-        self._write('double rev_A[%d], rev_beta[%d], rev_Ea[%d];' 
+        self._write('amrex::Real rev_A[%d], rev_beta[%d], rev_Ea[%d];' 
                     % (nReactions,nReactions,nReactions))
-        self._write('double troe_a[%d],troe_Ts[%d], troe_Tss[%d], troe_Tsss[%d];' 
+        self._write('amrex::Real troe_a[%d],troe_Ts[%d], troe_Tss[%d], troe_Tsss[%d];' 
                     % (nReactions,nReactions,nReactions,nReactions))
-        self._write('double sri_a[%d], sri_b[%d], sri_c[%d], sri_d[%d], sri_e[%d];'
+        self._write('amrex::Real sri_a[%d], sri_b[%d], sri_c[%d], sri_d[%d], sri_e[%d];'
                     % (nReactions,nReactions,nReactions,nReactions,nReactions))
-        self._write('double activation_units[%d], prefactor_units[%d], phase_units[%d];'
+        self._write('amrex::Real activation_units[%d], prefactor_units[%d], phase_units[%d];'
                     % (nReactions,nReactions,nReactions))
         self._write('int is_PD[%d], troe_len[%d], sri_len[%d], nTB[%d], *TBid[%d];' 
                     % (nReactions,nReactions,nReactions,nReactions,nReactions))
-        self._write('double *TB[%d];' 
+        self._write('amrex::Real *TB[%d];' 
                     % (nReactions))
 
         if nspecial > 0:  
-                self._write('double prefactor_units_rev[%d], activation_units_rev[%d];' 
+                self._write('amrex::Real prefactor_units_rev[%d], activation_units_rev[%d];' 
                             % (nReactions,nReactions))
 
-        self._write('std::vector<std::vector<double>> kiv(%d); ' % (nReactions))
-        self._write('std::vector<std::vector<double>> nuv(%d); ' % (nReactions))
+        self._write('std::vector<std::vector<amrex::Real>> kiv(%d); ' % (nReactions))
+        self._write('std::vector<std::vector<amrex::Real>> nuv(%d); ' % (nReactions))
 
         self._write()
-        self._write('double fwd_A_DEF[%d], fwd_beta_DEF[%d], fwd_Ea_DEF[%d];' 
+        self._write('amrex::Real fwd_A_DEF[%d], fwd_beta_DEF[%d], fwd_Ea_DEF[%d];' 
                     % (nReactions,nReactions,nReactions))
-        self._write('double low_A_DEF[%d], low_beta_DEF[%d], low_Ea_DEF[%d];' 
+        self._write('amrex::Real low_A_DEF[%d], low_beta_DEF[%d], low_Ea_DEF[%d];' 
                     % (nReactions,nReactions,nReactions))
-        self._write('double rev_A_DEF[%d], rev_beta_DEF[%d], rev_Ea_DEF[%d];' 
+        self._write('amrex::Real rev_A_DEF[%d], rev_beta_DEF[%d], rev_Ea_DEF[%d];' 
                     % (nReactions,nReactions,nReactions))
-        self._write('double troe_a_DEF[%d],troe_Ts_DEF[%d], troe_Tss_DEF[%d], troe_Tsss_DEF[%d];' 
+        self._write('amrex::Real troe_a_DEF[%d],troe_Ts_DEF[%d], troe_Tss_DEF[%d], troe_Tsss_DEF[%d];' 
                     % (nReactions,nReactions,nReactions,nReactions))
-        self._write('double sri_a_DEF[%d], sri_b_DEF[%d], sri_c_DEF[%d], sri_d_DEF[%d], sri_e_DEF[%d];'
+        self._write('amrex::Real sri_a_DEF[%d], sri_b_DEF[%d], sri_c_DEF[%d], sri_d_DEF[%d], sri_e_DEF[%d];'
                     % (nReactions,nReactions,nReactions,nReactions,nReactions))
-        self._write('double activation_units_DEF[%d], prefactor_units_DEF[%d], phase_units_DEF[%d];'
+        self._write('amrex::Real activation_units_DEF[%d], prefactor_units_DEF[%d], phase_units_DEF[%d];'
                     % (nReactions,nReactions,nReactions))
         self._write('int is_PD_DEF[%d], troe_len_DEF[%d], sri_len_DEF[%d], nTB_DEF[%d], *TBid_DEF[%d];' 
                     % (nReactions,nReactions,nReactions,nReactions,nReactions))
-        self._write('double *TB_DEF[%d];' 
+        self._write('amrex::Real *TB_DEF[%d];' 
                     % (nReactions))
         self._write('std::vector<int> rxn_map;')
 
@@ -630,7 +630,7 @@ class CPickler(CMill):
 
         self._write(self.line(' Inverse molecular weights'))
         self._write(self.line(' TODO: check necessity on CPU'))
-        self._write('static AMREX_GPU_DEVICE_MANAGED double imw[%d] = {' %nSpecies )
+        self._write('static AMREX_GPU_DEVICE_MANAGED amrex::Real imw[%d] = {' %nSpecies )
         self._indent()
         for i in range(0,self.nSpecies):
             species = self.species[i]
@@ -645,7 +645,7 @@ class CPickler(CMill):
 
         self._write(self.line(' Inverse molecular weights'))
         self._write(self.line(' TODO: check necessity because redundant with molecularWeight'))
-        self._write('static AMREX_GPU_DEVICE_MANAGED double molecular_weights[%d] = {' %nSpecies )
+        self._write('static AMREX_GPU_DEVICE_MANAGED amrex::Real molecular_weights[%d] = {' %nSpecies )
         self._indent()
         for i in range(0,self.nSpecies):
             species = self.species[i]
@@ -659,7 +659,7 @@ class CPickler(CMill):
         self._write()
 
         self._write('AMREX_GPU_HOST_DEVICE')
-        self._write('void get_imw(double imw_new[]){')
+        self._write('void get_imw(amrex::Real imw_new[]){')
         ##self._write('#pragma unroll')
         self._indent()
         self._write('for(int i = 0; i<%d; ++i) imw_new[i] = imw[i];' %nSpecies )
@@ -669,7 +669,7 @@ class CPickler(CMill):
 
         self._write(self.line(' TODO: check necessity because redundant with CKWT'))
         self._write('AMREX_GPU_HOST_DEVICE')
-        self._write('void get_mw(double mw_new[]){')
+        self._write('void get_mw(amrex::Real mw_new[]){')
         ##self._write('#pragma unroll')
         self._indent()
         self._write('for(int i = 0; i<%d; ++i) mw_new[i] = molecular_weights[i];' %nSpecies )
@@ -808,7 +808,7 @@ class CPickler(CMill):
                 efficiencies = reaction.efficiencies
                 if (len(efficiencies) > 0):
                     self._write("nTB[%d] = %d;" % (id, len(efficiencies)))
-                    self._write("TB[%d] = (double *) malloc(%d * sizeof(double));" % (id, len(efficiencies)))
+                    self._write("TB[%d] = (amrex::Real *) malloc(%d * sizeof(amrex::Real));" % (id, len(efficiencies)))
                     self._write("TBid[%d] = (int *) malloc(%d * sizeof(int));" % (id, len(efficiencies)))
                     for i, eff in enumerate(efficiencies):
                         symbol, efficiency = eff
@@ -839,7 +839,7 @@ class CPickler(CMill):
         self._write()
 
         self._write("#include <ReactionData.H>")
-        self._write("double* GetParamPtr(int                reaction_id,")
+        self._write("amrex::Real* GetParamPtr(int                reaction_id,")
         self._write("                    REACTION_PARAMETER param_id,")
         self._write("                    int                species_id,")
         self._write("                    int                get_default)")
@@ -849,7 +849,7 @@ class CPickler(CMill):
             self._write("  abort();")
             self._write("  return 0;")
         else:
-            self._write("  double* ret = 0;")
+            self._write("  amrex::Real* ret = 0;")
             self._write("  if (reaction_id<0 || reaction_id>=%d) {" % (nReactions))
             self._write("    printf(\"Bad reaction id = %d\",reaction_id);")
             self._write("    abort();")
@@ -950,7 +950,7 @@ class CPickler(CMill):
         self._write("")
         self._write("        nTB[i]  = nTB_DEF[i];")
         self._write("        if (nTB[i] != 0) {")
-        self._write("           TB[i] = (double *) malloc(sizeof(double) * nTB[i]);")
+        self._write("           TB[i] = (amrex::Real *) malloc(sizeof(amrex::Real) * nTB[i]);")
         self._write("           TBid[i] = (int *) malloc(sizeof(int) * nTB[i]);")
         self._write("           for (int j=0; j<nTB[i]; j++) {")
         self._write("             TB[i][j] = TB_DEF[i][j];")
@@ -1002,7 +1002,7 @@ class CPickler(CMill):
         self._write("")
         self._write("        nTB_DEF[i]  = nTB[i];")
         self._write("        if (nTB_DEF[i] != 0) {")
-        self._write("           TB_DEF[i] = (double *) malloc(sizeof(double) * nTB_DEF[i]);")
+        self._write("           TB_DEF[i] = (amrex::Real *) malloc(sizeof(amrex::Real) * nTB_DEF[i]);")
         self._write("           TBid_DEF[i] = (int *) malloc(sizeof(int) * nTB_DEF[i]);")
         self._write("           for (int j=0; j<nTB_DEF[i]; j++) {")
         self._write("             TB_DEF[i][j] = TB[i][j];")
@@ -1074,7 +1074,7 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line(' ckxnum... for parsing strings '))
-        self._write('void CKXNUM'+sym+'(char * line, int * nexp, int * lout, int * nval, double *  rval, int * kerr, int lenline )')
+        self._write('void CKXNUM'+sym+'(char * line, int * nexp, int * lout, int * nval, amrex::Real *  rval, int * kerr, int lenline )')
         self._write('{')
         self._indent()
         self._write('int n,i; /*Loop Counters */')
@@ -1121,7 +1121,7 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line(' cksnum... for parsing strings '))
-        self._write('void CKSNUM'+sym+'(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, double *  rval, int * kerr, int lenline, int lenkray)')
+        self._write('void CKSNUM'+sym+'(char * line, int * nexp, int * lout, char * kray, int * nn, int * knum, int * nval, amrex::Real *  rval, int * kerr, int lenline, int lenkray)')
         self._write('{')
         self._indent()
         
@@ -1246,7 +1246,7 @@ class CPickler(CMill):
         self._write()
         self._write(
             self.line(' Returns R, Rc, Patm' ))
-        self._write('void CKRP'+sym+'(double *  ru, double *  ruc, double *  pa)')
+        self._write('void CKRP'+sym+'(amrex::Real *  ru, amrex::Real *  ruc, amrex::Real *  pa)')
         self._write('{')
         self._indent()
         
@@ -1264,11 +1264,11 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Compute P = rhoRT/W(x)'))
-        self._write('void CKPX'+sym+'(double *  rho, double *  T, double *  x, double *  P)')
+        self._write('void CKPX'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  P)')
         self._write('{')
         self._indent()
 
-        self._write('double XW = 0;'+
+        self._write('amrex::Real XW = 0;'+
                     self.line(' To hold mean molecular wt'))
         
         # molecular weights of all species
@@ -1292,11 +1292,11 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Compute P = rhoRT/W(y)'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKPY'+sym+'(double *  rho, double *  T, double *  y,  double *  P)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKPY'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  P)')
         self._write('{')
         self._indent()
 
-        self._write('double YOW = 0;'+self.line(' for computing mean MW'))
+        self._write('amrex::Real YOW = 0;'+self.line(' for computing mean MW'))
         
         # molecular weights of all species
         for species in self.species:
@@ -1322,13 +1322,13 @@ class CPickler(CMill):
         self._write()
         self._write('#ifndef AMREX_USE_CUDA')
         self._write(self.line('Compute P = rhoRT/W(y)'))
-        self._write('void VCKPY'+sym+'(int *  np, double *  rho, double *  T, double *  y,  double *  P)')
+        self._write('void VCKPY'+sym+'(int *  np, amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  P)')
         self._write('{')
         self._indent()
 
         species = self.species
         nSpec = len(species)
-        self._write('double YOW[*np];')
+        self._write('amrex::Real YOW[*np];')
         self._write('for (int i=0; i<(*np); i++) {')
         self._indent()
         self._write('YOW[i] = 0.0;')
@@ -1369,15 +1369,15 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Compute P = rhoRT/W(c)'))
-        self._write('void CKPC'+sym+'(double *  rho, double *  T, double *  c,  double *  P)')
+        self._write('void CKPC'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  c,  amrex::Real *  P)')
         
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
         self._write(self.line('See Eq 5 in CK Manual'))
-        self._write('double W = 0;')
-        self._write('double sumC = 0;')
+        self._write('amrex::Real W = 0;')
+        self._write('amrex::Real sumC = 0;')
         
         # molecular weights of all species
         for species in self.species:
@@ -1410,11 +1410,11 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Compute rho = PW(x)/RT'))
-        self._write('void CKRHOX'+sym+'(double *  P, double *  T, double *  x,  double *  rho)')
+        self._write('void CKRHOX'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  rho)')
         self._write('{')
         self._indent()
 
-        self._write('double XW = 0;'+
+        self._write('amrex::Real XW = 0;'+
                     self.line(' To hold mean molecular wt'))
         
         # molecular weights of all species
@@ -1440,11 +1440,11 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Compute rho = P*W(y)/RT'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKRHOY'+sym+'(double *  P, double *  T, double *  y,  double *  rho)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKRHOY'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  rho)')
         self._write('{')
         self._indent()
-        self._write('double YOW = 0;')
-        self._write('double tmp[%d];' % (nSpec))
+        self._write('amrex::Real YOW = 0;')
+        self._write('amrex::Real tmp[%d];' % (nSpec))
         self._write('')
         self._write('for (int i = 0; i < %d; i++)' % (nSpec))
         self._write('{')
@@ -1470,15 +1470,15 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Compute rho = P*W(c)/(R*T)'))
-        self._write('void CKRHOC'+sym+'(double *  P, double *  T, double *  c,  double *  rho)')
+        self._write('void CKRHOC'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  c,  amrex::Real *  rho)')
         
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
         self._write(self.line('See Eq 5 in CK Manual'))
-        self._write('double W = 0;')
-        self._write('double sumC = 0;')
+        self._write('amrex::Real W = 0;')
+        self._write('amrex::Real sumC = 0;')
         
         # molecular weights of all species
         for species in self.species:
@@ -1510,7 +1510,7 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('get molecular weight for all species'))
-        self._write('void CKWT'+sym+'( double *  wt)')
+        self._write('void CKWT'+sym+'( amrex::Real *  wt)')
         self._write('{')
         self._indent()
         # call molecularWeight
@@ -1524,7 +1524,7 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('get atomic weight for all elements'))
-        self._write('void CKAWT'+sym+'( double *  awt)')
+        self._write('void CKAWT'+sym+'( amrex::Real *  awt)')
         self._write('{')
         self._indent()
         # call atomicWeight
@@ -1539,13 +1539,13 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('given y[species]: mass fractions'))
         self._write(self.line('returns mean molecular weight (gm/mole)'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKMMWY'+sym+'(double *  y,  double *  wtm)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKMMWY'+sym+'(amrex::Real *  y,  amrex::Real *  wtm)')
         self._write('{')
         self._indent()
         species = self.species
         nSpec = len(species)
-        self._write('double YOW = 0;')
-        self._write('double tmp[%d];' % (nSpec))
+        self._write('amrex::Real YOW = 0;')
+        self._write('amrex::Real tmp[%d];' % (nSpec))
         self._write('')
         self._write('for (int i = 0; i < %d; i++)' % (nSpec))
         self._write('{')
@@ -1573,10 +1573,10 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('given x[species]: mole fractions'))
         self._write(self.line('returns mean molecular weight (gm/mole)'))
-        self._write('void CKMMWX'+sym+'(double *  x,  double *  wtm)')
+        self._write('void CKMMWX'+sym+'(amrex::Real *  x,  amrex::Real *  wtm)')
         self._write('{')
         self._indent()
-        self._write('double XW = 0;'+self.line(' see Eq 4 in CK Manual'))
+        self._write('amrex::Real XW = 0;'+self.line(' see Eq 4 in CK Manual'))
         # molecular weights of all species
         for species in self.species:
             self._write('XW += x[%d]*%f; ' % (
@@ -1595,13 +1595,13 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('given c[species]: molar concentration'))
         self._write(self.line('returns mean molecular weight (gm/mole)'))
-        self._write('void CKMMWC'+sym+'(double *  c,  double *  wtm)')
+        self._write('void CKMMWC'+sym+'(amrex::Real *  c,  amrex::Real *  wtm)')
         self._write('{')
         self._indent()
         self._write('int id; ' + self.line('loop counter'))
         self._write(self.line('See Eq 5 in CK Manual'))
-        self._write('double W = 0;')
-        self._write('double sumC = 0;')
+        self._write('amrex::Real W = 0;')
+        self._write('amrex::Real sumC = 0;')
         # molecular weights of all species
         for species in self.species:
             self._write('W += c[%d]*%f; ' % (
@@ -1627,14 +1627,14 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'convert y[species] (mass fracs) to x[species] (mole fracs)'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKYTX'+sym+'(double *  y,  double *  x)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKYTX'+sym+'(amrex::Real *  y,  amrex::Real *  x)')
         self._write('{')
         self._indent()
 
         species = self.species
         nSpec = len(species)
-        self._write('double YOW = 0;')
-        self._write('double tmp[%d];' % (nSpec))
+        self._write('amrex::Real YOW = 0;')
+        self._write('amrex::Real tmp[%d];' % (nSpec))
         self._write('')
         self._write('for (int i = 0; i < %d; i++)' % (nSpec))
         self._write('{')
@@ -1649,7 +1649,7 @@ class CPickler(CMill):
         self._outdent()
         self._write('}')
         self._write('')
-        self._write('double YOWINV = 1.0/YOW;')
+        self._write('amrex::Real YOWINV = 1.0/YOW;')
         self._write('')
         self._write('for (int i = 0; i < %d; i++)' % (nSpec))
         self._write('{')
@@ -1670,13 +1670,13 @@ class CPickler(CMill):
         self._write('#ifndef AMREX_USE_CUDA')
         self._write(self.line(
             'convert y[npoints*species] (mass fracs) to x[npoints*species] (mole fracs)'))
-        self._write('void VCKYTX'+sym+'(int *  np, double *  y,  double *  x)')
+        self._write('void VCKYTX'+sym+'(int *  np, amrex::Real *  y,  amrex::Real *  x)')
         self._write('{')
         self._indent()
 
         species = self.species
         nSpec = len(species)
-        self._write('double YOW[*np];')
+        self._write('amrex::Real YOW[*np];')
         self._write('for (int i=0; i<(*np); i++) {')
         self._indent()
         self._write('YOW[i] = 0.0;')
@@ -1717,7 +1717,7 @@ class CPickler(CMill):
         self._write('}')
         self._write('#else') 
         self._write(self.line('TODO: remove this on GPU'))
-        self._write('void VCKYTX'+sym+'(int *  np, double *  y,  double *  x)')
+        self._write('void VCKYTX'+sym+'(int *  np, amrex::Real *  y,  amrex::Real *  x)')
         self._write('{')
         self._write('}')
         self._write('#endif') 
@@ -1730,14 +1730,14 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'convert y[species] (mass fracs) to c[species] (molar conc)'))
-        self._write('void CKYTCP'+sym+'(double *  P, double *  T, double *  y,  double *  c)')
+        self._write('void CKYTCP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  c)')
         self._write('{')
         self._indent()
 
         species = self.species
         nSpec = len(species)
-        self._write('double YOW = 0;')
-        self._write('double PWORT;')
+        self._write('amrex::Real YOW = 0;')
+        self._write('amrex::Real PWORT;')
         self._write('')
         self._write(self.line('Compute inverse of mean molecular wt first'))
         self._write('for (int i = 0; i < %d; i++)' % (nSpec))
@@ -1777,7 +1777,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'convert y[species] (mass fracs) to c[species] (molar conc)'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKYTCR'+sym+'(double *  rho, double *  T, double *  y,  double *  c)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKYTCR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  c)')
         self._write('{')
         self._indent()
         species = self.species
@@ -1888,7 +1888,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('get specific heat at constant volume as a function '))
         self._write(self.line('of T for all species (molar units)'))
-        self._write('void CKCVML'+sym+'(double *  T,  double *  cvml)')
+        self._write('void CKCVML'+sym+'(amrex::Real *  T,  amrex::Real *  cvml)')
         self._write('{')
         self._indent()
 
@@ -1896,10 +1896,10 @@ class CPickler(CMill):
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         
         # call routine
@@ -1926,7 +1926,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('get specific heat at constant pressure as a '))
         self._write(self.line('function of T for all species (molar units)'))
-        self._write('void CKCPML'+sym+'(double *  T,  double *  cpml)')
+        self._write('void CKCPML'+sym+'(amrex::Real *  T,  amrex::Real *  cpml)')
         self._write('{')
         self._indent()
 
@@ -1934,10 +1934,10 @@ class CPickler(CMill):
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         
         # call routine
@@ -1963,7 +1963,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('get internal energy as a function '))
         self._write(self.line('of T for all species (molar units)'))
-        self._write('void CKUML'+sym+'(double *  T,  double *  uml)')
+        self._write('void CKUML'+sym+'(amrex::Real *  T,  amrex::Real *  uml)')
         self._write('{')
         self._indent()
 
@@ -1971,13 +1971,13 @@ class CPickler(CMill):
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         
         # call routine
@@ -2004,7 +2004,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('get enthalpy as a function '))
         self._write(self.line('of T for all species (molar units)'))
-        self._write('void CKHML'+sym+'(double *  T,  double *  hml)')
+        self._write('void CKHML'+sym+'(amrex::Real *  T,  amrex::Real *  hml)')
         self._write('{')
         self._indent()
 
@@ -2012,13 +2012,13 @@ class CPickler(CMill):
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         
         # call routine
@@ -2045,7 +2045,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('get standard-state Gibbs energy as a function '))
         self._write(self.line('of T for all species (molar units)'))
-        self._write('void CKGML'+sym+'(double *  T,  double *  gml)')
+        self._write('void CKGML'+sym+'(amrex::Real *  T,  amrex::Real *  gml)')
         self._write('{')
         self._indent()
 
@@ -2053,13 +2053,13 @@ class CPickler(CMill):
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         
         # call routine
@@ -2086,7 +2086,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('get standard-state Helmholtz free energy as a '))
         self._write(self.line('function of T for all species (molar units)'))
-        self._write('void CKAML'+sym+'(double *  T,  double *  aml)')
+        self._write('void CKAML'+sym+'(amrex::Real *  T,  amrex::Real *  aml)')
         self._write('{')
         self._indent()
 
@@ -2094,13 +2094,13 @@ class CPickler(CMill):
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         
         # call routine
@@ -2126,7 +2126,7 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns the standard-state entropies in molar units'))
-        self._write('void CKSML'+sym+'(double *  T,  double *  sml)')
+        self._write('void CKSML'+sym+'(amrex::Real *  T,  amrex::Real *  sml)')
         self._write('{')
         self._indent()
 
@@ -2134,10 +2134,10 @@ class CPickler(CMill):
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         
         # call routine
@@ -2163,19 +2163,19 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns internal energy in mass units (Eq 30.)'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKUMS'+sym+'(double *  T,  double *  ums)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKUMS'+sym+'(amrex::Real *  T,  amrex::Real *  ums)')
         self._write('{')
         self._indent()
 
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         
         # call routine
@@ -2199,19 +2199,19 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns enthalpy in mass units (Eq 27.)'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKHMS'+sym+'(double *  T,  double *  hms)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKHMS'+sym+'(amrex::Real *  T,  amrex::Real *  hms)')
         self._write('{')
         self._indent()
 
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         
         # call routine
@@ -2237,14 +2237,14 @@ class CPickler(CMill):
         self._write()
         self._write('#ifndef AMREX_USE_CUDA')
         self._write(self.line('Returns enthalpy in mass units (Eq 27.)'))
-        self._write('void VCKHMS'+sym+'(int *  np, double *  T,  double *  hms)')
+        self._write('void VCKHMS'+sym+'(int *  np, amrex::Real *  T,  amrex::Real *  hms)')
         self._write('{')
         self._indent()
 
         species = self.species
         nSpec = len(species)
 
-        self._write('double tc[5], h[%d];' % nSpec)
+        self._write('amrex::Real tc[5], h[%d];' % nSpec)
 
         self._write()
 
@@ -2283,7 +2283,7 @@ class CPickler(CMill):
         self._write('}')
         self._write('#else')
         self._write(self.line('TODO: remove this on GPU'))
-        self._write('void VCKHMS'+sym+'(int *  np, double *  T,  double *  hms)')
+        self._write('void VCKHMS'+sym+'(int *  np, amrex::Real *  T,  amrex::Real *  hms)')
         self._write('{')
         self._write('}')
         self._write('#endif')
@@ -2294,19 +2294,19 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns helmholtz in mass units (Eq 32.)'))
-        self._write('void CKAMS'+sym+'(double *  T,  double *  ams)')
+        self._write('void CKAMS'+sym+'(amrex::Real *  T,  amrex::Real *  ams)')
         self._write('{')
         self._indent()
 
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         
         # call routine
@@ -2330,19 +2330,19 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns gibbs in mass units (Eq 31.)'))
-        self._write('void CKGMS'+sym+'(double *  T,  double *  gms)')
+        self._write('void CKGMS'+sym+'(amrex::Real *  T,  amrex::Real *  gms)')
         self._write('{')
         self._indent()
 
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         
         # call routine
@@ -2368,16 +2368,16 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the specific heats at constant volume'))
         self._write(self.line('in mass units (Eq. 29)'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKCVMS'+sym+'(double *  T,  double *  cvms)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKCVMS'+sym+'(amrex::Real *  T,  amrex::Real *  cvms)')
         self._write('{')
         self._indent()
 
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         
         # call routine
@@ -2402,16 +2402,16 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the specific heats at constant pressure'))
         self._write(self.line('in mass units (Eq. 26)'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKCPMS'+sym+'(double *  T,  double *  cpms)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKCPMS'+sym+'(amrex::Real *  T,  amrex::Real *  cpms)')
         self._write('{')
         self._indent()
 
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         
         # call routine
@@ -2436,16 +2436,16 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns the entropies in mass units (Eq 28.)'))
-        self._write('void CKSMS'+sym+'(double *  T,  double *  sms)')
+        self._write('void CKSMS'+sym+'(amrex::Real *  T,  amrex::Real *  sms)')
         self._write('{')
         self._indent()
 
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         
         # call routine
@@ -2470,22 +2470,22 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns the mean specific heat at CP (Eq. 33)'))
-        self._write('void CKCPBL'+sym+'(double *  T, double *  x,  double *  cpbl)')
+        self._write('void CKCPBL'+sym+'(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  cpbl)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
-        self._write('double result = 0; ')
+        self._write('amrex::Real result = 0; ')
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double cpor[%d]; ' % self.nSpecies + self.line(' temporary storage'))
+            'amrex::Real cpor[%d]; ' % self.nSpecies + self.line(' temporary storage'))
         
         # call routine
         self._write('cp_R(cpor, tc);')
@@ -2513,21 +2513,21 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns the mean specific heat at CP (Eq. 34)'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKCPBS'+sym+'(double *  T, double *  y,  double *  cpbs)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKCPBS'+sym+'(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  cpbs)')
         self._write('{')
         self._indent()
 
-        self._write('double result = 0; ')
+        self._write('amrex::Real result = 0; ')
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double cpor[%d], tresult[%d]; ' % (self.nSpecies,self.nSpecies) + self.line(' temporary storage'))
+            'amrex::Real cpor[%d], tresult[%d]; ' % (self.nSpecies,self.nSpecies) + self.line(' temporary storage'))
         
         # call routine
         self._write('cp_R(cpor, tc);')
@@ -2563,22 +2563,22 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns the mean specific heat at CV (Eq. 35)'))
-        self._write('void CKCVBL'+sym+'(double *  T, double *  x,  double *  cvbl)')
+        self._write('void CKCVBL'+sym+'(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  cvbl)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
-        self._write('double result = 0; ')
+        self._write('amrex::Real result = 0; ')
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double cvor[%d]; ' % self.nSpecies + self.line(' temporary storage'))
+            'amrex::Real cvor[%d]; ' % self.nSpecies + self.line(' temporary storage'))
         
         # call routine
         self._write('cv_R(cvor, tc);')
@@ -2605,21 +2605,21 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns the mean specific heat at CV (Eq. 36)'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKCVBS'+sym+'(double *  T, double *  y,  double *  cvbs)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKCVBS'+sym+'(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  cvbs)')
         self._write('{')
         self._indent()
 
-        self._write('double result = 0; ')
+        self._write('amrex::Real result = 0; ')
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double cvor[%d]; ' % self.nSpecies + self.line(' temporary storage'))
+            'amrex::Real cvor[%d]; ' % self.nSpecies + self.line(' temporary storage'))
         
         # call routine
         self._write('cv_R(cvor, tc);')
@@ -2643,24 +2643,24 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns the mean enthalpy of the mixture in molar units'))
-        self._write('void CKHBML'+sym+'(double *  T, double *  x,  double *  hbml)')
+        self._write('void CKHBML'+sym+'(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  hbml)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
-        self._write('double result = 0; ')
+        self._write('amrex::Real result = 0; ')
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double hml[%d]; ' % self.nSpecies + self.line(' temporary storage'))
+            'amrex::Real hml[%d]; ' % self.nSpecies + self.line(' temporary storage'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         
         # call routine
@@ -2689,24 +2689,24 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns mean enthalpy of mixture in mass units'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKHBMS'+sym+'(double *  T, double *  y,  double *  hbms)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKHBMS'+sym+'(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  hbms)')
         self._write('{')
         self._indent()
 
-        self._write('double result = 0;')
+        self._write('amrex::Real result = 0;')
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double hml[%d], tmp[%d]; ' % (self.nSpecies,self.nSpecies) + self.line(' temporary storage'))
+            'amrex::Real hml[%d], tmp[%d]; ' % (self.nSpecies,self.nSpecies) + self.line(' temporary storage'))
         
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         
         # call routine
@@ -2738,24 +2738,24 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('get mean internal energy in molar units'))
-        self._write('void CKUBML'+sym+'(double *  T, double *  x,  double *  ubml)')
+        self._write('void CKUBML'+sym+'(amrex::Real *  T, amrex::Real *  x,  amrex::Real *  ubml)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
-        self._write('double result = 0; ')
+        self._write('amrex::Real result = 0; ')
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double uml[%d]; ' % self.nSpecies + self.line(' temporary energy array'))
+            'amrex::Real uml[%d]; ' % self.nSpecies + self.line(' temporary energy array'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         
         # call routine
@@ -2783,24 +2783,24 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('get mean internal energy in mass units'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKUBMS'+sym+'(double *  T, double *  y,  double *  ubms)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKUBMS'+sym+'(amrex::Real *  T, amrex::Real *  y,  amrex::Real *  ubms)')
         self._write('{')
         self._indent()
 
-        self._write('double result = 0;')
+        self._write('amrex::Real result = 0;')
         
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double ums[%d]; ' % self.nSpecies + self.line(' temporary energy array'))
+            'amrex::Real ums[%d]; ' % self.nSpecies + self.line(' temporary energy array'))
         
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         
         # call routine
@@ -2828,24 +2828,24 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('get mixture entropy in molar units'))
-        self._write('void CKSBML'+sym+'(double *  P, double *  T, double *  x,  double *  sbml)')
+        self._write('void CKSBML'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  sbml)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
-        self._write('double result = 0; ')
+        self._write('amrex::Real result = 0; ')
         
         # get temperature cache
         self._write(self.line('Log of normalized pressure in cgs units dynes/cm^2 by Patm'))
-        self._write( 'double logPratio = log ( *P / 1013250.0 ); ')
+        self._write( 'amrex::Real logPratio = log ( *P / 1013250.0 ); ')
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double sor[%d]; ' % self.nSpecies + self.line(' temporary storage'))
+            'amrex::Real sor[%d]; ' % self.nSpecies + self.line(' temporary storage'))
         
         
         # call routine
@@ -2875,27 +2875,27 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('get mixture entropy in mass units'))
-        self._write('void CKSBMS'+sym+'(double *  P, double *  T, double *  y,  double *  sbms)')
+        self._write('void CKSBMS'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  sbms)')
         self._write('{')
         self._indent()
 
-        self._write('double result = 0; ')
+        self._write('amrex::Real result = 0; ')
         
         # get temperature cache
         self._write(self.line('Log of normalized pressure in cgs units dynes/cm^2 by Patm'))
-        self._write( 'double logPratio = log ( *P / 1013250.0 ); ')
+        self._write( 'amrex::Real logPratio = log ( *P / 1013250.0 ); ')
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double sor[%d]; ' % self.nSpecies + self.line(' temporary storage'))
+            'amrex::Real sor[%d]; ' % self.nSpecies + self.line(' temporary storage'))
         self._write(
-            'double x[%d]; ' % self.nSpecies + self.line(' need a ytx conversion'))
+            'amrex::Real x[%d]; ' % self.nSpecies + self.line(' need a ytx conversion'))
 
-        self._write('double YOW = 0; '+self.line('See Eq 4, 6 in CK Manual'))
+        self._write('amrex::Real YOW = 0; '+self.line('See Eq 4, 6 in CK Manual'))
         
         
         # compute inverse of mean molecular weight first (eq 3)
@@ -2932,27 +2932,27 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns mean gibbs free energy in molar units'))
-        self._write('void CKGBML'+sym+'(double *  P, double *  T, double *  x,  double *  gbml)')
+        self._write('void CKGBML'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  gbml)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
-        self._write('double result = 0; ')
+        self._write('amrex::Real result = 0; ')
         
         # get temperature cache
         self._write(self.line('Log of normalized pressure in cgs units dynes/cm^2 by Patm'))
-        self._write( 'double logPratio = log ( *P / 1013250.0 ); ')
+        self._write( 'amrex::Real logPratio = log ( *P / 1013250.0 ); ')
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         self._write(
-            'double gort[%d]; ' % self.nSpecies + self.line(' temporary storage'))
+            'amrex::Real gort[%d]; ' % self.nSpecies + self.line(' temporary storage'))
         
         # call routine
         self._write(self.line('Compute g/RT'))
@@ -2983,31 +2983,31 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns mixture gibbs free energy in mass units'))
-        self._write('void CKGBMS'+sym+'(double *  P, double *  T, double *  y,  double *  gbms)')
+        self._write('void CKGBMS'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  gbms)')
         self._write('{')
         self._indent()
 
-        self._write('double result = 0; ')
+        self._write('amrex::Real result = 0; ')
         
         # get temperature cache
         self._write(self.line('Log of normalized pressure in cgs units dynes/cm^2 by Patm'))
-        self._write( 'double logPratio = log ( *P / 1013250.0 ); ')
+        self._write( 'amrex::Real logPratio = log ( *P / 1013250.0 ); ')
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         self._write(
-            'double gort[%d]; ' % self.nSpecies + self.line(' temporary storage'))
+            'amrex::Real gort[%d]; ' % self.nSpecies + self.line(' temporary storage'))
         self._write(
-            'double x[%d]; ' % self.nSpecies + self.line(' need a ytx conversion'))
+            'amrex::Real x[%d]; ' % self.nSpecies + self.line(' need a ytx conversion'))
 
         self._write(
-            'double YOW = 0; '
+            'amrex::Real YOW = 0; '
             + self.line('To hold 1/molecularweight'))
         
         
@@ -3046,27 +3046,27 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns mean helmholtz free energy in molar units'))
-        self._write('void CKABML'+sym+'(double *  P, double *  T, double *  x,  double *  abml)')
+        self._write('void CKABML'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  abml)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
-        self._write('double result = 0; ')
+        self._write('amrex::Real result = 0; ')
         
         # get temperature cache
         self._write(self.line('Log of normalized pressure in cgs units dynes/cm^2 by Patm'))
-        self._write( 'double logPratio = log ( *P / 1013250.0 ); ')
+        self._write( 'amrex::Real logPratio = log ( *P / 1013250.0 ); ')
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         self._write(
-            'double aort[%d]; ' % self.nSpecies + self.line(' temporary storage'))
+            'amrex::Real aort[%d]; ' % self.nSpecies + self.line(' temporary storage'))
         
         # call routine
         self._write(self.line('Compute g/RT'))
@@ -3097,31 +3097,31 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns mixture helmholtz free energy in mass units'))
-        self._write('void CKABMS'+sym+'(double *  P, double *  T, double *  y,  double *  abms)')
+        self._write('void CKABMS'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  abms)')
         self._write('{')
         self._indent()
 
-        self._write('double result = 0; ')
+        self._write('amrex::Real result = 0; ')
         
         # get temperature cache
         self._write(self.line('Log of normalized pressure in cgs units dynes/cm^2 by Patm'))
-        self._write( 'double logPratio = log ( *P / 1013250.0 ); ')
+        self._write( 'amrex::Real logPratio = log ( *P / 1013250.0 ); ')
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
+            'amrex::Real RT = %1.14e*tT; ' % (R*kelvin*mole/erg)
             + self.line('R*T'))
         self._write(
-            'double aort[%d]; ' % self.nSpecies + self.line(' temporary storage'))
+            'amrex::Real aort[%d]; ' % self.nSpecies + self.line(' temporary storage'))
         self._write(
-            'double x[%d]; ' % self.nSpecies + self.line(' need a ytx conversion'))
+            'amrex::Real x[%d]; ' % self.nSpecies + self.line(' need a ytx conversion'))
 
         self._write(
-            'double YOW = 0; '
+            'amrex::Real YOW = 0; '
             + self.line('To hold 1/molecularweight'))
         
         
@@ -3160,7 +3160,7 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('compute the production rate for each species'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKWC'+sym+'(double *  T, double *  C,  double *  wdot)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKWC'+sym+'(amrex::Real *  T, amrex::Real *  C,  amrex::Real *  wdot)')
         self._write('{')
         self._indent()
 
@@ -3201,15 +3201,15 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the molar production rate of species'))
         self._write(self.line('Given P, T, and mass fractions'))
-        self._write('void CKWYP'+sym+'(double *  P, double *  T, double *  y,  double *  wdot)')
+        self._write('void CKWYP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  wdot)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
 
-        self._write('double c[%d]; ' % self.nSpecies + self.line('temporary storage'))
-        self._write('double YOW = 0; ')
-        self._write('double PWORT; ')
+        self._write('amrex::Real c[%d]; ' % self.nSpecies + self.line('temporary storage'))
+        self._write('amrex::Real YOW = 0; ')
+        self._write('amrex::Real PWORT; ')
         
         # compute inverse of mean molecular weight first (eq 3)
         self._write(self.line('Compute inverse of mean molecular wt first'))
@@ -3255,15 +3255,15 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the molar production rate of species'))
         self._write(self.line('Given P, T, and mole fractions'))
-        self._write('void CKWXP'+sym+'(double *  P, double *  T, double *  x,  double *  wdot)')
+        self._write('void CKWXP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  wdot)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
 
-        self._write('double c[%d]; ' % self.nSpecies + self.line('temporary storage'))
+        self._write('amrex::Real c[%d]; ' % self.nSpecies + self.line('temporary storage'))
         
-        self._write('double PORT = 1e6 * (*P)/(%1.14e * (*T)); ' % (R*kelvin*mole/erg) +
+        self._write('amrex::Real PORT = 1e6 * (*P)/(%1.14e * (*T)); ' % (R*kelvin*mole/erg) +
                     self.line('1e6 * P/RT so c goes to SI units'))
         
         # now compute conversion
@@ -3301,13 +3301,13 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the molar production rate of species'))
         self._write(self.line('Given rho, T, and mass fractions'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKWYR'+sym+'(double *  rho, double *  T, double *  y,  double *  wdot)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKWYR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y,  amrex::Real *  wdot)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
 
-        self._write('double c[%d]; ' % self.nSpecies + self.line('temporary storage'))
+        self._write('amrex::Real c[%d]; ' % self.nSpecies + self.line('temporary storage'))
 
         # now compute conversion
         self._write(self.line('See Eq 8 with an extra 1e6 so c goes to SI'))
@@ -3341,14 +3341,14 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the molar production rate of species'))
         self._write(self.line('Given rho, T, and mass fractions'))
-        self._write('void VCKWYR'+sym+'(int *  np, double *  rho, double *  T,')
-        self._write('	    double *  y,')
-        self._write('	    double *  wdot)')
+        self._write('void VCKWYR'+sym+'(int *  np, amrex::Real *  rho, amrex::Real *  T,')
+        self._write('	    amrex::Real *  y,')
+        self._write('	    amrex::Real *  wdot)')
         self._write('{')
         self._write('#ifndef AMREX_USE_CUDA')
         self._indent()
 
-        self._write('double c[%d*(*np)]; ' % self.nSpecies + self.line('temporary storage'))
+        self._write('amrex::Real c[%d*(*np)]; ' % self.nSpecies + self.line('temporary storage'))
 
         # now compute conversion
         self._write(self.line('See Eq 8 with an extra 1e6 so c goes to SI'))
@@ -3389,16 +3389,16 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the molar production rate of species'))
         self._write(self.line('Given rho, T, and mole fractions'))
-        self._write('void CKWXR'+sym+'(double *  rho, double *  T, double *  x,  double *  wdot)')
+        self._write('void CKWXR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  wdot)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
 
-        self._write('double c[%d]; ' % self.nSpecies + self.line('temporary storage'))
+        self._write('amrex::Real c[%d]; ' % self.nSpecies + self.line('temporary storage'))
         
-        self._write('double XW = 0; '+self.line('See Eq 4, 11 in CK Manual'))
-        self._write('double ROW; ')
+        self._write('amrex::Real XW = 0; '+self.line('See Eq 4, 11 in CK Manual'))
+        self._write('amrex::Real ROW; ')
         
         # compute mean molecular weight first (eq 3)
         self._write(self.line('Compute mean molecular wt first'))
@@ -3583,7 +3583,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the arrehenius coefficients '))
         self._write(self.line('for all reactions'))
-        self._write('void CKABE'+sym+'( double *  a, double *  b, double *  e)')
+        self._write('void CKABE'+sym+'( amrex::Real *  a, amrex::Real *  b, amrex::Real *  e)')
         self._write('{')
         self._indent()
 
@@ -3611,11 +3611,11 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'convert x[species] (mole fracs) to y[species] (mass fracs)'))
-        self._write('AMREX_GPU_HOST_DEVICE void CKXTY'+sym+'(double *  x,  double *  y)')
+        self._write('AMREX_GPU_HOST_DEVICE void CKXTY'+sym+'(amrex::Real *  x,  amrex::Real *  y)')
         self._write('{')
         self._indent()
 
-        self._write('double XW = 0; '+self.line('See Eq 4, 9 in CK Manual'))
+        self._write('amrex::Real XW = 0; '+self.line('See Eq 4, 9 in CK Manual'))
         
         # compute mean molecular weight first (eq 3)
         self._write(self.line('Compute mean molecular wt first'))
@@ -3625,7 +3625,7 @@ class CPickler(CMill):
  
         # now compute conversion
         self._write(self.line('Now compute conversion'))
-        self._write('double XWinv = 1.0/XW;')
+        self._write('amrex::Real XWinv = 1.0/XW;')
         for species in self.species:
             self._write('y[%d] = x[%d]*%f*XWinv; ' % (
                 species.id, species.id, species.weight) )
@@ -3643,12 +3643,12 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'convert x[species] (mole fracs) to c[species] (molar conc)'))
-        self._write('void CKXTCP'+sym+'(double *  P, double *  T, double *  x,  double *  c)')
+        self._write('void CKXTCP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x,  amrex::Real *  c)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
-        self._write('double PORT = (*P)/(%1.14e * (*T)); ' % (R*kelvin*mole/erg) +
+        self._write('amrex::Real PORT = (*P)/(%1.14e * (*T)); ' % (R*kelvin*mole/erg) +
                     self.line('P/RT'))
         # now compute conversion
         self._write()
@@ -3672,13 +3672,13 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'convert x[species] (mole fracs) to c[species] (molar conc)'))
-        self._write('void CKXTCR'+sym+'(double *  rho, double *  T, double *  x, double *  c)')
+        self._write('void CKXTCR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  c)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
-        self._write('double XW = 0; '+self.line('See Eq 4, 11 in CK Manual'))
-        self._write('double ROW; ')
+        self._write('amrex::Real XW = 0; '+self.line('See Eq 4, 11 in CK Manual'))
+        self._write('amrex::Real ROW; ')
         
         # compute mean molecular weight first (eq 3)
         self._write(self.line('Compute mean molecular wt first'))
@@ -3709,12 +3709,12 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'convert c[species] (molar conc) to x[species] (mole fracs)'))
-        self._write('void CKCTX'+sym+'(double *  c, double *  x)')
+        self._write('void CKCTX'+sym+'(amrex::Real *  c, amrex::Real *  x)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
-        self._write('double sumC = 0; ')
+        self._write('amrex::Real sumC = 0; ')
 
         self._write()
         self._write(self.line('compute sum of c '))
@@ -3727,7 +3727,7 @@ class CPickler(CMill):
         # now compute conversion
         self._write()
         self._write(self.line(' See Eq 13 '))
-        self._write('double sumCinv = 1.0/sumC;')
+        self._write('amrex::Real sumCinv = 1.0/sumC;')
         self._write('for (id = 0; id < %d; ++id) {' % self.nSpecies)
         self._indent()
         self._write('x[id] = c[id]*sumCinv;')
@@ -3747,11 +3747,11 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'convert c[species] (molar conc) to y[species] (mass fracs)'))
-        self._write('void CKCTY'+sym+'(double *  c, double *  y)')
+        self._write('void CKCTY'+sym+'(amrex::Real *  c, amrex::Real *  y)')
         self._write('{')
         self._indent()
 
-        self._write('double CW = 0; '+self.line('See Eq 12 in CK Manual'))
+        self._write('amrex::Real CW = 0; '+self.line('See Eq 12 in CK Manual'))
         
         # compute denominator in eq 12
         self._write(self.line('compute denominator in eq 12 first'))
@@ -3761,7 +3761,7 @@ class CPickler(CMill):
 
         # now compute conversion
         self._write(self.line('Now compute conversion'))
-        self._write('double CWinv = 1.0/CW;')
+        self._write('amrex::Real CWinv = 1.0/CW;')
         for species in self.species:
             self._write('y[%d] = c[%d]*%f*CWinv; ' % (
                 species.id, species.id, species.weight) )
@@ -3779,16 +3779,16 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('get Cp/R as a function of T '))
         self._write(self.line('for all species (Eq 19)'))
-        self._write('void CKCPOR'+sym+'(double *  T, double *  cpor)')
+        self._write('void CKCPOR'+sym+'(amrex::Real *  T, amrex::Real *  cpor)')
         self._write('{')
         self._indent()
 
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         
         # call routine
@@ -3805,16 +3805,16 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('get H/RT as a function of T '))
         self._write(self.line('for all species (Eq 20)'))
-        self._write('void CKHORT'+sym+'(double *  T, double *  hort)')
+        self._write('void CKHORT'+sym+'(amrex::Real *  T, amrex::Real *  hort)')
         self._write('{')
         self._indent()
 
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { 0, tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         
         # call routine
@@ -3831,16 +3831,16 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('get S/R as a function of T '))
         self._write(self.line('for all species (Eq 21)'))
-        self._write('void CKSOR'+sym+'(double *  T, double *  sor)')
+        self._write('void CKSOR'+sym+'(amrex::Real *  T, amrex::Real *  sor)')
         self._write('{')
         self._indent()
 
         # get temperature cache
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         
         # call routine
@@ -3861,7 +3861,7 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns the rate of progress for each reaction'))
-        self._write('void CKQC'+sym+'(double *  T, double *  C, double *  qdot)')
+        self._write('void CKQC'+sym+'(amrex::Real *  T, amrex::Real *  C, amrex::Real *  qdot)')
         self._write('{')
         self._indent()
 
@@ -3914,15 +3914,15 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the progress rates of each reactions'))
         self._write(self.line('Given P, T, and mole fractions'))
-        self._write('void CKKFKR'+sym+'(double *  P, double *  T, double *  x, double *  q_f, double *  q_r)')
+        self._write('void CKKFKR'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  q_f, amrex::Real *  q_r)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
 
-        self._write('double c[%d]; ' % nSpecies + self.line('temporary storage'))
+        self._write('amrex::Real c[%d]; ' % nSpecies + self.line('temporary storage'))
         
-        self._write('double PORT = 1e6 * (*P)/(%1.14e * (*T)); ' % (R*kelvin*mole/erg) +
+        self._write('amrex::Real PORT = 1e6 * (*P)/(%1.14e * (*T)); ' % (R*kelvin*mole/erg) +
                     self.line('1e6 * P/RT so c goes to SI units'))
         
         # now compute conversion
@@ -3965,15 +3965,15 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the progress rates of each reactions'))
         self._write(self.line('Given P, T, and mass fractions'))
-        self._write('void CKQYP'+sym+'(double *  P, double *  T, double *  y, double *  qdot)')
+        self._write('void CKQYP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
 
-        self._write('double c[%d]; ' % nSpecies + self.line('temporary storage'))
-        self._write('double YOW = 0; ')
-        self._write('double PWORT; ')
+        self._write('amrex::Real c[%d]; ' % nSpecies + self.line('temporary storage'))
+        self._write('amrex::Real YOW = 0; ')
+        self._write('amrex::Real PWORT; ')
         
         # compute inverse of mean molecular weight first (eq 3)
         self._write(self.line('Compute inverse of mean molecular wt first'))
@@ -4023,15 +4023,15 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the progress rates of each reactions'))
         self._write(self.line('Given P, T, and mole fractions'))
-        self._write('void CKQXP'+sym+'(double *  P, double *  T, double *  x, double *  qdot)')
+        self._write('void CKQXP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
 
-        self._write('double c[%d]; ' % nSpecies + self.line('temporary storage'))
+        self._write('amrex::Real c[%d]; ' % nSpecies + self.line('temporary storage'))
         
-        self._write('double PORT = 1e6 * (*P)/(%1.14e * (*T)); ' % (R*kelvin*mole/erg) +
+        self._write('amrex::Real PORT = 1e6 * (*P)/(%1.14e * (*T)); ' % (R*kelvin*mole/erg) +
                     self.line('1e6 * P/RT so c goes to SI units'))
         
         # now compute conversion
@@ -4073,13 +4073,13 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the progress rates of each reactions'))
         self._write(self.line('Given rho, T, and mass fractions'))
-        self._write('void CKQYR'+sym+'(double *  rho, double *  T, double *  y, double *  qdot)')
+        self._write('void CKQYR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  qdot)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
 
-        self._write('double c[%d]; ' % nSpecies + self.line('temporary storage'))
+        self._write('amrex::Real c[%d]; ' % nSpecies + self.line('temporary storage'))
 
         # now compute conversion
         self._write(self.line('See Eq 8 with an extra 1e6 so c goes to SI'))
@@ -4117,16 +4117,16 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the progress rates of each reactions'))
         self._write(self.line('Given rho, T, and mole fractions'))
-        self._write('void CKQXR'+sym+'(double *  rho, double *  T, double *  x, double *  qdot)')
+        self._write('void CKQXR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  qdot)')
         self._write('{')
         self._indent()
 
         self._write('int id; ' + self.line('loop counter'))
 
-        self._write('double c[%d]; ' % nSpecies + self.line('temporary storage'))
+        self._write('amrex::Real c[%d]; ' % nSpecies + self.line('temporary storage'))
         
-        self._write('double XW = 0; '+self.line('See Eq 4, 11 in CK Manual'))
-        self._write('double ROW; ')
+        self._write('amrex::Real XW = 0; '+self.line('See Eq 4, 11 in CK Manual'))
+        self._write('amrex::Real ROW; ')
         
         # compute mean molecular weight first (eq 3)
         self._write(self.line('Compute mean molecular wt first'))
@@ -4172,13 +4172,13 @@ class CPickler(CMill):
         nReactions = len(mechanism.reaction())
 
         self._write(
-            'double tT = *T; '
+            'amrex::Real tT = *T; '
             + self.line('temporary temperature'))
         self._write(
-            'double tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
+            'amrex::Real tc[] = { log(tT), tT, tT*tT, tT*tT*tT, tT*tT*tT*tT }; '
             + self.line('temperature cache'))
         self._write(
-            'double gort[%d]; ' % nSpecies + self.line(' temporary storage'))
+            'amrex::Real gort[%d]; ' % nSpecies + self.line(' temporary storage'))
 
         # compute the gibbs free energy
         self._write()
@@ -4215,7 +4215,7 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('Returns the equil constants for each reaction'))
-        self._write('void CKEQC'+sym+'(double *  T, double *  C, double *  eqcon)')
+        self._write('void CKEQC'+sym+'(amrex::Real *  T, amrex::Real *  C, amrex::Real *  eqcon)')
         self._write('{')
         self._indent()
 
@@ -4237,7 +4237,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the equil constants for each reaction'))
         self._write(self.line('Given P, T, and mass fractions'))
-        self._write('void CKEQYP'+sym+'(double *  P, double *  T, double *  y, double *  eqcon)')
+        self._write('void CKEQYP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon)')
         self._write('{')
         self._indent()
 
@@ -4259,7 +4259,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the equil constants for each reaction'))
         self._write(self.line('Given P, T, and mole fractions'))
-        self._write('void CKEQXP'+sym+'(double *  P, double *  T, double *  x, double *  eqcon)')
+        self._write('void CKEQXP'+sym+'(amrex::Real *  P, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon)')
         self._write('{')
         self._indent()
 
@@ -4281,7 +4281,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the equil constants for each reaction'))
         self._write(self.line('Given rho, T, and mass fractions'))
-        self._write('void CKEQYR'+sym+'(double *  rho, double *  T, double *  y, double *  eqcon)')
+        self._write('void CKEQYR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  y, amrex::Real *  eqcon)')
         self._write('{')
         self._indent()
 
@@ -4303,7 +4303,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line('Returns the equil constants for each reaction'))
         self._write(self.line('Given rho, T, and mole fractions'))
-        self._write('void CKEQXR'+sym+'(double *  rho, double *  T, double *  x, double *  eqcon)')
+        self._write('void CKEQXR'+sym+'(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  eqcon)')
         self._write('{')
         self._indent()
 
@@ -4327,16 +4327,16 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'get temperature given internal energy in mass units and mass fracs'))
-        self._write('int feeytt'+fsym+'(double *  e, double *  y, double *  t)')
+        self._write('int feeytt'+fsym+'(amrex::Real *  e, amrex::Real *  y, amrex::Real *  t)')
         self._write('{')
         self._indent()
 
         self._write('const int maxiter = 50;')
-        self._write('const double tol  = 0.001;')
-        self._write('double ein  = *e;')
-        self._write('double tmin = %g; // max lower bound for thermo def' % lowT)
-        self._write('double tmax = %g; // min upper bound for thermo def' % highT)
-        self._write('double e1,emin,emax,cv,t1,dt;')
+        self._write('const amrex::Real tol  = 0.001;')
+        self._write('amrex::Real ein  = *e;')
+        self._write('amrex::Real tmin = %g; // max lower bound for thermo def' % lowT)
+        self._write('amrex::Real tmax = %g; // min upper bound for thermo def' % highT)
+        self._write('amrex::Real e1,emin,emax,cv,t1,dt;')
         self._write('int i; // loop counter')
         self._write('CKUBMS'+sym+'(&tmin, y, &emin);')
         self._write('CKUBMS'+sym+'(&tmax, y, &emax);')
@@ -4390,16 +4390,16 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'get temperature given enthalpy in mass units and mass fracs'))
-        self._write('int fehytt'+fsym+'(double *  h, double *  y, double *  t)')
+        self._write('int fehytt'+fsym+'(amrex::Real *  h, amrex::Real *  y, amrex::Real *  t)')
         self._write('{')
         self._indent()
 
         self._write('const int maxiter = 50;')
-        self._write('const double tol  = 0.001;')
-        self._write('double hin  = *h;')
-        self._write('double tmin = %g; // max lower bound for thermo def' % lowT)
-        self._write('double tmax = %g; // min upper bound for thermo def' % highT)
-        self._write('double h1,hmin,hmax,cp,t1,dt;')
+        self._write('const amrex::Real tol  = 0.001;')
+        self._write('amrex::Real hin  = *h;')
+        self._write('amrex::Real tmin = %g; // max lower bound for thermo def' % lowT)
+        self._write('amrex::Real tmax = %g; // min upper bound for thermo def' % highT)
+        self._write('amrex::Real h1,hmin,hmax,cp,t1,dt;')
         self._write('int i; // loop counter')
         self._write('CKHBMS'+sym+'(&tmin, y, &hmin);')
         self._write('CKHBMS'+sym+'(&tmax, y, &hmax);')
@@ -4449,11 +4449,11 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'convert phi[species] (specific mole nums) to y[species] (mass fracs)'))
-        self._write('void fephity'+fsym+'(double *  phi, double *  y)')
+        self._write('void fephity'+fsym+'(amrex::Real *  phi, amrex::Real *  y)')
         self._write('{')
         self._indent()
 
-        self._write('double XW  = 0; ')
+        self._write('amrex::Real XW  = 0; ')
         self._write('int id; ' + self.line('loop counter'))
         
         # compute mean molecular weight first (eq 3)
@@ -4483,7 +4483,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'convert y[species] (mass fracs) to phi[species] (specific mole num)'))
-        self._write('void feytphi'+fsym+'(double *  y, double *  phi)')
+        self._write('void feytphi'+fsym+'(amrex::Real *  y, amrex::Real *  phi)')
         self._write('{')
         self._indent()
 
@@ -4506,7 +4506,7 @@ class CPickler(CMill):
         self._write()
         self._write(self.line(
             'reverse of ytcr, useful for rate computations'))
-        self._write('void fectyr'+fsym+'(double *  c, double *  rho, double *  y)')
+        self._write('void fectyr'+fsym+'(amrex::Real *  c, amrex::Real *  rho, amrex::Real *  y)')
         self._write('{')
         self._indent()
 
@@ -4534,16 +4534,16 @@ class CPickler(CMill):
             'rwrk[0] and rwrk[1] should contain rho and ene respectively'))
         self._write(self.line(
             'working variable phi contains specific mole numbers'))
-        self._write('void fecvrhs'+fsym+'(double *  time, double *  phi, double *  phidot)')
+        self._write('void fecvrhs'+fsym+'(amrex::Real *  time, amrex::Real *  phi, amrex::Real *  phidot)')
 
 	self._write('{')
 	self._indent()
 	# main body
-        self._write('double rho,ene; ' + self.line('CV Parameters'))
-        self._write('double y[%s], wdot[%s]; ' % (self.nSpecies, self.nSpecies) +
+        self._write('amrex::Real rho,ene; ' + self.line('CV Parameters'))
+        self._write('amrex::Real y[%s], wdot[%s]; ' % (self.nSpecies, self.nSpecies) +
                     self.line('temporary storage'))
         self._write('int i; ' + self.line('Loop counter'))
-        self._write('double temperature,pressure; ' + self.line('temporary var'))
+        self._write('amrex::Real temperature,pressure; ' + self.line('temporary var'))
         self._write('rho = rwrk[0];')
         self._write('ene = rwrk[1];')
         self._write('fephity'+fsym+'(phi, y);')
@@ -4586,19 +4586,19 @@ class CPickler(CMill):
         self._write(self.line( 'rwrk[1] : preshock density (g/cc) '))
         self._write(self.line( 'rwrk[2] : detonation velocity (cm/s) '))
         self._write(self.line( 'solution vector: [P; rho; y0 ... ylast] '))
-        self._write('void fezndrhs'+fsym+'(double *  time, double *  z, double *  zdot)')
+        self._write('void fezndrhs'+fsym+'(amrex::Real *  time, amrex::Real *  z, amrex::Real *  zdot)')
 
 	self._write('{')
 	self._indent()
 	# main body
-        self._write('double psc,rho1,udet; ' + self.line('ZND Parameters'))
-        self._write('double wt[%s], hms[%s], wdot[%s]; ' %
+        self._write('amrex::Real psc,rho1,udet; ' + self.line('ZND Parameters'))
+        self._write('amrex::Real wt[%s], hms[%s], wdot[%s]; ' %
                     (self.nSpecies, self.nSpecies, self.nSpecies) +
                     self.line('temporary storage'))
         self._write('int i; ' + self.line('Loop counter'))
         self._write(self.line('temporary variables'))
-        self._write('double ru, T, uvel, wtm, p, rho, gam, son, xm, sum, drdy, eta, cp, cv ;')
-        self._write('double *  y; ' + self.line('mass frac pointer'))
+        self._write('amrex::Real ru, T, uvel, wtm, p, rho, gam, son, xm, sum, drdy, eta, cp, cv ;')
+        self._write('amrex::Real *  y; ' + self.line('mass frac pointer'))
         self._write()
         self._write('ru = %1.14e;' % (R * mole * kelvin / erg))
         self._write()
@@ -4729,7 +4729,7 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('save atomic weights into array'))
-        self._write('void atomicWeight(double *  awt)')
+        self._write('void atomicWeight(amrex::Real *  awt)')
         self._write('{')
         self._indent()
         import pyre
@@ -4835,7 +4835,7 @@ class CPickler(CMill):
     ##            self._write("user_data->nTB[%d] = %d;" % (id, len(efficiencies)))
 
     ##            if (len(efficiencies) > 0):
-    ##                self._write("cudaMallocManaged(&user_data->TB[%d], %d * sizeof(double));"% (id, len(efficiencies)))
+    ##                self._write("cudaMallocManaged(&user_data->TB[%d], %d * sizeof(amrex::Real));"% (id, len(efficiencies)))
     ##                self._write("cudaMallocManaged(&user_data->TBid[%d], %d * sizeof(int));"% (id, len(efficiencies)))
     ##                for i, eff in enumerate(efficiencies):
     ##                    symbol, efficiency = eff
@@ -4880,18 +4880,18 @@ class CPickler(CMill):
         self._write('#ifdef AMREX_USE_CUDA')
         self._write(self.line('GPU version of productionRate: no more use of thermo namespace vectors'))
         self._write(self.line('compute the production rate for each species'))
-        self._write('AMREX_GPU_HOST_DEVICE inline void  productionRate(double * wdot, double * sc, double T)')
+        self._write('AMREX_GPU_HOST_DEVICE inline void  productionRate(amrex::Real * wdot, amrex::Real * sc, amrex::Real T)')
         self._write('{')
         self._indent()
 
-        self._write('double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
-        self._write('double invT = 1.0 / tc[1];')
+        self._write('amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
+        self._write('amrex::Real invT = 1.0 / tc[1];')
         
         if (nReactions == 0):
             self._write()
         else:
             self._write()
-            self._write('double qdot, q_f[%d], q_r[%d];' % (nReactions,nReactions))
+            self._write('amrex::Real qdot, q_f[%d], q_r[%d];' % (nReactions,nReactions))
             self._write('comp_qfqr(q_f, q_r, sc, tc, invT);');
 
         self._write()
@@ -4934,7 +4934,7 @@ class CPickler(CMill):
 
         # k_f function
         ##self._write()
-        ##self._write('AMREX_GPU_HOST_DEVICE void comp_k_f(double *  tc, double invT, double *  k_f)')
+        ##self._write('AMREX_GPU_HOST_DEVICE void comp_k_f(amrex::Real *  tc, amrex::Real invT, amrex::Real *  k_f)')
         ##self._write('{')
         ##self._indent()
         ##for j in range(nReactions):
@@ -4960,12 +4960,12 @@ class CPickler(CMill):
 
         # Kc
         ##self._write()
-        ##self._write('AMREX_GPU_HOST_DEVICE inline void comp_Kc(double *  tc, double invT, double *  Kc)')
+        ##self._write('AMREX_GPU_HOST_DEVICE inline void comp_Kc(amrex::Real *  tc, amrex::Real invT, amrex::Real *  Kc)')
         ##self._write('{')
         ##self._indent()
 
         ##self._write(self.line('compute the Gibbs free energy'))
-        ##self._write('double g_RT[%d];' % (nSpecies))
+        ##self._write('amrex::Real g_RT[%d];' % (nSpecies))
         ##self._write('gibbs(g_RT, tc);')
 
         ##self._write()
@@ -4992,8 +4992,8 @@ class CPickler(CMill):
         ##self._write()
 
         ##self._write(self.line('reference concentration: P_atm / (RT) in inverse mol/m^3'))
-        ##self._write('double refC = %g / %g * invT;' % (atm.value, R.value))
-        ##self._write('double refCinv = 1 / refC;')
+        ##self._write('amrex::Real refC = %g / %g * invT;' % (atm.value, R.value))
+        ##self._write('amrex::Real refCinv = 1 / refC;')
 
         ##self._write()
 
@@ -5011,7 +5011,7 @@ class CPickler(CMill):
 
         # qdot
         self._write()
-        self._write('AMREX_GPU_HOST_DEVICE inline void comp_qfqr(double *  qf, double * qr, double * sc, double * tc, double invT)')
+        self._write('AMREX_GPU_HOST_DEVICE inline void comp_qfqr(amrex::Real *  qf, amrex::Real * qr, amrex::Real * sc, amrex::Real * tc, amrex::Real invT)')
         self._write('{')
         self._indent()
 
@@ -5037,7 +5037,7 @@ class CPickler(CMill):
 
             # Mixt concentration for PD & TB
             self._write(self.line('compute the mixture concentration'))
-            self._write('double mixture = 0.0;')
+            self._write('amrex::Real mixture = 0.0;')
             self._write('for (int i = 0; i < %d; ++i) {' % nSpecies)
             self._indent()
             self._write('mixture += sc[i];')
@@ -5047,26 +5047,26 @@ class CPickler(CMill):
 
             # Kc stuff
             self._write(self.line('compute the Gibbs free energy'))
-            self._write('double g_RT[%d];' % (nSpecies))
+            self._write('amrex::Real g_RT[%d];' % (nSpecies))
             self._write('gibbs(g_RT, tc);')
 
             self._write()
 
             self._write(self.line('reference concentration: P_atm / (RT) in inverse mol/m^3'))
-            self._write('double refC = %g / %g * invT;' % (atm.value, R.value))
-            self._write('double refCinv = 1 / refC;')
+            self._write('amrex::Real refC = %g / %g * invT;' % (atm.value, R.value))
+            self._write('amrex::Real refCinv = 1 / refC;')
 
             self._write()
             
             # kfs
             self._write("/* Evaluate the kfs */")
-            #self._write("double k_f[%d];"% nclassd)
-            #self._write("double Corr[%d];" % nclassd)
-            self._write("double k_f, k_r, Corr;")
+            #self._write("amrex::Real k_f[%d];"% nclassd)
+            #self._write("amrex::Real Corr[%d];" % nclassd)
+            self._write("amrex::Real k_f, k_r, Corr;")
             if ntroe > 0:
-                self._write("double redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;")
+                self._write("amrex::Real redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;")
             if nsri > 0:
-                self._write("double redP, F, X, F_sri;")
+                self._write("amrex::Real redP, F, X, F_sri;")
             self._write()
 
             # build reverse reaction map
@@ -5233,17 +5233,17 @@ class CPickler(CMill):
         # OMP stuff
         self._write()
         self._write("#ifndef AMREX_USE_CUDA")
-        self._write('static double T_save = -1;')
+        self._write('static amrex::Real T_save = -1;')
         self._write('#ifdef _OPENMP')
         self._write('#pragma omp threadprivate(T_save)')
         self._write('#endif')
         self._write()
-        self._write('static double k_f_save[%d];' % nReactions)
+        self._write('static amrex::Real k_f_save[%d];' % nReactions)
         self._write('#ifdef _OPENMP')
         self._write('#pragma omp threadprivate(k_f_save)')
         self._write('#endif')
         self._write()
-        self._write('static double Kc_save[%d];' % nReactions)
+        self._write('static amrex::Real Kc_save[%d];' % nReactions)
         self._write('#ifdef _OPENMP')
         self._write('#pragma omp threadprivate(Kc_save)')
         self._write('#endif')
@@ -5252,12 +5252,12 @@ class CPickler(CMill):
         # main function
         self._write()
         self._write(self.line('compute the production rate for each species pointwise on CPU'))
-        self._write('void productionRate(double *  wdot, double *  sc, double T)')
+        self._write('void productionRate(amrex::Real *  wdot, amrex::Real *  sc, amrex::Real T)')
         self._write('{')
         self._indent()
 
-        self._write('double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
-        self._write('double invT = 1.0 / tc[1];')
+        self._write('amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
+        self._write('amrex::Real invT = 1.0 / tc[1];')
         
         self._write()
         self._write('if (T != T_save)')
@@ -5270,7 +5270,7 @@ class CPickler(CMill):
         self._write("}")
 
         self._write()
-        self._write('double qdot, q_f[%d], q_r[%d];' % (nReactions,nReactions))
+        self._write('amrex::Real qdot, q_f[%d], q_r[%d];' % (nReactions,nReactions))
         self._write('comp_qfqr(q_f, q_r, sc, tc, invT);');
 
         self._write()
@@ -5313,7 +5313,7 @@ class CPickler(CMill):
 
         # k_f function
         self._write()
-        self._write('void comp_k_f(double *  tc, double invT, double *  k_f)')
+        self._write('void comp_k_f(amrex::Real *  tc, amrex::Real invT, amrex::Real *  k_f)')
         self._write('{')
         self._indent()
         self._outdent()
@@ -5335,12 +5335,12 @@ class CPickler(CMill):
 
         # Kc
         self._write()
-        self._write('void comp_Kc(double *  tc, double invT, double *  Kc)')
+        self._write('void comp_Kc(amrex::Real *  tc, amrex::Real invT, amrex::Real *  Kc)')
         self._write('{')
         self._indent()
 
         self._write(self.line('compute the Gibbs free energy'))
-        self._write('double g_RT[%d];' % (nSpecies))
+        self._write('amrex::Real g_RT[%d];' % (nSpecies))
         self._write('gibbs(g_RT, tc);')
 
         self._write()
@@ -5367,8 +5367,8 @@ class CPickler(CMill):
         self._write()
 
         self._write(self.line('reference concentration: P_atm / (RT) in inverse mol/m^3'))
-        self._write('double refC = %g / %g * invT;' % (atm.value, R.value))
-        self._write('double refCinv = 1 / refC;')
+        self._write('amrex::Real refC = %g / %g * invT;' % (atm.value, R.value))
+        self._write('amrex::Real refCinv = 1 / refC;')
 
         self._write()
 
@@ -5385,7 +5385,7 @@ class CPickler(CMill):
 
         # qdot
         self._write()
-        self._write('void comp_qfqr(double *  qf, double *  qr, double *  sc, double *  tc, double invT)')
+        self._write('void comp_qfqr(amrex::Real *  qf, amrex::Real *  qr, amrex::Real *  sc, amrex::Real *  tc, amrex::Real invT)')
         self._write('{')
         self._indent()
 
@@ -5406,10 +5406,10 @@ class CPickler(CMill):
                 self._write("qr[%d] = 0.0;" % (i))
 
         self._write()
-        self._write('double T = tc[1];')
+        self._write('amrex::Real T = tc[1];')
         self._write()
         self._write(self.line('compute the mixture concentration'))
-        self._write('double mixture = 0.0;')
+        self._write('amrex::Real mixture = 0.0;')
         self._write('for (int i = 0; i < %d; ++i) {' % nSpecies)
         self._indent()
         self._write('mixture += sc[i];')
@@ -5417,7 +5417,7 @@ class CPickler(CMill):
         self._write('}')
 
         self._write()
-        self._write("double Corr[%d];" % nclassd)
+        self._write("amrex::Real Corr[%d];" % nclassd)
         self._write('for (int i = 0; i < %d; ++i) {' % nclassd)
         self._indent()
         self._write('Corr[i] = 1.0;')
@@ -5429,7 +5429,7 @@ class CPickler(CMill):
             self._write(self.line(" troe"))
             self._write("{")
             self._indent()
-            self._write("double alpha[%d];" % ntroe)
+            self._write("amrex::Real alpha[%d];" % ntroe)
             alpha_d = {}
             for i in range(itroe[0],itroe[1]):
                 ii = i - itroe[0]
@@ -5457,7 +5457,7 @@ class CPickler(CMill):
             self._write("for (int i=%d; i<%d; i++)" %(itroe[0],itroe[1]))
             self._write("{")
             self._indent()
-            self._write("double redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;")
+            self._write("amrex::Real redP, F, logPred, logFcent, troe_c, troe_n, troe, F_troe;")
             self._write("redP = alpha[i-%d] / k_f_save[i] * phase_units[i] * low_A[i] * exp(low_beta[i] * tc[0] - activation_units[i] * low_Ea[i] *invT);" % itroe[0])
             self._write("F = redP / (1.0 + redP);")
             self._write("logPred = log10(redP);")
@@ -5481,8 +5481,8 @@ class CPickler(CMill):
             self._write(self.line(" SRI"))
             self._write("{")
             self._indent()
-            self._write("double alpha[%d];" % nsri)
-            self._write("double redP, F, X, F_sri;")
+            self._write("amrex::Real alpha[%d];" % nsri)
+            self._write("amrex::Real redP, F, X, F_sri;")
             alpha_d = {}
             for i in range(isri[0],isri[1]):
                 ii = i - isri[0]
@@ -5530,9 +5530,9 @@ class CPickler(CMill):
             self._write("{")
             self._indent()
             if nlindemann > 1:
-                self._write("double alpha[%d];" % nlindemann)
+                self._write("amrex::Real alpha[%d];" % nlindemann)
             else:
-                self._write("double alpha;")
+                self._write("amrex::Real alpha;")
 
             for i in range(ilindemann[0],ilindemann[1]):
                 ii = i - ilindemann[0]
@@ -5545,7 +5545,7 @@ class CPickler(CMill):
                         self._write("alpha = %s;" %(alpha))
 
             if nlindemann == 1:
-                self._write("double redP = alpha / k_f_save[%d] * phase_units[%d] * low_A[%d] * exp(low_beta[%d] * tc[0] - activation_units[%d] * low_Ea[%d] * invT);" 
+                self._write("amrex::Real redP = alpha / k_f_save[%d] * phase_units[%d] * low_A[%d] * exp(low_beta[%d] * tc[0] - activation_units[%d] * low_Ea[%d] * invT);" 
                             % (ilindemann[0],ilindemann[0],ilindemann[0],ilindemann[0],ilindemann[0],ilindemann[0]))
                 self._write("Corr[%d] = redP / (1. + redP);" % ilindemann[0])
             else:
@@ -5560,7 +5560,7 @@ class CPickler(CMill):
                 self._write("for (int i=%d; i<%d; i++)" % (ilindemann[0], ilindemann[1]))
                 self._write("{")
                 self._indent()
-                self._write("double redP = alpha[i-%d] / k_f_save[i] * phase_units[i] * low_A[i] * exp(low_beta[i] * tc[0] - activation_units[i] * low_Ea[i] * invT);"
+                self._write("amrex::Real redP = alpha[i-%d] / k_f_save[i] * phase_units[i] * low_A[i] * exp(low_beta[i] * tc[0] - activation_units[i] * low_Ea[i] * invT);"
                             % ilindemann[0])
                 self._write("Corr[i] = redP / (1. + redP);")
                 self._outdent()
@@ -5574,7 +5574,7 @@ class CPickler(CMill):
             self._write(self.line(" simple three-body correction"))
             self._write("{")
             self._indent()
-            self._write("double alpha;")
+            self._write("amrex::Real alpha;")
             alpha_save = ""
             for i in range(i3body[0],i3body[1]):
                 reaction = mechanism.reaction(id=i)
@@ -5607,25 +5607,25 @@ class CPickler(CMill):
 
             self._write(self.line("reactions: %d to %d" % (ispecial[0]+1,ispecial[1])))
 
-            #self._write('double Kc;                      ' + self.line('equilibrium constant'))
-            self._write('double k_f;                     ' + self.line('forward reaction rate'))
-            self._write('double k_r;                     ' + self.line('reverse reaction rate'))
-            self._write('double q_f;                     ' + self.line('forward progress rate'))
-            self._write('double q_r;                     ' + self.line('reverse progress rate'))
-            self._write('double phi_f;                   '
+            #self._write('amrex::Real Kc;                      ' + self.line('equilibrium constant'))
+            self._write('amrex::Real k_f;                     ' + self.line('forward reaction rate'))
+            self._write('amrex::Real k_r;                     ' + self.line('reverse reaction rate'))
+            self._write('amrex::Real q_f;                     ' + self.line('forward progress rate'))
+            self._write('amrex::Real q_r;                     ' + self.line('reverse progress rate'))
+            self._write('amrex::Real phi_f;                   '
                         + self.line('forward phase space factor'))
-            self._write('double phi_r;                   ' + self.line('reverse phase space factor'))
-            self._write('double alpha;                   ' + self.line('enhancement'))
+            self._write('amrex::Real phi_r;                   ' + self.line('reverse phase space factor'))
+            self._write('amrex::Real alpha;                   ' + self.line('enhancement'))
 
-            #self._write('double redP;                    ' + self.line('reduced pressure'))
-            #self._write('double logPred;                 ' + self.line('log of above'))
-            #self._write('double F;                       ' + self.line('fallof rate enhancement'))
+            #self._write('amrex::Real redP;                    ' + self.line('reduced pressure'))
+            #self._write('amrex::Real logPred;                 ' + self.line('log of above'))
+            #self._write('amrex::Real F;                       ' + self.line('fallof rate enhancement'))
             #self._write()
-            #self._write('double F_troe;                  ' + self.line('TROE intermediate'))
-            #self._write('double logFcent;                ' + self.line('TROE intermediate'))
-            #self._write('double troe;                    ' + self.line('TROE intermediate'))
-            #self._write('double troe_c;                  ' + self.line('TROE intermediate'))
-            #self._write('double troe_n;                  ' + self.line('TROE intermediate'))
+            #self._write('amrex::Real F_troe;                  ' + self.line('TROE intermediate'))
+            #self._write('amrex::Real logFcent;                ' + self.line('TROE intermediate'))
+            #self._write('amrex::Real troe;                    ' + self.line('TROE intermediate'))
+            #self._write('amrex::Real troe_c;                  ' + self.line('TROE intermediate'))
+            #self._write('amrex::Real troe_n;                  ' + self.line('TROE intermediate'))
 
             for i in range(ispecial[0],ispecial[1]):
                 self._write()
@@ -5660,12 +5660,12 @@ class CPickler(CMill):
         self._write('#ifdef USE_PYJAC')
         self._write()
         self._write(self.line('compute the reaction Jacobian using PyJac'))
-        self._write('void DWDOT_PYJAC(double *  J, double *  y, double *  Tp, double *  Press)')
+        self._write('void DWDOT_PYJAC(amrex::Real *  J, amrex::Real *  y, amrex::Real *  Tp, amrex::Real *  Press)')
         self._write('{')
         self._indent()
 
-        self._write('double y_pyjac[%d];' % (nSpecies + 1))
-        self._write('double J_reorg[%d];' % (nSpecies+1)**2)
+        self._write('amrex::Real y_pyjac[%d];' % (nSpecies + 1))
+        self._write('amrex::Real J_reorg[%d];' % (nSpecies+1)**2)
 
         self._write()
         self._write(self.line(' INPUT Y'))
@@ -5677,7 +5677,7 @@ class CPickler(CMill):
         self._write('}')
 
         self._write()
-        self._write('double Press_MKS = *Press / 10.0;')
+        self._write('amrex::Real Press_MKS = *Press / 10.0;')
 
         self._write()
         self._write('for (int k=0; k<%d; k++) {' % (nSpecies+1)**2)
@@ -5742,11 +5742,11 @@ class CPickler(CMill):
 
         self._write()
         self._write(self.line('compute the reaction Jacobian'))
-        self._write('AMREX_GPU_HOST_DEVICE void DWDOT(double *  J, double *  sc, double *  Tp, int * consP)')
+        self._write('AMREX_GPU_HOST_DEVICE void DWDOT(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * consP)')
         self._write('{')
         self._indent()
 
-        self._write('double c[%d];' % (nSpecies))
+        self._write('amrex::Real c[%d];' % (nSpecies))
         self._write()
         self._write('for (int k=0; k<%d; k++) {' % nSpecies)
         self._indent()
@@ -5782,11 +5782,11 @@ class CPickler(CMill):
 
         self._write()
         self._write(self.line('compute an approx to the reaction Jacobian (for preconditioning)'))
-        self._write('AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(double *  J, double *  sc, double *  Tp, int * HP)')
+        self._write('AMREX_GPU_HOST_DEVICE void DWDOT_SIMPLIFIED(amrex::Real *  J, amrex::Real *  sc, amrex::Real *  Tp, int * HP)')
         self._write('{')
         self._indent()
 
-        self._write('double c[%d];' % (nSpecies))
+        self._write('amrex::Real c[%d];' % (nSpecies))
         self._write()
         self._write('for (int k=0; k<%d; k++) {' % nSpecies)
         self._indent()
@@ -5822,13 +5822,13 @@ class CPickler(CMill):
 
         self._write()
         self._write(self.line('compute an approx to the SPS Jacobian'))
-        self._write('AMREX_GPU_HOST_DEVICE void SLJ_PRECOND_CSC(double *  Jsps, int * indx, int * len, double * sc, double * Tp, int * HP, double * gamma)')
+        self._write('AMREX_GPU_HOST_DEVICE void SLJ_PRECOND_CSC(amrex::Real *  Jsps, int * indx, int * len, amrex::Real * sc, amrex::Real * Tp, int * HP, amrex::Real * gamma)')
         self._write('{')
         self._indent()
 
-        self._write('double c[%d];' % (nSpecies))
-        self._write('double J[%d];' % ((nSpecies+1) * (nSpecies+1)))
-        self._write('double mwt[%d];' % (nSpecies))
+        self._write('amrex::Real c[%d];' % (nSpecies))
+        self._write('amrex::Real J[%d];' % ((nSpecies+1) * (nSpecies+1)))
+        self._write('amrex::Real mwt[%d];' % (nSpecies))
         self._write()
         self._write('get_mw(mwt);')
         self._write()
@@ -5901,8 +5901,8 @@ class CPickler(CMill):
         self._write('{')
         self._indent()
 
-        self._write('double c[%d];' % (nSpecies))
-        self._write('double J[%d];' % (nSpecies+1)**2)
+        self._write('amrex::Real c[%d];' % (nSpecies))
+        self._write('amrex::Real J[%d];' % (nSpecies+1)**2)
         self._write()
         self._write('for (int k=0; k<%d; k++) {' % nSpecies)
         self._indent()
@@ -5947,8 +5947,8 @@ class CPickler(CMill):
         self._write('{')
         self._indent()
 
-        self._write('double c[%d];' % (nSpecies))
-        self._write('double J[%d];' % (nSpecies+1)**2)
+        self._write('amrex::Real c[%d];' % (nSpecies))
+        self._write('amrex::Real J[%d];' % (nSpecies+1)**2)
         self._write()
         self._write('for (int k=0; k<%d; k++) {' % nSpecies)
         self._indent()
@@ -6001,8 +6001,8 @@ class CPickler(CMill):
         self._write('{')
         self._indent()
 
-        self._write('double c[%d];' % (nSpecies))
-        self._write('double J[%d];' % (nSpecies+1)**2)
+        self._write('amrex::Real c[%d];' % (nSpecies))
+        self._write('amrex::Real J[%d];' % (nSpecies+1)**2)
         self._write()
         self._write('for (int k=0; k<%d; k++) {' % nSpecies)
         self._indent()
@@ -6055,8 +6055,8 @@ class CPickler(CMill):
         self._write('{')
         self._indent()
 
-        self._write('double c[%d];' % (nSpecies))
-        self._write('double J[%d];' % (nSpecies+1)**2)
+        self._write('amrex::Real c[%d];' % (nSpecies))
+        self._write('amrex::Real J[%d];' % (nSpecies+1)**2)
         self._write('int offset_row;')
         self._write('int offset_col;')
         self._write()
@@ -6107,8 +6107,8 @@ class CPickler(CMill):
         self._write('{')
         self._indent()
 
-        self._write('double c[%d];' % (nSpecies))
-        self._write('double J[%d];' % (nSpecies+1)**2)
+        self._write('amrex::Real c[%d];' % (nSpecies))
+        self._write('amrex::Real J[%d];' % (nSpecies+1)**2)
         self._write('int offset;')
         self._write()
         self._write('for (int k=0; k<%d; k++) {' % nSpecies)
@@ -6188,8 +6188,8 @@ class CPickler(CMill):
         self._write('{')
         self._indent()
 
-        self._write('double c[%d];' % (nSpecies))
-        self._write('double J[%d];' % (nSpecies+1)**2)
+        self._write('amrex::Real c[%d];' % (nSpecies))
+        self._write('amrex::Real J[%d];' % (nSpecies+1)**2)
         self._write('int offset;')
 
         self._write()
@@ -6287,8 +6287,8 @@ class CPickler(CMill):
         self._write('{')
         self._indent()
 
-        self._write('double c[%d];' % (nSpecies))
-        self._write('double J[%d];' % (nSpecies+1)**2)
+        self._write('amrex::Real c[%d];' % (nSpecies))
+        self._write('amrex::Real J[%d];' % (nSpecies+1)**2)
         self._write()
         self._write('for (int k=0; k<%d; k++) {' % nSpecies)
         self._indent()
@@ -6343,8 +6343,8 @@ class CPickler(CMill):
         self._write('{')
         self._indent()
 
-        self._write('double c[%d];' % (nSpecies))
-        self._write('double J[%d];' % (nSpecies+1)**2)
+        self._write('amrex::Real c[%d];' % (nSpecies))
+        self._write('amrex::Real J[%d];' % (nSpecies+1)**2)
         self._write()
         self._write('for (int k=0; k<%d; k++) {' % nSpecies)
         self._indent()
@@ -6433,7 +6433,7 @@ class CPickler(CMill):
 
         self._write()
         self._write(self.line('compute an approx to the reaction Jacobian'))
-        self._write('AMREX_GPU_HOST_DEVICE void aJacobian_precond(double *  J, double *  sc, double T, int HP)')
+        self._write('AMREX_GPU_HOST_DEVICE void aJacobian_precond(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int HP)')
         self._write('{')
         self._indent()
 
@@ -6445,7 +6445,7 @@ class CPickler(CMill):
         
         self._write()
 
-        self._write('double wdot[%d];' % (nSpecies))
+        self._write('amrex::Real wdot[%d];' % (nSpecies))
         self._write('for (int k=0; k<%d; k++) {' % (nSpecies))
         self._indent()
         self._write('wdot[k] = 0.0;')
@@ -6454,20 +6454,20 @@ class CPickler(CMill):
         
         self._write()
 
-        self._write('double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
-        self._write('double invT = 1.0 / tc[1];')
-        self._write('double invT2 = invT * invT;')
+        self._write('amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
+        self._write('amrex::Real invT = 1.0 / tc[1];')
+        self._write('amrex::Real invT2 = invT * invT;')
 
         self._write()
 
         self._write(self.line('reference concentration: P_atm / (RT) in inverse mol/m^3'))
-        self._write('double refC = %g / %g / T;' % (atm.value, R.value))
-        self._write('double refCinv = 1.0 / refC;')
+        self._write('amrex::Real refC = %g / %g / T;' % (atm.value, R.value))
+        self._write('amrex::Real refCinv = 1.0 / refC;')
 
         self._write()
 
         self._write(self.line('compute the mixture concentration'))
-        self._write('double mixture = 0.0;')
+        self._write('amrex::Real mixture = 0.0;')
         self._write('for (int k = 0; k < %d; ++k) {' % nSpecies)
         self._indent()
         self._write('mixture += sc[k];')
@@ -6477,27 +6477,27 @@ class CPickler(CMill):
         self._write()
 
         self._write(self.line('compute the Gibbs free energy'))
-        self._write('double g_RT[%d];' % (nSpecies))
+        self._write('amrex::Real g_RT[%d];' % (nSpecies))
         self._write('gibbs(g_RT, tc);')
 
         self._write()
 
         self._write(self.line('compute the species enthalpy'))
-        self._write('double h_RT[%d];' % (nSpecies))
+        self._write('amrex::Real h_RT[%d];' % (nSpecies))
         self._write('speciesEnthalpy(h_RT, tc);')
 
         self._write()
 
-        self._write('double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;') 
-        self._write('double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;')
-        self._write('double dqdci, dcdc_fac, dqdc[%d];' % (nSpecies))
-        self._write('double Pr, fPr, F, k_0, logPr;') 
-        self._write('double logFcent, troe_c, troe_n, troePr_den, troePr, troe;')
-        self._write('double Fcent1, Fcent2, Fcent3, Fcent;')
-        self._write('double dlogFdc, dlogFdn, dlogFdcn_fac;')
-        self._write('double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;')
-        self._write('const double ln10 = log(10.0);')
-        self._write('const double log10e = 1.0/log(10.0);')
+        self._write('amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;') 
+        self._write('amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;')
+        self._write('amrex::Real dqdci, dcdc_fac, dqdc[%d];' % (nSpecies))
+        self._write('amrex::Real Pr, fPr, F, k_0, logPr;') 
+        self._write('amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;')
+        self._write('amrex::Real Fcent1, Fcent2, Fcent3, Fcent;')
+        self._write('amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;')
+        self._write('amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;')
+        self._write('const amrex::Real ln10 = log(10.0);')
+        self._write('const amrex::Real log10e = 1.0/log(10.0);')
 
         for i, reaction in zip(range(nReactions), mechanism.reaction()):
 
@@ -6518,8 +6518,8 @@ class CPickler(CMill):
                 self._ajac_reaction_precond(mechanism, reaction, 3)
             self._write()
 
-        self._write('double c_R[%d], dcRdT[%d], e_RT[%d];' % (nSpecies, nSpecies, nSpecies))
-        self._write('double * eh_RT;')
+        self._write('amrex::Real c_R[%d], dcRdT[%d], e_RT[%d];' % (nSpecies, nSpecies, nSpecies))
+        self._write('amrex::Real * eh_RT;')
         self._write('if (HP) {')
         self._indent()
 
@@ -6542,7 +6542,7 @@ class CPickler(CMill):
 
         self._write()
 
-        self._write('double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;')
+        self._write('amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;')
         self._write('for (int k = 0; k < %d; ++k) {' % nSpecies)
         self._indent()
         self._write('cmix += c_R[k]*sc[k];')
@@ -6554,11 +6554,11 @@ class CPickler(CMill):
         self._write('}')
 
         self._write()
-        self._write('double cmixinv = 1.0/cmix;')
-        self._write('double tmp1 = ehmix*cmixinv;')
-        self._write('double tmp3 = cmixinv*T;')
-        self._write('double tmp2 = tmp1*tmp3;')
-        self._write('double dehmixdc;')
+        self._write('amrex::Real cmixinv = 1.0/cmix;')
+        self._write('amrex::Real tmp1 = ehmix*cmixinv;')
+        self._write('amrex::Real tmp3 = cmixinv*T;')
+        self._write('amrex::Real tmp2 = tmp1*tmp3;')
+        self._write('amrex::Real dehmixdc;')
 
         self._write('/* dTdot/d[X] */')
         self._write('for (int k = 0; k < %d; ++k) {' % nSpecies)
@@ -6990,7 +6990,7 @@ class CPickler(CMill):
         self._write('#ifdef AMREX_USE_CUDA')
         self._write(self.line('compute the reaction Jacobian on GPU'))
         self._write('AMREX_GPU_HOST_DEVICE')
-        self._write('void aJacobian(double * J, double * sc, double T, int consP)')
+        self._write('void aJacobian(amrex::Real * J, amrex::Real * sc, amrex::Real T, int consP)')
         self._write('{')
         self._indent()
 
@@ -7006,7 +7006,7 @@ class CPickler(CMill):
         
         self._write()
 
-        self._write('double wdot[%d];' % (nSpecies))
+        self._write('amrex::Real wdot[%d];' % (nSpecies))
         self._write('for (int k=0; k<%d; k++) {' % (nSpecies))
         self._indent()
         self._write('wdot[k] = 0.0;')
@@ -7015,20 +7015,20 @@ class CPickler(CMill):
         
         self._write()
 
-        self._write('double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
-        self._write('double invT = 1.0 / tc[1];')
-        self._write('double invT2 = invT * invT;')
+        self._write('amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
+        self._write('amrex::Real invT = 1.0 / tc[1];')
+        self._write('amrex::Real invT2 = invT * invT;')
 
         self._write()
 
         self._write(self.line('reference concentration: P_atm / (RT) in inverse mol/m^3'))
-        self._write('double refC = %g / %g / T;' % (atm.value, R.value))
-        self._write('double refCinv = 1.0 / refC;')
+        self._write('amrex::Real refC = %g / %g / T;' % (atm.value, R.value))
+        self._write('amrex::Real refCinv = 1.0 / refC;')
 
         self._write()
 
         self._write(self.line('compute the mixture concentration'))
-        self._write('double mixture = 0.0;')
+        self._write('amrex::Real mixture = 0.0;')
         self._write('for (int k = 0; k < %d; ++k) {' % nSpecies)
         self._indent()
         self._write('mixture += sc[k];')
@@ -7038,27 +7038,27 @@ class CPickler(CMill):
         self._write()
 
         self._write(self.line('compute the Gibbs free energy'))
-        self._write('double g_RT[%d];' % (nSpecies))
+        self._write('amrex::Real g_RT[%d];' % (nSpecies))
         self._write('gibbs(g_RT, tc);')
 
         self._write()
 
         self._write(self.line('compute the species enthalpy'))
-        self._write('double h_RT[%d];' % (nSpecies))
+        self._write('amrex::Real h_RT[%d];' % (nSpecies))
         self._write('speciesEnthalpy(h_RT, tc);')
 
         self._write()
 
-        self._write('double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;') 
-        self._write('double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;')
-        self._write('double dqdci, dcdc_fac, dqdc[%d];' % (nSpecies))
-        self._write('double Pr, fPr, F, k_0, logPr;') 
-        self._write('double logFcent, troe_c, troe_n, troePr_den, troePr, troe;')
-        self._write('double Fcent1, Fcent2, Fcent3, Fcent;')
-        self._write('double dlogFdc, dlogFdn, dlogFdcn_fac;')
-        self._write('double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;')
-        self._write('const double ln10 = log(10.0);')
-        self._write('const double log10e = 1.0/log(10.0);')
+        self._write('amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;') 
+        self._write('amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;')
+        self._write('amrex::Real dqdci, dcdc_fac, dqdc[%d];' % (nSpecies))
+        self._write('amrex::Real Pr, fPr, F, k_0, logPr;') 
+        self._write('amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;')
+        self._write('amrex::Real Fcent1, Fcent2, Fcent3, Fcent;')
+        self._write('amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;')
+        self._write('amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;')
+        self._write('const amrex::Real ln10 = log(10.0);')
+        self._write('const amrex::Real log10e = 1.0/log(10.0);')
 
         for i, reaction in zip(range(nReactions), mechanism.reaction()):
 
@@ -7079,8 +7079,8 @@ class CPickler(CMill):
                 self._ajac_reaction_d(mechanism, reaction, 3)
             self._write()
 
-        self._write('double c_R[%d], dcRdT[%d], e_RT[%d];' % (nSpecies, nSpecies, nSpecies))
-        self._write('double * eh_RT;')
+        self._write('amrex::Real c_R[%d], dcRdT[%d], e_RT[%d];' % (nSpecies, nSpecies, nSpecies))
+        self._write('amrex::Real * eh_RT;')
         self._write('if (consP) {')
         self._indent()
 
@@ -7103,7 +7103,7 @@ class CPickler(CMill):
 
         self._write()
 
-        self._write('double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;')
+        self._write('amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;')
         self._write('for (int k = 0; k < %d; ++k) {' % nSpecies)
         self._indent()
         self._write('cmix += c_R[k]*sc[k];')
@@ -7115,11 +7115,11 @@ class CPickler(CMill):
         self._write('}')
 
         self._write()
-        self._write('double cmixinv = 1.0/cmix;')
-        self._write('double tmp1 = ehmix*cmixinv;')
-        self._write('double tmp3 = cmixinv*T;')
-        self._write('double tmp2 = tmp1*tmp3;')
-        self._write('double dehmixdc;')
+        self._write('amrex::Real cmixinv = 1.0/cmix;')
+        self._write('amrex::Real tmp1 = ehmix*cmixinv;')
+        self._write('amrex::Real tmp3 = cmixinv*T;')
+        self._write('amrex::Real tmp2 = tmp1*tmp3;')
+        self._write('amrex::Real dehmixdc;')
 
         self._write('/* dTdot/d[X] */')
         self._write('for (int k = 0; k < %d; ++k) {' % nSpecies)
@@ -7549,7 +7549,7 @@ class CPickler(CMill):
         self._write()
         self._write('#ifndef AMREX_USE_CUDA')
         self._write(self.line('compute the reaction Jacobian on CPU'))
-        self._write('void aJacobian(double *  J, double *  sc, double T, int consP)')
+        self._write('void aJacobian(amrex::Real *  J, amrex::Real *  sc, amrex::Real T, int consP)')
         self._write('{')
         self._indent()
 
@@ -7561,7 +7561,7 @@ class CPickler(CMill):
         
         self._write()
 
-        self._write('double wdot[%d];' % (nSpecies))
+        self._write('amrex::Real wdot[%d];' % (nSpecies))
         self._write('for (int k=0; k<%d; k++) {' % (nSpecies))
         self._indent()
         self._write('wdot[k] = 0.0;')
@@ -7570,20 +7570,20 @@ class CPickler(CMill):
         
         self._write()
 
-        self._write('double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
-        self._write('double invT = 1.0 / tc[1];')
-        self._write('double invT2 = invT * invT;')
+        self._write('amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
+        self._write('amrex::Real invT = 1.0 / tc[1];')
+        self._write('amrex::Real invT2 = invT * invT;')
 
         self._write()
 
         self._write(self.line('reference concentration: P_atm / (RT) in inverse mol/m^3'))
-        self._write('double refC = %g / %g / T;' % (atm.value, R.value))
-        self._write('double refCinv = 1.0 / refC;')
+        self._write('amrex::Real refC = %g / %g / T;' % (atm.value, R.value))
+        self._write('amrex::Real refCinv = 1.0 / refC;')
 
         self._write()
 
         self._write(self.line('compute the mixture concentration'))
-        self._write('double mixture = 0.0;')
+        self._write('amrex::Real mixture = 0.0;')
         self._write('for (int k = 0; k < %d; ++k) {' % nSpecies)
         self._indent()
         self._write('mixture += sc[k];')
@@ -7593,27 +7593,27 @@ class CPickler(CMill):
         self._write()
 
         self._write(self.line('compute the Gibbs free energy'))
-        self._write('double g_RT[%d];' % (nSpecies))
+        self._write('amrex::Real g_RT[%d];' % (nSpecies))
         self._write('gibbs(g_RT, tc);')
 
         self._write()
 
         self._write(self.line('compute the species enthalpy'))
-        self._write('double h_RT[%d];' % (nSpecies))
+        self._write('amrex::Real h_RT[%d];' % (nSpecies))
         self._write('speciesEnthalpy(h_RT, tc);')
 
         self._write()
 
-        self._write('double phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;') 
-        self._write('double dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;')
-        self._write('double dqdci, dcdc_fac, dqdc[%d];' % (nSpecies))
-        self._write('double Pr, fPr, F, k_0, logPr;') 
-        self._write('double logFcent, troe_c, troe_n, troePr_den, troePr, troe;')
-        self._write('double Fcent1, Fcent2, Fcent3, Fcent;')
-        self._write('double dlogFdc, dlogFdn, dlogFdcn_fac;')
-        self._write('double dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;')
-        self._write('const double ln10 = log(10.0);')
-        self._write('const double log10e = 1.0/log(10.0);')
+        self._write('amrex::Real phi_f, k_f, k_r, phi_r, Kc, q, q_nocor, Corr, alpha;') 
+        self._write('amrex::Real dlnkfdT, dlnk0dT, dlnKcdT, dkrdT, dqdT;')
+        self._write('amrex::Real dqdci, dcdc_fac, dqdc[%d];' % (nSpecies))
+        self._write('amrex::Real Pr, fPr, F, k_0, logPr;') 
+        self._write('amrex::Real logFcent, troe_c, troe_n, troePr_den, troePr, troe;')
+        self._write('amrex::Real Fcent1, Fcent2, Fcent3, Fcent;')
+        self._write('amrex::Real dlogFdc, dlogFdn, dlogFdcn_fac;')
+        self._write('amrex::Real dlogPrdT, dlogfPrdT, dlogFdT, dlogFcentdT, dlogFdlogPr, dlnCorrdT;')
+        self._write('const amrex::Real ln10 = log(10.0);')
+        self._write('const amrex::Real log10e = 1.0/log(10.0);')
 
         for i, reaction in zip(range(nReactions), mechanism.reaction()):
 
@@ -7634,8 +7634,8 @@ class CPickler(CMill):
                 self._ajac_reaction(mechanism, reaction, 3)
             self._write()
 
-        self._write('double c_R[%d], dcRdT[%d], e_RT[%d];' % (nSpecies, nSpecies, nSpecies))
-        self._write('double * eh_RT;')
+        self._write('amrex::Real c_R[%d], dcRdT[%d], e_RT[%d];' % (nSpecies, nSpecies, nSpecies))
+        self._write('amrex::Real * eh_RT;')
         self._write('if (consP) {')
         self._indent()
 
@@ -7658,7 +7658,7 @@ class CPickler(CMill):
 
         self._write()
 
-        self._write('double cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;')
+        self._write('amrex::Real cmix = 0.0, ehmix = 0.0, dcmixdT=0.0, dehmixdT=0.0;')
         self._write('for (int k = 0; k < %d; ++k) {' % nSpecies)
         self._indent()
         self._write('cmix += c_R[k]*sc[k];')
@@ -7670,11 +7670,11 @@ class CPickler(CMill):
         self._write('}')
 
         self._write()
-        self._write('double cmixinv = 1.0/cmix;')
-        self._write('double tmp1 = ehmix*cmixinv;')
-        self._write('double tmp3 = cmixinv*T;')
-        self._write('double tmp2 = tmp1*tmp3;')
-        self._write('double dehmixdc;')
+        self._write('amrex::Real cmixinv = 1.0/cmix;')
+        self._write('amrex::Real tmp1 = ehmix*cmixinv;')
+        self._write('amrex::Real tmp3 = cmixinv*T;')
+        self._write('amrex::Real tmp2 = tmp1*tmp3;')
+        self._write('amrex::Real dehmixdc;')
 
         self._write('/* dTdot/d[X] */')
         self._write('for (int k = 0; k < %d; ++k) {' % nSpecies)
@@ -8082,13 +8082,13 @@ class CPickler(CMill):
         self._write()
         self._write('#ifndef AMREX_USE_CUDA')
         self._write(self.line('compute the production rate for each species'))
-        self._write('void vproductionRate(int npt, double *  wdot, double *  sc, double *  T)')
+        self._write('void vproductionRate(int npt, amrex::Real *  wdot, amrex::Real *  sc, amrex::Real *  T)')
         self._write('{')
         self._indent()
 
-        self._write('double k_f_s[%d*npt], Kc_s[%d*npt], mixture[npt], g_RT[%d*npt];'
+        self._write('amrex::Real k_f_s[%d*npt], Kc_s[%d*npt], mixture[npt], g_RT[%d*npt];'
                     % (nReactions, nReactions, nSpecies))
-        self._write('double tc[5*npt], invT[npt];')
+        self._write('amrex::Real tc[5*npt], invT[npt];')
 
         self._write()
 
@@ -8147,7 +8147,7 @@ class CPickler(CMill):
 
         self._write()
 
-        self._write('void vcomp_k_f(int npt, double *  k_f_s, double *  tc, double *  invT)')
+        self._write('void vcomp_k_f(int npt, amrex::Real *  k_f_s, amrex::Real *  tc, amrex::Real *  invT)')
         self._write('{')
         # self._write('#ifdef __INTEL_COMPILER')
         # self._indent()
@@ -8168,13 +8168,13 @@ class CPickler(CMill):
 
         self._write()
 
-        self._write('void vcomp_gibbs(int npt, double *  g_RT, double *  tc)')
+        self._write('void vcomp_gibbs(int npt, amrex::Real *  g_RT, amrex::Real *  tc)')
         self._write('{')
         self._indent()
         self._write(self.line('compute the Gibbs free energy'))
         self._write('for (int i=0; i<npt; i++) {')
         self._indent()
-        self._write('double tg[5], g[%d];' % nSpecies)
+        self._write('amrex::Real tg[5], g[%d];' % nSpecies)
         self._write('tg[0] = tc[0*npt+i];')
         self._write('tg[1] = tc[1*npt+i];')
         self._write('tg[2] = tc[2*npt+i];')
@@ -8192,7 +8192,7 @@ class CPickler(CMill):
 
         self._write()
 
-        self._write('void vcomp_Kc(int npt, double *  Kc_s, double *  g_RT, double *  invT)')
+        self._write('void vcomp_Kc(int npt, amrex::Real *  Kc_s, amrex::Real *  g_RT, amrex::Real *  invT)')
         self._write('{')
         # self._write('#ifdef __INTEL_COMPILER')
         # self._indent()
@@ -8203,8 +8203,8 @@ class CPickler(CMill):
         self._write('for (int i=0; i<npt; i++) {')
         self._indent()
         self._write(self.line('reference concentration: P_atm / (RT) in inverse mol/m^3'))
-        self._write('double refC = (101325. / 8.31451) * invT[i];');
-        self._write('double refCinv = 1.0 / refC;');
+        self._write('amrex::Real refC = (101325. / 8.31451) * invT[i];');
+        self._write('amrex::Real refCinv = 1.0 / refC;');
         self._write()
         for reaction in mechanism.reaction():
             K_c = self._vKc(mechanism, reaction)
@@ -8216,18 +8216,18 @@ class CPickler(CMill):
 
         self._write()
         if nReactions <= 50:
-            self._write('void vcomp_wdot(int npt, double *  wdot, double *  mixture, double *  sc,')
-            self._write('		double *  k_f_s, double *  Kc_s,')
-            self._write('		double *  tc, double *  invT, double *  T)')
+            self._write('void vcomp_wdot(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,')
+            self._write('		amrex::Real *  k_f_s, amrex::Real *  Kc_s,')
+            self._write('		amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T)')
             self._write('{')
             self._vcomp_wdot(mechanism,0,nReactions)
             self._write('}')
         else:
             for i in range(0,nReactions,50):
                 nr = min(50, nReactions-i)
-                self._write('void vcomp_wdot_%d_%d(int npt, double *  wdot, double *  mixture, double *  sc,' % (i+1,i+nr))
-                self._write('		double *  k_f_s, double *  Kc_s,')
-                self._write('		double *  tc, double *  invT, double *  T)')
+                self._write('void vcomp_wdot_%d_%d(int npt, amrex::Real *  wdot, amrex::Real *  mixture, amrex::Real *  sc,' % (i+1,i+nr))
+                self._write('		amrex::Real *  k_f_s, amrex::Real *  Kc_s,')
+                self._write('		amrex::Real *  tc, amrex::Real *  invT, amrex::Real *  T)')
                 self._write('{')
                 self._vcomp_wdot(mechanism,i,nr)
                 self._write('}')
@@ -8265,18 +8265,18 @@ class CPickler(CMill):
         self._write('for (int i=0; i<npt; i++) {')
         self._indent()
 
-        self._write('double qdot, q_f, q_r, phi_f, phi_r, k_f, k_r, Kc;')
-        self._write('double alpha;')
+        self._write('amrex::Real qdot, q_f, q_r, phi_f, phi_r, k_f, k_r, Kc;')
+        self._write('amrex::Real alpha;')
         #if istart < isimple[0]:
-        #    self._write('double alpha;')
+        #    self._write('amrex::Real alpha;')
         if istart < i3body[0]:
-            self._write('double redP, F;') 
+            self._write('amrex::Real redP, F;') 
         if istart < ilindemann[0]:
-            self._write('double logPred;')
+            self._write('amrex::Real logPred;')
             if ntroe>0:
-                self._write('double logFcent, troe_c, troe_n, troe, F_troe;')
+                self._write('amrex::Real logFcent, troe_c, troe_n, troe, F_troe;')
             if nsri>0:
-                self._write('double X, F_sri;')
+                self._write('amrex::Real X, F_sri;')
 
         first_id = istart + 1
         last_id  = istart + nr
@@ -8353,12 +8353,12 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('compute the progress rate for each reaction'))
-        self._write('AMREX_GPU_HOST_DEVICE void progressRate(double *  qdot, double *  sc, double T)')
+        self._write('AMREX_GPU_HOST_DEVICE void progressRate(amrex::Real *  qdot, amrex::Real *  sc, amrex::Real T)')
         self._write('{')
         self._indent()
 
-        self._write('double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
-        self._write('double invT = 1.0 / tc[1];')
+        self._write('amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
+        self._write('amrex::Real invT = 1.0 / tc[1];')
         
         self._write()
         self._outdent()
@@ -8380,7 +8380,7 @@ class CPickler(CMill):
             self._write()
         else:
             self._write()
-            self._write('double q_f[%d], q_r[%d];' % (nReactions,nReactions))
+            self._write('amrex::Real q_f[%d], q_r[%d];' % (nReactions,nReactions))
             self._write('comp_qfqr(q_f, q_r, sc, tc, invT);');
             self._write()
             self._write('for (int i = 0; i < %d; ++i) {' % nReactions)
@@ -8407,47 +8407,47 @@ class CPickler(CMill):
         self._write()
         self._write('int id; ' + self.line('loop counter'))
 
-        self._write('double mixture;                 '
+        self._write('amrex::Real mixture;                 '
                     + self.line('mixture concentration'))
-        self._write('double g_RT[%d];                ' % nSpecies
+        self._write('amrex::Real g_RT[%d];                ' % nSpecies
                     + self.line('Gibbs free energy'))
 
-        self._write('double Kc;                      ' + self.line('equilibrium constant'))
-        self._write('double k_f;                     ' + self.line('forward reaction rate'))
-        self._write('double k_r;                     ' + self.line('reverse reaction rate'))
-        self._write('double q_f;                     ' + self.line('forward progress rate'))
-        self._write('double q_r;                     ' + self.line('reverse progress rate'))
-        self._write('double phi_f;                   '
+        self._write('amrex::Real Kc;                      ' + self.line('equilibrium constant'))
+        self._write('amrex::Real k_f;                     ' + self.line('forward reaction rate'))
+        self._write('amrex::Real k_r;                     ' + self.line('reverse reaction rate'))
+        self._write('amrex::Real q_f;                     ' + self.line('forward progress rate'))
+        self._write('amrex::Real q_r;                     ' + self.line('reverse progress rate'))
+        self._write('amrex::Real phi_f;                   '
                     + self.line('forward phase space factor'))
-        self._write('double phi_r;                   '
+        self._write('amrex::Real phi_r;                   '
                     + self.line('reverse phase space factor'))
-        self._write('double alpha;                   ' + self.line('enhancement'))
+        self._write('amrex::Real alpha;                   ' + self.line('enhancement'))
 
 
-        self._write('double redP;                    ' + self.line('reduced pressure'))
-        self._write('double logPred;                 ' + self.line('log of above'))
-        self._write('double F;                       '
+        self._write('amrex::Real redP;                    ' + self.line('reduced pressure'))
+        self._write('amrex::Real logPred;                 ' + self.line('log of above'))
+        self._write('amrex::Real F;                       '
                     + self.line('fallof rate enhancement'))
         self._write()
-        self._write('double F_troe;                  ' + self.line('TROE intermediate'))
-        self._write('double logFcent;                ' + self.line('TROE intermediate'))
-        self._write('double troe;                    ' + self.line('TROE intermediate'))
-        self._write('double troe_c;                  ' + self.line('TROE intermediate'))
-        self._write('double troe_n;                  ' + self.line('TROE intermediate'))
+        self._write('amrex::Real F_troe;                  ' + self.line('TROE intermediate'))
+        self._write('amrex::Real logFcent;                ' + self.line('TROE intermediate'))
+        self._write('amrex::Real troe;                    ' + self.line('TROE intermediate'))
+        self._write('amrex::Real troe_c;                  ' + self.line('TROE intermediate'))
+        self._write('amrex::Real troe_n;                  ' + self.line('TROE intermediate'))
         self._write()
 
         self._write(
-            'double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; '
+            'amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; '
             + self.line('temperature cache'))
 
         self._write()
-        self._write('double invT = 1.0 / tc[1];')
+        self._write('amrex::Real invT = 1.0 / tc[1];')
 
         # compute the reference concentration
         self._write()
         self._write(self.line('reference concentration: P_atm / (RT) in inverse mol/m^3'))
-        self._write('double refC = %g / %g / T;' % (atm.value, R.value))
-        self._write('double refCinv = 1 / refC;')
+        self._write('amrex::Real refC = %g / %g / T;' % (atm.value, R.value))
+        self._write('amrex::Real refCinv = 1 / refC;')
 
         # compute the mixture concentration
         self._write()
@@ -8698,14 +8698,14 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('compute the progress rate for each reaction'))
-        self._write('AMREX_GPU_HOST_DEVICE void progressRateFR(double *  q_f, double *  q_r, double *  sc, double T)')
+        self._write('AMREX_GPU_HOST_DEVICE void progressRateFR(amrex::Real *  q_f, amrex::Real *  q_r, amrex::Real *  sc, amrex::Real T)')
         self._write('{')
         self._indent()
 
         if (nReactions > 0):
 
-            self._write('double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
-            self._write('double invT = 1.0 / tc[1];')
+            self._write('amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; /*temperature cache */')
+            self._write('amrex::Real invT = 1.0 / tc[1];')
             
             self._outdent()
             self._write('#ifndef AMREX_USE_CUDA')
@@ -8761,18 +8761,18 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('compute the critical parameters for each species'))
-        self._write('void GET_CRITPARAMS(double *  Tci, double *  ai, double *  bi, double *  acentric_i)')
+        self._write('void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i)')
         self._write('{')
         self._write()
         self._indent()
         
         
-        self._write('double   EPS[%d];'%nSpecies)
-        self._write('double   SIG[%d];' %nSpecies)
-        self._write('double    wt[%d];' %nSpecies)
-        self._write('double avogadro = 6.02214199e23;')
-        self._write('double boltzmann = 1.3806503e-16; //we work in CGS')
-        self._write('double Rcst = 83.144598; //in bar [CGS] !')
+        self._write('amrex::Real   EPS[%d];'%nSpecies)
+        self._write('amrex::Real   SIG[%d];' %nSpecies)
+        self._write('amrex::Real    wt[%d];' %nSpecies)
+        self._write('amrex::Real avogadro = 6.02214199e23;')
+        self._write('amrex::Real boltzmann = 1.3806503e-16; //we work in CGS')
+        self._write('amrex::Real Rcst = 83.144598; //in bar [CGS] !')
         
         self._write()
 
@@ -8825,44 +8825,44 @@ class CPickler(CMill):
         self._write()
         self._write('int id; ' + self.line('loop counter'))
 
-        self._write('double mixture;                 '
+        self._write('amrex::Real mixture;                 '
                     + self.line('mixture concentration'))
-        self._write('double g_RT[%d];                ' % nSpecies
+        self._write('amrex::Real g_RT[%d];                ' % nSpecies
                     + self.line('Gibbs free energy'))
 
-        self._write('double Kc;                      ' + self.line('equilibrium constant'))
-        self._write('double k_f;                     ' + self.line('forward reaction rate'))
-        self._write('double k_r;                     ' + self.line('reverse reaction rate'))
-        self._write('double phi_f;                   '
+        self._write('amrex::Real Kc;                      ' + self.line('equilibrium constant'))
+        self._write('amrex::Real k_f;                     ' + self.line('forward reaction rate'))
+        self._write('amrex::Real k_r;                     ' + self.line('reverse reaction rate'))
+        self._write('amrex::Real phi_f;                   '
                     + self.line('forward phase space factor'))
-        self._write('double phi_r;                   '
+        self._write('amrex::Real phi_r;                   '
                     + self.line('reverse phase space factor'))
-        self._write('double alpha;                   ' + self.line('enhancement'))
+        self._write('amrex::Real alpha;                   ' + self.line('enhancement'))
 
 
-        self._write('double redP;                    ' + self.line('reduced pressure'))
-        self._write('double logPred;                 ' + self.line('log of above'))
-        self._write('double F;                       '
+        self._write('amrex::Real redP;                    ' + self.line('reduced pressure'))
+        self._write('amrex::Real logPred;                 ' + self.line('log of above'))
+        self._write('amrex::Real F;                       '
                     + self.line('fallof rate enhancement'))
         self._write()
-        self._write('double F_troe;                  ' + self.line('TROE intermediate'))
-        self._write('double logFcent;                ' + self.line('TROE intermediate'))
-        self._write('double troe;                    ' + self.line('TROE intermediate'))
-        self._write('double troe_c;                  ' + self.line('TROE intermediate'))
-        self._write('double troe_n;                  ' + self.line('TROE intermediate'))
+        self._write('amrex::Real F_troe;                  ' + self.line('TROE intermediate'))
+        self._write('amrex::Real logFcent;                ' + self.line('TROE intermediate'))
+        self._write('amrex::Real troe;                    ' + self.line('TROE intermediate'))
+        self._write('amrex::Real troe_c;                  ' + self.line('TROE intermediate'))
+        self._write('amrex::Real troe_n;                  ' + self.line('TROE intermediate'))
         self._write()
 
         self._write(
-            'double tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; '
+            'amrex::Real tc[] = { log(T), T, T*T, T*T*T, T*T*T*T }; '
             + self.line('temperature cache'))
 
         self._write()
-        self._write('double invT = 1.0 / tc[1];')
+        self._write('amrex::Real invT = 1.0 / tc[1];')
 
         # compute the reference concentration
         self._write()
         self._write(self.line('reference concentration: P_atm / (RT) in inverse mol/m^3'))
-        self._write('double refC = %g / %g / T;' % (atm.value, R.value))
+        self._write('amrex::Real refC = %g / %g / T;' % (atm.value, R.value))
 
         # compute the mixture concentration
         self._write()
@@ -9027,13 +9027,13 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('compute the equilibrium constants for each reaction'))
-        self._write('void equilibriumConstants(double *  kc, double *  g_RT, double T)')
+        self._write('void equilibriumConstants(amrex::Real *  kc, amrex::Real *  g_RT, amrex::Real T)')
         self._write('{')
         self._indent()
 
         # compute the reference concentration
         self._write(self.line('reference concentration: P_atm / (RT) in inverse mol/m^3'))
-        self._write('double refC = %g / %g / T;' % (atm.value, R.value))
+        self._write('amrex::Real refC = %g / %g / T;' % (atm.value, R.value))
 
         # compute the equilibrium constants
         for reaction in mechanism.reaction():
@@ -9481,7 +9481,7 @@ class CPickler(CMill):
 
     def _generateThermoRoutine_GPU_H(self, name):
 
-        self._write('AMREX_GPU_HOST_DEVICE void %s(double * species, double *  tc);' % name)
+        self._write('AMREX_GPU_HOST_DEVICE void %s(amrex::Real * species, amrex::Real *  tc);' % name)
 
         return
 
@@ -9489,7 +9489,7 @@ class CPickler(CMill):
 
         lowT, highT, midpoints = speciesInfo
         
-        self._write('AMREX_GPU_HOST_DEVICE void %s(double * species, double *  tc)' % name)
+        self._write('AMREX_GPU_HOST_DEVICE void %s(amrex::Real * species, amrex::Real *  tc)' % name)
         self._write('{')
 
         self._indent()
@@ -9497,11 +9497,11 @@ class CPickler(CMill):
         # declarations
         self._write()
         self._write(self.line('temperature'))
-        self._write('double T = tc[1];')
+        self._write('amrex::Real T = tc[1];')
         if needsInvT != 0:
-           self._write('double invT = 1 / T;')
+           self._write('amrex::Real invT = 1 / T;')
         if needsInvT == 2:
-           self._write('double invT2 = invT*invT;')
+           self._write('amrex::Real invT2 = invT*invT;')
 
         # temperature check
         # self._write()
@@ -9554,7 +9554,7 @@ class CPickler(CMill):
 
         lowT, highT, midpoints = speciesInfo
         
-        self._write('void %s(double *  species, double *  tc)' % name)
+        self._write('void %s(amrex::Real *  species, amrex::Real *  tc)' % name)
         self._write('{')
 
         self._indent()
@@ -9562,11 +9562,11 @@ class CPickler(CMill):
         # declarations
         self._write()
         self._write(self.line('temperature'))
-        self._write('double T = tc[1];')
+        self._write('amrex::Real T = tc[1];')
         if needsInvT != 0:
-           self._write('double invT = 1 / T;')
+           self._write('amrex::Real invT = 1 / T;')
         if needsInvT == 2:
-           self._write('double invT2 = invT*invT;')
+           self._write('amrex::Real invT2 = invT*invT;')
 
         # temperature check
         # self._write()
@@ -9653,7 +9653,7 @@ class CPickler(CMill):
             self._write('#define egtransetPATM egtransetpatm_')
             self._write('#endif')
 
-        self._write('void egtransetPATM(double* PATM) {')
+        self._write('void egtransetPATM(amrex::Real* PATM) {')
         self._indent()
         self._write('*PATM =   0.1013250000000000E+07;}')
         self._outdent()
@@ -9676,7 +9676,7 @@ class CPickler(CMill):
             self._write('#define egtransetWT egtransetwt_')
             self._write('#endif')
 
-        self._write('void %s(double* %s ) {' % ("egtransetWT", "WT"))
+        self._write('void %s(amrex::Real* %s ) {' % ("egtransetWT", "WT"))
         self._indent()
 
         for species in self.species:
@@ -9875,7 +9875,7 @@ class CPickler(CMill):
             self._write('#endif')
 
         #visco coefs
-        self._write('void egtransetCOFETA(double* COFETA) {')
+        self._write('void egtransetCOFETA(amrex::Real* COFETA) {')
         self._indent()
 
         for spec in self.species:
@@ -9899,7 +9899,7 @@ class CPickler(CMill):
             self._write('#endif')
 
         #visco coefs
-        self._write('void egtransetCOFLAM(double* COFLAM) {')
+        self._write('void egtransetCOFLAM(amrex::Real* COFLAM) {')
 
         self._indent()
 
@@ -9995,7 +9995,7 @@ class CPickler(CMill):
             self._write('#endif')
 
         #visco coefs
-        self._write('void egtransetCOFTD(double* COFTD) {')
+        self._write('void egtransetCOFTD(amrex::Real* COFTD) {')
         self._indent()
 
         for i in range(len(coftd)):
@@ -10099,7 +10099,7 @@ class CPickler(CMill):
             self._write('#endif')
 
         #coefs
-        self._write('void egtransetCOFD(double* COFD) {')
+        self._write('void egtransetCOFD(amrex::Real* COFD) {')
 
         self._indent()
 
@@ -10670,7 +10670,7 @@ class CPickler(CMill):
             self._write('#define %s %s' % (nametab[0], nametab[3]))
             self._write('#endif')
 
-        self._write('void %s(double* %s ) {' % (nametab[0], nametab[4]))
+        self._write('void %s(amrex::Real* %s ) {' % (nametab[0], nametab[4]))
         self._indent()
 
         for species in mechanism.species():
@@ -11059,24 +11059,24 @@ class CPickler(CMill):
     def _T_given_ey(self, mechanism):
         self._write()
         self._write(self.line(' get temperature given internal energy in mass units and mass fracs'))
-        self._write('AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(double *  e, double *  y, double *  t, int * ierr)')
+        self._write('AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_EY(amrex::Real *  e, amrex::Real *  y, amrex::Real *  t, int * ierr)')
         self._write('{')
         self._write('#ifdef CONVERGENCE')
         self._indent()
         self._write('const int maxiter = 5000;')
-        self._write('const double tol  = 1.e-12;')
+        self._write('const amrex::Real tol  = 1.e-12;')
         self._outdent()
         self._write('#else')
         self._indent()
         self._write('const int maxiter = 200;')
-        self._write('const double tol  = 1.e-6;')
+        self._write('const amrex::Real tol  = 1.e-6;')
         self._outdent()
         self._write('#endif')
         self._indent()
-        self._write('double ein  = *e;')
-        self._write('double tmin = 90;'+self.line('max lower bound for thermo def'))
-        self._write('double tmax = 4000;'+self.line('min upper bound for thermo def'))
-        self._write('double e1,emin,emax,cv,t1,dt;')
+        self._write('amrex::Real ein  = *e;')
+        self._write('amrex::Real tmin = 90;'+self.line('max lower bound for thermo def'))
+        self._write('amrex::Real tmax = 4000;'+self.line('min upper bound for thermo def'))
+        self._write('amrex::Real e1,emin,emax,cv,t1,dt;')
         self._write('int i;'+self.line(' loop counter'))
         self._write('CKUBMS(&tmin, y, &emin);')
         self._write('CKUBMS(&tmax, y, &emax);')
@@ -11125,24 +11125,24 @@ class CPickler(CMill):
 
     def _T_given_hy(self, mechanism):
         self._write(self.line(' get temperature given enthalpy in mass units and mass fracs'))
-        self._write('AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(double *  h, double *  y, double *  t, int * ierr)')
+        self._write('AMREX_GPU_HOST_DEVICE void GET_T_GIVEN_HY(amrex::Real *  h, amrex::Real *  y, amrex::Real *  t, int * ierr)')
         self._write('{')
         self._write('#ifdef CONVERGENCE')
         self._indent()
         self._write('const int maxiter = 5000;')
-        self._write('const double tol  = 1.e-12;')
+        self._write('const amrex::Real tol  = 1.e-12;')
         self._outdent()
         self._write('#else')
         self._indent()
         self._write('const int maxiter = 200;')
-        self._write('const double tol  = 1.e-6;')
+        self._write('const amrex::Real tol  = 1.e-6;')
         self._outdent()
         self._write('#endif')
         self._indent()
-        self._write('double hin  = *h;')
-        self._write('double tmin = 90;'+self.line('max lower bound for thermo def'))
-        self._write('double tmax = 4000;'+self.line('min upper bound for thermo def'))
-        self._write('double h1,hmin,hmax,cp,t1,dt;')
+        self._write('amrex::Real hin  = *h;')
+        self._write('amrex::Real tmin = 90;'+self.line('max lower bound for thermo def'))
+        self._write('amrex::Real tmax = 4000;'+self.line('min upper bound for thermo def'))
+        self._write('amrex::Real h1,hmin,hmax,cp,t1,dt;')
         self._write('int i;'+self.line(' loop counter'))
         self._write('CKHBMS(&tmin, y, &hmin);')
         self._write('CKHBMS(&tmax, y, &hmax);')
@@ -11191,7 +11191,7 @@ class CPickler(CMill):
     def _emptygjs(self, mechanism):
         self._write()
         self._write(self.line(' Replace this routine with the one generated by the Gauss Jordan solver of DW'))
-        self._write('AMREX_GPU_HOST_DEVICE void sgjsolve(double* A, double* x, double* b) {')
+        self._write('AMREX_GPU_HOST_DEVICE void sgjsolve(amrex::Real* A, amrex::Real* x, amrex::Real* b) {')
         self._indent()
         self._write('amrex::Abort("sgjsolve not implemented, choose a different solver ");')
         self._outdent()
@@ -11199,7 +11199,7 @@ class CPickler(CMill):
 
         self._write()
         self._write(self.line(' Replace this routine with the one generated by the Gauss Jordan solver of DW'))
-        self._write('AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(double* A, double* x, double* b) {')
+        self._write('AMREX_GPU_HOST_DEVICE void sgjsolve_simplified(amrex::Real* A, amrex::Real* x, amrex::Real* b) {')
         self._indent()
         self._write('amrex::Abort("sgjsolve_simplified not implemented, choose a different solver ");')
         self._outdent()


### PR DESCRIPTION
I'm not sure if there was a specific reason to use `double`. However, these changes allow me to build PeleC in single precision and may allow for some interesting things in the future.