### PR TITLE
Fix memory leak in transport

### DIFF
--- a/Transport/Simple/Transport.cpp
+++ b/Transport/Simple/Transport.cpp
@@ -1,11 +1,10 @@
 #include <Transport.H>
 
 TransParm *trans_parm_g;
+TransParm trans_parm;
 
 void transport_init() 
 {
-    TransParm trans_parm;
-
     /* CPU */
     trans_parm.trans_wt   = (amrex::Real*) amrex::The_Arena()->alloc(sizeof(amrex::Real) * trans_parm.array_size);
     trans_parm.trans_iwt  = (amrex::Real*) amrex::The_Arena()->alloc(sizeof(amrex::Real) * trans_parm.array_size);
@@ -40,7 +39,7 @@ void transport_init()
 
     /* GPU */
     trans_parm_g = (TransParm *) amrex::The_Device_Arena()->alloc(sizeof(trans_parm));
-#ifdef AMREX_USE_CUDA
+#ifdef AMREX_USE_GPU
     amrex::Gpu::htod_memcpy(trans_parm_g, &trans_parm, sizeof(trans_parm));
 #else
     std::memcpy(trans_parm_g, &trans_parm, sizeof(trans_parm));
@@ -49,5 +48,17 @@ void transport_init()
 
 void transport_close()
 {
-  amrex::The_Device_Arena()->free(trans_parm_g);
+    amrex::The_Device_Arena()->free(trans_parm_g);
+
+    amrex::The_Arena()->free(trans_parm.trans_wt);
+    amrex::The_Arena()->free(trans_parm.trans_iwt);
+    amrex::The_Arena()->free(trans_parm.trans_eps);
+    amrex::The_Arena()->free(trans_parm.trans_sig);
+    amrex::The_Arena()->free(trans_parm.trans_dip);
+    amrex::The_Arena()->free(trans_parm.trans_pol);
+    amrex::The_Arena()->free(trans_parm.trans_zrot);
+    amrex::The_Arena()->free(trans_parm.trans_fitmu);
+    amrex::The_Arena()->free(trans_parm.trans_fitlam);
+    amrex::The_Arena()->free(trans_parm.trans_fitdbin);
+    amrex::The_Arena()->free(trans_parm.trans_nlin);
 }


### PR DESCRIPTION
I don't understand why I couldn't free the host allocations for `trans_parm` within `transport_init` after they have gone through `memcpy` to `trans_parm_g`. I would always get a reference after freed, even though `trans_parm_g` is the only thing referenced after `transport_init`. It seems like it must stay allocated on the host through the duration of the execution. So I chose to make `trans_parm` global. I'm not convinced it's the best solution, but it runs clean like that.