### PR TITLE
Hardcode gamma in GammaLaw EOS, at least for now

### DIFF
--- a/Eos/GammaLaw/EOS.H
+++ b/Eos/GammaLaw/EOS.H
@@ -12,7 +12,7 @@
 
 namespace EOS {
 
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real gamma;
+constexpr amrex::Real gamma = 1.4;
 constexpr amrex::Real RU = 8.31446261815324e7;
 constexpr amrex::Real RUC  = 1.98721558317399615845;
 constexpr amrex::Real PATM = 1.01325e+06;

--- a/Eos/GammaLaw/EOS.cpp
+++ b/Eos/GammaLaw/EOS.cpp
@@ -2,14 +2,9 @@
 
 namespace EOS {
 
-AMREX_GPU_DEVICE_MANAGED amrex::Real gamma = 1.4;
-
 void
 init()
 {
-  amrex::ParmParse pp("eos");
-  pp.query("gamma", gamma);
-
   CKINIT();
 }
 


### PR DESCRIPTION
I say we make this a runtime parameter later, whenever we want to pass `gamma` into all 17 EOS functions that use it. In the meantime, I think it's best to have this stuff working on HIP and DPC++, and this one isn't fun.