### PR TITLE
Nonideal Transport

### DIFF
--- a/Eos/Soave-Redlich-Kwong/EOS.H
+++ b/Eos/Soave-Redlich-Kwong/EOS.H
@@ -962,7 +962,7 @@ RTY2transport(amrex::Real R, amrex::Real T, amrex::Real Y[],
     + am * (2.0*tau + bm) * InvEosT2Denom*InvEosT2Denom;
   
   for (int ii = 0; ii < NUM_SPECIES; ii++) {
-    Rmk = Rm * inv_mwt[ii];
+    Rmk = EOS::RU * inv_mwt[ii];
     dpdYk[ii] = Rmk * T * InvEosT1Denom - dAmdY[ii] * InvEosT2Denom
       + EOS::Bi[ii] * (Rm * T * InvEosT1Denom * InvEosT1Denom
 		       + am * InvEosT2Denom * InvEosT3Denom);
@@ -982,7 +982,7 @@ RTY2transport(amrex::Real R, amrex::Real T, amrex::Real Y[],
     }
     dijY[ii][ii] = wbar * inv_mwt[ii];   
     for (int jj = 0; jj < NUM_SPECIES; jj++) {
-      dijY[ii][jj] -= diP[ii] * dpdYk[jj]
+      dijY[ii][jj] += - diP[ii] * dpdYk[jj]
 	+ wbar * Y[ii] *InvEosT1Denom * (EOS::Bi[ii] * inv_mwt[jj]
 					 + EOS::Bi[jj] * inv_mwt[ii])
 	+ Y[ii] * InvEosT1Denom * InvEosT1Denom * EOS::Bi[ii] * EOS::Bi[jj]

--- a/Eos/Soave-Redlich-Kwong/EOS.cpp
+++ b/Eos/Soave-Redlich-Kwong/EOS.cpp
@@ -2,14 +2,14 @@
 
 namespace EOS {
 
-  bool initialized=false;
+  AMREX_GPU_DEVICE_MANAGED bool initialized=false;
   
-  amrex::Real Tc[NUM_SPECIES];
-  amrex::Real Bi[NUM_SPECIES];
-  amrex::Real oneOverTc[NUM_SPECIES];
-  amrex::Real sqrtOneOverTc[NUM_SPECIES];
-  amrex::Real sqrtAsti[NUM_SPECIES];
-  amrex::Real Fomega[NUM_SPECIES];
+  AMREX_GPU_DEVICE_MANAGED amrex::Real Tc[NUM_SPECIES];
+  AMREX_GPU_DEVICE_MANAGED amrex::Real Bi[NUM_SPECIES];
+  AMREX_GPU_DEVICE_MANAGED amrex::Real oneOverTc[NUM_SPECIES];
+  AMREX_GPU_DEVICE_MANAGED amrex::Real sqrtOneOverTc[NUM_SPECIES];
+  AMREX_GPU_DEVICE_MANAGED amrex::Real sqrtAsti[NUM_SPECIES];
+  AMREX_GPU_DEVICE_MANAGED amrex::Real Fomega[NUM_SPECIES];
   
 void init() 
 {

--- a/Support/Fuego/Mechanism/Models/LiDryer/chemistry_file.H
+++ b/Support/Fuego/Mechanism/Models/LiDryer/chemistry_file.H
@@ -1628,6 +1628,83 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void GET_T_GIVEN_HY(amrex::Real *  h, a
 }
 
 
+/*compute the critical parameters for each species */
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i)
+{
+
+    amrex::Real   EPS[9];
+    amrex::Real   SIG[9];
+    amrex::Real    wt[9];
+    amrex::Real avogadro = 6.02214199e23;
+    amrex::Real boltzmann = 1.3806503e-16; //we work in CGS
+    amrex::Real Rcst = 83.144598; //in bar [CGS] !
+
+    egtransetEPS(EPS);
+    egtransetSIG(SIG);
+    get_mw(wt);
+
+    /*species 0: H2 */
+    /*Imported from NIST */
+    Tci[0] = 33.145000 ; 
+    ai[0] = 1e6 * 0.42748 * pow(Rcst,2.0) * pow(Tci[0],2.0) / (pow(2.015880,2.0) * 12.964000); 
+    bi[0] = 0.08664 * Rcst * Tci[0] / (2.015880 * 12.964000); 
+    acentric_i[0] = -0.219000 ;
+
+    /*species 1: O2 */
+    /*Imported from NIST */
+    Tci[1] = 154.581000 ; 
+    ai[1] = 1e6 * 0.42748 * pow(Rcst,2.0) * pow(Tci[1],2.0) / (pow(31.998800,2.0) * 50.430466); 
+    bi[1] = 0.08664 * Rcst * Tci[1] / (31.998800 * 50.430466); 
+    acentric_i[1] = 0.022200 ;
+
+    /*species 2: H2O */
+    /*Imported from NIST */
+    Tci[2] = 647.096000 ; 
+    ai[2] = 1e6 * 0.42748 * pow(Rcst,2.0) * pow(Tci[2],2.0) / (pow(18.015340,2.0) * 220.640000); 
+    bi[2] = 0.08664 * Rcst * Tci[2] / (18.015340 * 220.640000); 
+    acentric_i[2] = 0.344300 ;
+
+    /*species 3: H */
+    Tci[3] = 1.316 * EPS[3] ; 
+    ai[3] = (5.55 * pow(avogadro,2.0) * EPS[3]*boltzmann * pow(1e-8*SIG[3],3.0) ) / (pow(wt[3],2.0)); 
+    bi[3] = 0.855 * avogadro * pow(1e-8*SIG[3],3.0) / (wt[3]); 
+    acentric_i[3] = 0.0 ;
+
+    /*species 4: O */
+    Tci[4] = 1.316 * EPS[4] ; 
+    ai[4] = (5.55 * pow(avogadro,2.0) * EPS[4]*boltzmann * pow(1e-8*SIG[4],3.0) ) / (pow(wt[4],2.0)); 
+    bi[4] = 0.855 * avogadro * pow(1e-8*SIG[4],3.0) / (wt[4]); 
+    acentric_i[4] = 0.0 ;
+
+    /*species 5: OH */
+    Tci[5] = 1.316 * EPS[5] ; 
+    ai[5] = (5.55 * pow(avogadro,2.0) * EPS[5]*boltzmann * pow(1e-8*SIG[5],3.0) ) / (pow(wt[5],2.0)); 
+    bi[5] = 0.855 * avogadro * pow(1e-8*SIG[5],3.0) / (wt[5]); 
+    acentric_i[5] = 0.0 ;
+
+    /*species 6: HO2 */
+    Tci[6] = 1.316 * EPS[6] ; 
+    ai[6] = (5.55 * pow(avogadro,2.0) * EPS[6]*boltzmann * pow(1e-8*SIG[6],3.0) ) / (pow(wt[6],2.0)); 
+    bi[6] = 0.855 * avogadro * pow(1e-8*SIG[6],3.0) / (wt[6]); 
+    acentric_i[6] = 0.0 ;
+
+    /*species 7: H2O2 */
+    Tci[7] = 1.316 * EPS[7] ; 
+    ai[7] = (5.55 * pow(avogadro,2.0) * EPS[7]*boltzmann * pow(1e-8*SIG[7],3.0) ) / (pow(wt[7],2.0)); 
+    bi[7] = 0.855 * avogadro * pow(1e-8*SIG[7],3.0) / (wt[7]); 
+    acentric_i[7] = 0.0 ;
+
+    /*species 8: N2 */
+    /*Imported from NIST */
+    Tci[8] = 126.192000 ; 
+    ai[8] = 1e6 * 0.42748 * pow(Rcst,2.0) * pow(Tci[8],2.0) / (pow(28.013400,2.0) * 33.958000); 
+    bi[8] = 0.08664 * Rcst * Tci[8] / (28.013400 * 33.958000); 
+    acentric_i[8] = 0.037200 ;
+
+    return;
+}
+
+
 /*Compute P = rhoRT/W(x) */
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void CKPX(amrex::Real *  rho, amrex::Real *  T, amrex::Real *  x, amrex::Real *  P)
 {

--- a/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/c/CPickler.py
+++ b/Support/Fuego/Pythia/pythia-0.4/packages/fuego/fuego/serialization/c/CPickler.py
@@ -272,6 +272,7 @@ class CPickler(CMill):
 
         self._T_given_ey(mechanism)
         self._T_given_hy(mechanism)
+        self._getCriticalParameters(mechanism)
         #self._cksyms(mechanism)
 
         self._ckpx(mechanism)
@@ -12307,7 +12308,7 @@ class CPickler(CMill):
         self._write()
         self._write()
         self._write(self.line('compute the critical parameters for each species'))
-        self._write('void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i)')
+        self._write('AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void GET_CRITPARAMS(amrex::Real *  Tci, amrex::Real *  ai, amrex::Real *  bi, amrex::Real *  acentric_i)')
         self._write('{')
         self._write()
         self._indent()

--- a/Transport/Simple/F90/actual_transport_nonideal.f90
+++ b/Transport/Simple/F90/actual_transport_nonideal.f90
@@ -30,8 +30,8 @@ module actual_transport_module
   real(amrex_real), save, allocatable :: Afac(:,:)
   real(amrex_real), save, allocatable :: Bfac(:,:)
   real(amrex_real), save, allocatable :: Sigmaij(:,:)
-  real(amrex_real), parameter :: Avna = 6.022140857e23
-  real(amrex_real), parameter :: PI = 4 * atan (1.0)
+  real(amrex_real), parameter :: Avna = 6.022140857d23
+  real(amrex_real), parameter :: PI = 4.0d0 * atan (1.0d0)
   real(amrex_real), save, allocatable :: Kappai(:)
 
 contains
@@ -104,7 +104,7 @@ contains
 
     Afac(1,1) = 6.32402d0;     Afac(1,2) = 50.41190d0;  Afac(1,3) = -51.68010d0; Afac(1,4) = 1189.020d0
 
-    Afac(2,1) = 0.12102e-2;    Afac(2,2) = -0.11536e-2; Afac(2,3) = -0.62571e-2; Afac(2,4) = 0.37283d-1
+    Afac(2,1) = 0.12102d-2;    Afac(2,2) = -0.11536d-2; Afac(2,3) = -0.62571d-2; Afac(2,4) = 0.37283d-1
 
     Afac(3,1) = 5.28346d0;     Afac(3,2) = 254.209d0;   Afac(3,3) = -168.48100d0; Afac(3,4) = 3898.27000d0
 
@@ -116,16 +116,16 @@ contains
 
     Afac(7,1) = 24.27450d0;    Afac(7,2) = 3.44945d0;   Afac(7,3) = -11.29130d0; Afac(7,4) = 69.34660d0
 
-    Afac(8,1) = 0.79716d0;     Afac(8,2) = 1.11764d0;   Afac(8,3) = 0.12348e-1; Afac(8,4) = -4.11661d0 
+    Afac(8,1) = 0.79716d0;     Afac(8,2) = 1.11764d0;   Afac(8,3) = 0.12348d-1; Afac(8,4) = -4.11661d0
 
-    Afac(9,1) = -0.23816d0;    Afac(9,2) = 0.67695e-1;  Afac(9,3) = -0.81630d0; Afac(9,4) = 4.02528d0
+    Afac(9,1) = -0.23816d0;    Afac(9,2) = 0.67695d-1;  Afac(9,3) = -0.81630d0; Afac(9,4) = 4.02528d0
 
-    Afac(10,1) = 0.68629e-1;   Afac(10,2) = 0.34793d0;  Afac(10,3) = 0.59256d0; Afac(10,4) = -0.72663d0
+    Afac(10,1) = 0.68629d-1;   Afac(10,2) = 0.34793d0;  Afac(10,3) = 0.59256d0; Afac(10,4) = -0.72663d0
 
     A_cst = 1.16145d0;  B_cst = 0.14874d0
     C_cst = 0.52487d0;  D_cst = 0.77320d0
     E_cst = 2.16178d0;  F_cst = 2.43787d0
-    G_cst = -6.435e-4;  H_cst = 7.27371d0
+    G_cst = -6.435d-4;  H_cst = 7.27371d0
     S_cst = 18.0323d0;  W_cst = -0.76830d0
 
     Bfac(1,1) = 2.41657d0;   Bfac(1,2) = 0.74824d0;   Bfac(1,3) = -0.91858d0;  Bfac(1,4) = 121.721d0
@@ -141,7 +141,7 @@ contains
     do j = 1,nspecies
        do i = 1,nspecies
 !!$         Sigmaij(i,j) = sqrt(sig(i)*sig(j))*1e-8  ! converted into cm
-          Sigmaij(i,j) = 0.5d0*(sig(i)+sig(j))*1e-8  ! converted into cm
+          Sigmaij(i,j) = 0.5d0*(sig(i)+sig(j))*1d-8  ! converted into cm
        end do
     end do
 
@@ -788,7 +788,7 @@ contains
     real(amrex_real) :: sumMWij,lambda_p,beta
     real(amrex_real) :: y,G1,G2,eta_P, H2
     real(amrex_real) :: A(10), B(7)
-    real(amrex_real), parameter :: dpFactor = 297.2069113e6
+    real(amrex_real), parameter :: dpFactor = 297.2069113d+6
 
 
     real(amrex_real)  :: scr
@@ -838,7 +838,7 @@ contains
        end do
 
 
-       Mw_m = MW_m **2
+       Mw_m = MW_m * MW_m
 
        sigma_M = sigma_M_3**(1.0d0/3.0d0)
 
@@ -852,7 +852,7 @@ contains
 
        Tcm = 1.2593d0*Epsilon_M              ! K
 
-       Vcm = 1.8887*sigma_M_3                ! cm3/mol
+       Vcm = 1.8887d0*sigma_M_3                ! cm3/mol
 
        Omega_M = Omega_M*InvSigma3          
 
@@ -873,7 +873,7 @@ contains
        
        G2 = (A(1)*(1.0d0-exp(-A(4)*y))/y + A(2)*G1*exp(A(5)*y) + A(3)*G1)/(A(1)*A(4)+A(2)+A(3))
 
-       eta_P = (36.344e-6*sqrt(MW_m*Tcm)/(Vcm**(2.0d0/3.0d0)))*A(7)*y*y*G2*exp(A(8) + A(9)/Tstar + A(10)/(Tstar*Tstar))
+       eta_P = (36.344d-6*sqrt(MW_m*Tcm)/(Vcm**(2.0d0/3.0d0)))*A(7)*y*y*G2*exp(A(8) + A(9)/Tstar + A(10)/(Tstar*Tstar))
 
        ! Viscosity
 !      if (which % wtr_get_mu) then
@@ -903,9 +903,9 @@ contains
 
        H2 = (B(1)*(1.0d0-exp(-B(4)*y))/y + B(2)*G1*exp(B(5)*y) + B(3)*G1)/(B(1)*B(4)+B(2)+B(3))
 
-       lambda_p = 3.039e-4*sqrt(Tcm/MW_m)/(Vcm**(2.0d0/3.0d0))*B(7)*y*y*H2*sqrt(Tstar)  ! (cal/cm s K)
+       lambda_p = 3.039d-4*sqrt(Tcm/MW_m)/(Vcm**(2.0d0/3.0d0))*B(7)*y*y*H2*sqrt(Tstar)  ! (cal/cm s K)
 
-       lambda_p = lambda_p* 4.184e+7   ! erg/(cm s K)
+       lambda_p = lambda_p* 4.184d+7   ! erg/(cm s K)
 
        beta = (1.0d0/H2)+B(6)*y  ! Non-dimensional 
 

--- a/Transport/Simple/Transport.H
+++ b/Transport/Simple/Transport.H
@@ -76,6 +76,156 @@ void comp_pure_bulk(
       }
 }
 
+#ifdef PELEPHYSICS_NONIDEAL_EOS
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+void
+nonIdeal_Chung(
+  bool wtr_get_mu,
+  bool wtr_get_lam,
+  amrex::Real& Temp,
+  amrex::Real* Xloc,
+  amrex::Real& rholoc,
+  amrex::Real& wbar,
+  amrex::Real& mu,
+  amrex::Real& xi,
+  amrex::Real& lam,
+  TransParm const* trans_parm)
+{
+  amrex::Real sigma_M_3 = 0.0;
+  amrex::Real Epsilon_M = 0.0;
+  amrex::Real Omega_M = 0.0;
+  amrex::Real MW_m = 0.0;
+  amrex::Real DP_m_4 = 0.0;
+  amrex::Real KappaM = 0.0;
+
+  // Note: all the square roots could be precalculated
+
+  for (int i = 0; i < NUM_SPECIES; ++i) {
+    for (int j = 0; j < NUM_SPECIES; ++j) {
+      amrex::Real T2 = trans_parm->trans_sig[i] * trans_parm->trans_sig[j];
+      amrex::Real T3 = T2 * std::sqrt(T2);
+      sigma_M_3 += Xloc[i] * Xloc[j] * T3;
+
+      amrex::Real Epsilon_ij = std::sqrt(trans_parm->trans_eps[i] * trans_parm->trans_eps[j]);
+      Epsilon_M += Xloc[i] * Xloc[j] * Epsilon_ij * T3;
+
+      amrex::Real Omega_ij = 0.5*(trans_parm->omega[i] + trans_parm->omega[j]);
+      Omega_M += Xloc[i] * Xloc[j] * Omega_ij * T3;
+
+      amrex::Real MW_ij = 2.0/(trans_parm->trans_iwt[i] + trans_parm->trans_iwt[j]);
+      MW_m += Xloc[i] * Xloc[j] * Epsilon_ij * T2 * std::sqrt(MW_ij);
+
+      DP_m_4 += Xloc[i] * Xloc[j] * trans_parm->trans_dip[i] * trans_parm->trans_dip[i]
+	* trans_parm->trans_dip[j] * trans_parm->trans_dip[j] / (T3*Epsilon_ij);
+
+      KappaM += Xloc[i] * Xloc[j] * std::sqrt(trans_parm->Kappai[i] * trans_parm->Kappai[j]);
+    }
+  }
+
+  MW_m *= MW_m;
+  amrex::Real sigma_M = std::cbrt(sigma_M_3);
+  amrex::Real InvSigma1 = 1.0 / sigma_M;
+  amrex::Real InvSigma3 = 1.0 / sigma_M_3;
+  Epsilon_M *= InvSigma3;
+  amrex::Real Tstar = Temp / Epsilon_M;
+  amrex::Real Tcm = 1.2593* Epsilon_M;
+  amrex::Real Vcm = 1.8887 * sigma_M_3;
+  Omega_M *= InvSigma3;
+  MW_m = MW_m * InvSigma3 * InvSigma1 / (Epsilon_M * Epsilon_M);
+  DP_m_4 = DP_m_4 * sigma_M_3 * Epsilon_M;
+  amrex::Real DP_red_4 =  297.2069113e6 * DP_m_4 / (Vcm * Vcm * Tcm * Tcm);
+  amrex::Real y = Vcm * rholoc / (6.0 * wbar);
+  amrex::Real A[10];
+  for (int i = 0; i<10; ++i) {
+    A[i] = trans_parm->Afac[4*i] + trans_parm->Afac[4*i+1] * Omega_M + trans_parm->Afac[4*i+2] * DP_red_4 + trans_parm->Afac[4*i+3]*KappaM;
+  }
+  amrex::Real G1 = (1.0 - 0.5*y)/((1.0-y)*(1.0-y)*(1.0-y));
+  amrex::Real G2 = ( A[0]*(1.0 - std::exp(-A[3]*y))/y + A[1] * G1 * std::exp(A[4] * y)
+	+ A[2]*G1 ) / (A[0]*A[3] + A[1] + A[2]);
+  amrex::Real eta_P = (36.344e-6*std::sqrt(MW_m*Tcm)/std::pow(Vcm, 2.0/3.0) )
+    *A[6]*y*y*G2*exp(A[7] + A[8]/Tstar + A[9]/(Tstar*Tstar));
+
+  // Set nonideal viscosity
+  if (wtr_get_mu) {
+    mu = mu * (1.0/G2 + A[5] * y ) + eta_P;
+  }
+
+  amrex::Real B[7];
+  for (int i = 0; i<7; ++i) {
+    B[i] = trans_parm->Bfac[i*4] + trans_parm->Bfac[i*4+1]*Omega_M + trans_parm->Bfac[i*4+2]*DP_red_4 + trans_parm->Bfac[i*4+3] * KappaM;
+  }
+  amrex::Real H2 = ( B[0]*(1.0-std::exp(-B[3]*y))/y + B[1]*G1*std::exp(B[4]*y) + B[2]*G1 )
+    / (B[0]*B[3] + B[1] + B[2]);
+
+  amrex::Real lambda_p = 3.039e-4 * std::sqrt(Tcm/MW_m)/std::pow(Vcm, 2.0/3.0)
+    * B[6] * y * y * H2 * std::sqrt(Tstar);
+
+  lambda_p *= 4.184e+7; // erg/(cm s K)
+  amrex::Real beta = 1.0/H2 + B[5]*y;
+
+  // Set nonideal conductivity
+  if (wtr_get_lam) {
+    lam = lam*beta + lambda_p;
+    //lam = H2;
+    //mu = H2;
+    //xi = beta;
+  }
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+void
+nonIdeal_Binary_Diff(
+  amrex::Real* Xloc,
+  amrex::Real* Yloc,
+  amrex::Real* logT,
+  amrex::Real& rholoc,
+  amrex::Real& Tloc,
+  amrex::Real* Ddiag,
+  TransParm const* trans_parm)
+{
+  amrex::Real term1, term2, Upsilonij;
+  amrex::Real dbintemp;
+  const amrex::Real Pst = 1013250.00;
+  const amrex::Real Ru = 8.31446261815324e7;
+  int idx_ij, idx_ik, idx_jk;
+  for (int i = 0; i < NUM_SPECIES; ++i) {
+    term1 = 0.0;
+    term2 = 0.0;
+    for (int j = 0; j < NUM_SPECIES; ++j) {
+      idx_ij = i + NUM_SPECIES * j;
+      if (i != j) {
+	dbintemp = trans_parm->trans_fitdbin[4 * (idx_ij)] +
+	  trans_parm->trans_fitdbin[1 + 4 * (idx_ij)] * logT[0] +
+	  trans_parm->trans_fitdbin[2 + 4 * (idx_ij)] * logT[1] +
+	  trans_parm->trans_fitdbin[3 + 4 * (idx_ij)] * logT[2];
+	dbintemp = std::exp(dbintemp);
+
+	Upsilonij = 0.0;
+	for (int k = 0; k < NUM_SPECIES; ++k) {
+	  idx_ik = i + NUM_SPECIES * k;
+	  idx_jk = j + NUM_SPECIES * k;
+	  Upsilonij += trans_parm->trans_iwt[k] * Yloc[k] * (
+						 8.0 * (trans_parm->Sigmaij[idx_ik]*trans_parm->Sigmaij[idx_ik]*trans_parm->Sigmaij[idx_ik] +
+							trans_parm->Sigmaij[idx_jk]*trans_parm->Sigmaij[idx_jk]*trans_parm->Sigmaij[idx_jk])
+						 - 6.0 * (trans_parm->Sigmaij[idx_ik]*trans_parm->Sigmaij[idx_ik] +
+							  trans_parm->Sigmaij[idx_jk]*trans_parm->Sigmaij[idx_jk] ) * trans_parm->Sigmaij[idx_ij]
+						 - 3.0 * std::pow((trans_parm->Sigmaij[idx_ik]*trans_parm->Sigmaij[idx_ik] -
+								   trans_parm->Sigmaij[idx_jk]*trans_parm->Sigmaij[idx_jk] ),2.0) / trans_parm->Sigmaij[idx_ij]
+						 + trans_parm->Sigmaij[idx_ij]*trans_parm->Sigmaij[idx_ij]*trans_parm->Sigmaij[idx_ij] );
+	}
+	Upsilonij = Upsilonij * rholoc * trans_parm->Avna * 3.141592653589793 / 12.0 + 1.0;
+	dbintemp = dbintemp * Pst / (Ru * Tloc * Upsilonij); // * wbar/rholoc
+	term1 += Yloc[j];
+	term2 += Xloc[j] / dbintemp;
+      }
+    }
+    Ddiag[i] = trans_parm->trans_wt[i] * term1 / term2; // * rholoc / wbar
+  }
+}
+#endif // nonideal
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
@@ -178,6 +328,10 @@ void transport(
         }
         lam = lam * lam * lam * lam; // lam = lam^4
       }
+      // Add nonideal corrections if necessary
+#ifdef PELEPHYSICS_NONIDEAL_EOS
+      nonIdeal_Chung(wtr_get_mu, wtr_get_lam, Tloc, Xloc, rholoc, wbar, mu, xi, lam, trans_parm);
+#endif
 
       if (wtr_get_Ddiag) {
         //       for (int i = 0; i < NUM_SPECIES ; ++i){
@@ -192,8 +346,10 @@ void transport(
         //          dbinloc(i+NUM_SPECIES*i) = 0.0;
         //       }
 
+#ifdef PELEPHYSICS_NONIDEAL_EOS
+	nonIdeal_Binary_Diff(Xloc, Yloc, logT, rholoc, Tloc, Ddiag, trans_parm);
+#else
         amrex::Real term1, term2, dbintemp;
-
         for (int i = 0; i < NUM_SPECIES; ++i) {
           term1 = 0.0;
           term2 = 0.0;
@@ -211,12 +367,13 @@ void transport(
         }
 
         // Call CKRP ?
-        amrex::Real Ru = 8.31446261815324e7;;
+        amrex::Real Ru = 8.31446261815324e7;
         pscale = Patm * wbar / (Ru * Tloc * rholoc);
 
         for (int i = 0; i < NUM_SPECIES; ++i) {
           Ddiag[i] = rholoc * pscale * Ddiag[i];
         }
+#endif
       }
 }
 

--- a/Transport/Simple/Transport.cpp
+++ b/Transport/Simple/Transport.cpp
@@ -94,8 +94,8 @@ void transport_init()
       CKSYMS_STR(spec_names_kappa);
       for (int i = 0; i < trans_parm.array_size; i++) {
 	if (spec_names_kappa[i] == "H2O") {
-	  //trans_parm.Kappai[i] = 0.075908;
-	  trans_parm.Kappai[i] = 0.076;
+	  trans_parm.Kappai[i] = 0.075908;
+	  //trans_parm.Kappai[i] = 0.076;
 	} else if (spec_names_kappa[i] == "CH3OH") {
 	  trans_parm.Kappai[i] = 0.215175;
 	} else if (spec_names_kappa[i] == "CH3CH2OH") {

--- a/Transport/Simple/Transport.cpp
+++ b/Transport/Simple/Transport.cpp
@@ -37,6 +37,74 @@ void transport_init()
         trans_parm.trans_iwt[i] = 1. / trans_parm.trans_wt[i];
     }
 
+#ifdef PELEPHYSICS_NONIDEAL_EOS
+    // Nonideal transport coefficients computed using Chung's method:
+    // Chung, T.H., Ajlan, M., Lee, L.L. and Starling, K.E., 1988.
+    // Generalized multiparameter correlation for nonpolar and polar
+    // fluid transport properties. Industrial & engineering chemistry
+    // research, 27(4), pp.671-679.
+
+    trans_parm.Afac    = (amrex::Real*) amrex::The_Arena()->alloc(sizeof(amrex::Real) * 10 * 4);
+    trans_parm.Bfac    = (amrex::Real*) amrex::The_Arena()->alloc(sizeof(amrex::Real) * 7 * 4);
+    trans_parm.omega   = (amrex::Real*) amrex::The_Arena()->alloc(sizeof(amrex::Real) * trans_parm.array_size);
+    trans_parm.Kappai  = (amrex::Real*) amrex::The_Arena()->alloc(sizeof(amrex::Real) * trans_parm.array_size);
+    trans_parm.Sigmaij = (amrex::Real*) amrex::The_Arena()->alloc(sizeof(amrex::Real) * trans_parm.array_size
+								  * trans_parm.array_size);
+
+    // Initialize coefficients of model
+    {
+      amrex::Real tmp1[trans_parm.array_size], tmp2[trans_parm.array_size], tmp3[trans_parm.array_size];
+      GET_CRITPARAMS(tmp1, tmp2, tmp3, trans_parm.omega);
+    }
+    
+    trans_parm.Afac[0]  = 6.32402;    trans_parm.Afac[1]  = 50.41190;    trans_parm.Afac[2]  = -51.68010;   trans_parm.Afac[3]  = 1189.020;
+    trans_parm.Afac[4]  = 0.12102e-2; trans_parm.Afac[5]  = -0.11536e-2; trans_parm.Afac[6]  = -0.62571e-2; trans_parm.Afac[7]  = 0.37283e-1;
+    trans_parm.Afac[8]  = 5.28346;    trans_parm.Afac[9]  = 254.209;     trans_parm.Afac[10] = -168.481;    trans_parm.Afac[11] = 3898.27;
+    trans_parm.Afac[12] = 6.62263;    trans_parm.Afac[13] = 38.09570;    trans_parm.Afac[14] = -8.46414;    trans_parm.Afac[15] = 31.41780;
+    trans_parm.Afac[16] = 19.74540;   trans_parm.Afac[17] = 7.63034;     trans_parm.Afac[18] = -14.35440;   trans_parm.Afac[19] = 31.52670;
+    trans_parm.Afac[20] = -1.89992;   trans_parm.Afac[21] = -12.5367;    trans_parm.Afac[22] = 4.98529;     trans_parm.Afac[23] = -18.15070;
+    trans_parm.Afac[24] = 24.27450;   trans_parm.Afac[25] = 3.44945;     trans_parm.Afac[26] = -11.29130;   trans_parm.Afac[27] = 69.34660;
+    trans_parm.Afac[28] = 0.79716;    trans_parm.Afac[29] = 1.11764;     trans_parm.Afac[30] = 0.12348e-1;  trans_parm.Afac[31] = -4.11661;
+    trans_parm.Afac[32] = -0.23816;   trans_parm.Afac[33] = 0.67695e-1;  trans_parm.Afac[34] = -0.81630;    trans_parm.Afac[35] = 4.02528;
+    trans_parm.Afac[36] = 0.68629e-1; trans_parm.Afac[37] = 0.34793;     trans_parm.Afac[38] = 0.59256;     trans_parm.Afac[39] = -0.72663;
+    
+    trans_parm.Bfac[0]  = 2.41657;   trans_parm.Bfac[1]  = 0.74824;   trans_parm.Bfac[2]  = -0.91858;  trans_parm.Bfac[3]  = 121.721;
+    trans_parm.Bfac[4]  = -0.50924;  trans_parm.Bfac[5]  = -1.50936;  trans_parm.Bfac[6]  = -49.99120; trans_parm.Bfac[7]  = 69.9834;
+    trans_parm.Bfac[8]  = 6.61069;   trans_parm.Bfac[9]  = 5.62073;   trans_parm.Bfac[10] = 64.75990;  trans_parm.Bfac[11] = 27.0389;
+    trans_parm.Bfac[12] = 14.54250;  trans_parm.Bfac[13] = -8.91387;  trans_parm.Bfac[14] = -5.63794;  trans_parm.Bfac[15] = 74.3435;
+    trans_parm.Bfac[16] = 0.79274;   trans_parm.Bfac[17] = 0.82019;   trans_parm.Bfac[18] = -0.69369;  trans_parm.Bfac[19] = 6.31734;
+    trans_parm.Bfac[20] = -5.86340;  trans_parm.Bfac[21] = 12.80050;  trans_parm.Bfac[22] = 9.58926;   trans_parm.Bfac[23] = -65.5292;
+    trans_parm.Bfac[24] = 81.17100;  trans_parm.Bfac[25] = 114.15800; trans_parm.Bfac[26] = -60.84100; trans_parm.Bfac[27] = 466.7750;
+
+    for (int i = 0; i < trans_parm.array_size; ++i) {
+      for (int j = 0; j < trans_parm.array_size; ++j) {
+	trans_parm.Sigmaij[i*trans_parm.array_size + j] = 0.5*(trans_parm.trans_sig[i]
+							       + trans_parm.trans_sig[j]) * 1e-8; // converted to cm
+      }
+    }
+    
+    // Initialize Kappa, which has nonzero values only for specific polar species
+    for (int i = 0; i < trans_parm.array_size; ++i) {
+      trans_parm.Kappai[i] = 0.0;
+    }
+    {
+      amrex::Vector<std::string> spec_names_kappa;
+      spec_names_kappa.resize(1);
+      spec_names_kappa[0] = "Null";
+      CKSYMS_STR(spec_names_kappa);
+      for (int i = 0; i < trans_parm.array_size; i++) {
+	if (spec_names_kappa[i] == "H2O") {
+	  //trans_parm.Kappai[i] = 0.075908;
+	  trans_parm.Kappai[i] = 0.076;
+	} else if (spec_names_kappa[i] == "CH3OH") {
+	  trans_parm.Kappai[i] = 0.215175;
+	} else if (spec_names_kappa[i] == "CH3CH2OH") {
+	  trans_parm.Kappai[i] = 0.174823;
+	}
+      }
+    }
+#endif
+    
     /* GPU */
     trans_parm_g = (TransParm *) amrex::The_Device_Arena()->alloc(sizeof(trans_parm));
 #ifdef AMREX_USE_GPU
@@ -61,4 +129,11 @@ void transport_close()
     amrex::The_Arena()->free(trans_parm.trans_fitlam);
     amrex::The_Arena()->free(trans_parm.trans_fitdbin);
     amrex::The_Arena()->free(trans_parm.trans_nlin);
+#ifdef PELEPHYSICS_NONIDEAL_EOS
+    amrex::The_Arena()->free(trans_parm.Afac);
+    amrex::The_Arena()->free(trans_parm.Bfac);
+    amrex::The_Arena()->free(trans_parm.Kappai);
+    amrex::The_Arena()->free(trans_parm.Sigmaij);
+    amrex::The_Arena()->free(trans_parm.omega);
+#endif
 }

--- a/Transport/Simple/TransportParams.H
+++ b/Transport/Simple/TransportParams.H
@@ -18,6 +18,14 @@ struct TransParm {
     int* trans_nlin;
     int array_size = NUM_SPECIES;
     int fit_length = NUM_FIT;
+#ifdef PELEPHYSICS_NONIDEAL_EOS
+    amrex::Real Avna = 6.022140857e23;
+    amrex::Real* Afac;
+    amrex::Real* Bfac;
+    amrex::Real* Sigmaij;
+    amrex::Real* Kappai;
+    amrex::Real* omega;
+#endif
 };
 
 extern TransParm *trans_parm_g;


### PR DESCRIPTION
This pull request contains the corrections necessary to compute transport coefficients with a nonideal EOS (e.g., Chung's model), which have been reimplemented from previous Fortran Code. Other notes about what is included:

- Bug fixes for SRK EOS
- Re-inclusion of the GET_CRITPARAMS function in CPickler.py so it gets included in the mechanism source files when they are generated
- Updating the old Fortran nonideal transport properties code so all constants are double precision (the C++ version then matches to machine precision)
- Since most of the code is the same for ideal and real gas transport properties and the EOS must be selected at compile time anyway, the additional code is turned on/off with an \#ifdef using the flag "PELEPHYSICS_NONIDEAL_EOS" 