### PR TITLE
Simplify fkernelspec

### DIFF
--- a/Reactions/arkode/reactor_arkode.cpp
+++ b/Reactions/arkode/reactor_arkode.cpp
@@ -452,3 +452,4 @@ int cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
 
   return (0);
 }
+

--- a/Reactions/reactor.H
+++ b/Reactions/reactor.H
@@ -294,49 +294,48 @@ void fKernelSpec(int icell,
   amrex::Real* rhoesrc_ext,
   amrex::Real* rYs)
 {
-  int offset = icell * (NUM_SPECIES + 1);
-
-  amrex::Real mw[NUM_SPECIES] = {0.0};
-  get_mw(mw);
+  const int offset = icell * (NUM_SPECIES + 1);
 
   amrex::Real rho_pt = 0.0;
+  amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {0.0};
   for (int n = 0; n < NUM_SPECIES; n++) {
-    rho_pt = rho_pt + yvec_d[offset + n];
+    massfrac[i] = yvec_d[offset + n];
+    rho_pt += massfrac[i];
   }
+  const amrex::Real rho_pt_inv = 1.0 / rho_pt;
 
-  amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac;
   for (int i = 0; i < NUM_SPECIES; i++) {
-    massfrac[i] = yvec_d[offset + i] / rho_pt;
+    massfrac[i] *= rho_pt_inv;
   }
 
-  amrex::Real nrg_pt = (rhoe_init[icell] + rhoesrc_ext[icell] * dt_save) / rho_pt;
+  const amrex::Real nrg_pt =
+    (rhoe_init[icell] + rhoesrc_ext[icell] * dt_save) * rho_pt_inv;
 
   amrex::Real temp_pt = yvec_d[offset + NUM_SPECIES];
 
-  amrex::GpuArray<amrex::Real, NUM_SPECIES> ei_pt;
   amrex::Real Cv_pt = 0.0;
+  amrex::GpuArray<amrex::Real, NUM_SPECIES> ei_pt = {0.0};
   auto eos = pele::physics::PhysicsType::eos();
   if (reactor_type == 1) {
     eos.EY2T(nrg_pt, massfrac.arr, temp_pt);
-    eos.TY2Cv(temp_pt, massfrac.arr, Cv_pt);
     eos.T2Ei(temp_pt, ei_pt.arr);
+    eos.TY2Cv(temp_pt, massfrac.arr, Cv_pt);
   } else {
     eos.HY2T(nrg_pt, massfrac.arr, temp_pt);
     eos.TY2Cp(temp_pt, massfrac.arr, Cv_pt);
     eos.T2Hi(temp_pt, ei_pt.arr);
   }
 
-  amrex::GpuArray<amrex::Real, NUM_SPECIES> cdots_pt;
+  amrex::GpuArray<amrex::Real, NUM_SPECIES> cdots_pt = {0.0};
   eos.RTY2WDOT(rho_pt, temp_pt, massfrac.arr, cdots_pt.arr);
 
-  ydot_d[offset + NUM_SPECIES] = rhoesrc_ext[icell];
+  amrex::Real rhoesrc = rhoesrc_ext[icell];
   for (int i = 0; i < NUM_SPECIES; i++) {
-    ydot_d[offset + i] = cdots_pt[i] + rYs[icell * NUM_SPECIES + i];
-    ydot_d[offset + NUM_SPECIES] =
-      ydot_d[offset + NUM_SPECIES] - ydot_d[offset + i] * ei_pt[i];
+    const amrex::Real cdot_rYs = cdots_pt[i] + rYs[icell * NUM_SPECIES + i];
+    ydot_d[offset + i] = cdot_rYs;
+    rhoesrc -= cdot_rYs * ei_pt[i];
   }
-  ydot_d[offset + NUM_SPECIES] =
-    ydot_d[offset + NUM_SPECIES] / (rho_pt * Cv_pt);
+  ydot_d[offset + NUM_SPECIES] = rhoesrc * (rho_pt_inv / Cv_pt);
 }
 //===================================================================
 

--- a/Reactions/reactor.H
+++ b/Reactions/reactor.H
@@ -299,13 +299,13 @@ void fKernelSpec(int icell,
   amrex::Real rho_pt = 0.0;
   amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {0.0};
   for (int n = 0; n < NUM_SPECIES; n++) {
-    massfrac[i] = yvec_d[offset + n];
+    massfrac[n] = yvec_d[offset + n];
     rho_pt += massfrac[i];
   }
   const amrex::Real rho_pt_inv = 1.0 / rho_pt;
 
-  for (int i = 0; i < NUM_SPECIES; i++) {
-    massfrac[i] *= rho_pt_inv;
+  for (int n = 0; n < NUM_SPECIES; n++) {
+    massfrac[n] *= rho_pt_inv;
   }
 
   const amrex::Real nrg_pt =
@@ -330,10 +330,10 @@ void fKernelSpec(int icell,
   eos.RTY2WDOT(rho_pt, temp_pt, massfrac.arr, cdots_pt.arr);
 
   amrex::Real rhoesrc = rhoesrc_ext[icell];
-  for (int i = 0; i < NUM_SPECIES; i++) {
-    const amrex::Real cdot_rYs = cdots_pt[i] + rYs[icell * NUM_SPECIES + i];
-    ydot_d[offset + i] = cdot_rYs;
-    rhoesrc -= cdot_rYs * ei_pt[i];
+  for (int n = 0; n < NUM_SPECIES; n++) {
+    const amrex::Real cdot_rYs = cdots_pt[n] + rYs[icell * NUM_SPECIES + n];
+    ydot_d[offset + n] = cdot_rYs;
+    rhoesrc -= cdot_rYs * ei_pt[n];
   }
   ydot_d[offset + NUM_SPECIES] = rhoesrc * (rho_pt_inv / Cv_pt);
 }

--- a/Reactions/reactor.H
+++ b/Reactions/reactor.H
@@ -300,7 +300,7 @@ void fKernelSpec(int icell,
   amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {0.0};
   for (int n = 0; n < NUM_SPECIES; n++) {
     massfrac[n] = yvec_d[offset + n];
-    rho_pt += massfrac[i];
+    rho_pt += massfrac[n];
   }
   const amrex::Real rho_pt_inv = 1.0 / rho_pt;
 


### PR DESCRIPTION
My previous simplifications of `fkernelspec` in PR #172 got overridden by PR #178 This is the same thing with some minimizations of global memory read/writes. 