### PR TITLE
Transpose yvec for global memory coalescence

### DIFF
--- a/Reactions/arkode/Make.package
+++ b/Reactions/arkode/Make.package
@@ -1,2 +1,2 @@
-#CEXE_headers += reactor.H
+CEXE_headers += reactor_utils.H
 CEXE_sources += reactor_arkode.cpp

--- a/Reactions/arkode/reactor_arkode.cpp
+++ b/Reactions/arkode/reactor_arkode.cpp
@@ -199,7 +199,7 @@ react(
   amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
     int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
     box_flatten(
-      icell, i, j, k, user_data->ireactor_type, rY_in, rY_src_in, T_in,
+      icell, NCELLS, i, j, k, user_data->ireactor_type, rY_in, rY_src_in, T_in,
       rEner_in, rEner_src_in, yvec_d, user_data->rYsrc_d,
       user_data->rhoe_init_d, user_data->rhoesrc_ext_d);
   });
@@ -239,7 +239,7 @@ react(
   amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
     int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
     box_unflatten(
-      icell, i, j, k, user_data->ireactor_type, rY_in, T_in, rEner_in,
+      icell, NCELLS, i, j, k, user_data->ireactor_type, rY_in, T_in, rEner_in,
       rEner_src_in, FC_in, yvec_d, user_data->rhoe_init_d, nfe, dt_react);
   });
 
@@ -442,7 +442,7 @@ int cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
 //    });
   amrex::ParallelFor(udata->ncells_d, [=] AMREX_GPU_DEVICE(int icell) noexcept {
     fKernelSpec(
-      icell, udata->dt_save, udata->ireactor_type, yvec_d, ydot_d,
+      icell, udata->ncells_d, udata->dt_save, udata->ireactor_type, yvec_d, ydot_d,
       udata->rhoe_init_d, udata->rhoesrc_ext_d, udata->rYsrc_d);
   });
 

--- a/Reactions/arkode/reactor_utils.H
+++ b/Reactions/arkode/reactor_utils.H
@@ -1,0 +1,15 @@
+#ifndef _REACTOR_UTILS_H_
+#define _REACTOR_UTILS_H_
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE int
+sunvec_index(const int specie_idx, const int icell, const int ncells)
+{
+  return specie_idx * ncells + icell;
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE int
+sunspec_index(const int specie_idx, const int icell, const int ncells)
+{
+  return sunvec_index(specie_idx, icell, ncells);
+}
+#endif

--- a/Reactions/cvode/Make.package
+++ b/Reactions/cvode/Make.package
@@ -1,4 +1,4 @@
-#CEXE_headers += reactor.H
+CEXE_headers += reactor_utils.H
 ifneq (, $(filter TRUE, $(USE_CUDA) $(USE_HIP)))
         CEXE_sources += reactor_cvode_GPU.cpp
 else

--- a/Reactions/cvode/reactor_cvode_CPU.cpp
+++ b/Reactions/cvode/reactor_cvode_CPU.cpp
@@ -573,7 +573,7 @@ react_2(
   ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
     int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
     box_flatten(
-      icell, i, j, k, data->ireactor_type, rY_in, rY_src_in, T_in, rEner_in,
+      icell, box_ncells, i, j, k, data->ireactor_type, rY_in, rY_src_in, T_in, rEner_in,
       rEner_src_in, data->Yvect_full, data->rYsrc, data->rhoX_init,
       data->rhoXsrc_ext);
   });
@@ -648,7 +648,7 @@ react_2(
   ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
     int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
     box_unflatten(
-      icell, i, j, k, data->ireactor_type, rY_in, T_in, rEner_in, rEner_src_in,
+      icell, box_ncells, i, j, k, data->ireactor_type, rY_in, T_in, rEner_in, rEner_src_in,
       FC_in, data->Yvect_full, data->rhoX_init, nfe, dt_react);
   });
   BL_PROFILE_VAR_STOP(FlatStuff);
@@ -860,7 +860,7 @@ cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
   udata->dt_save = t;
   
   BL_PROFILE_VAR("fKernelSpec()", fKernelSpec);
-  fKernelSpec(icell,udata->dt_save, udata->ireactor_type,
+  fKernelSpec(icell,udata->ncells, udata->dt_save, udata->ireactor_type,
           y_d, ydot_d, udata->rhoX_init, 
           udata->rhoXsrc_ext, udata->rYsrc);
   BL_PROFILE_VAR_STOP(fKernelSpec);

--- a/Reactions/cvode/reactor_cvode_GPU.cpp
+++ b/Reactions/cvode/reactor_cvode_GPU.cpp
@@ -492,7 +492,7 @@ react(
     int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
 
     box_flatten(
-      icell, i, j, k, user_data->ireactor_type, rY_in, rY_src_in, T_in,
+      icell, NCELLS, i, j, k, user_data->ireactor_type, rY_in, rY_src_in, T_in,
       rEner_in, rEner_src_in, yvec_d, user_data->rYsrc_d,
       user_data->rhoe_init_d, user_data->rhoesrc_ext_d);
   });
@@ -636,7 +636,7 @@ react(
     int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
 
     box_unflatten(
-      icell, i, j, k, user_data->ireactor_type, rY_in, T_in, rEner_in,
+      icell, NCELLS, i, j, k, user_data->ireactor_type, rY_in, T_in, rEner_in,
       rEner_src_in, FC_in, yvec_d, user_data->rhoe_init_d, nfe, dt_react);
   });
   BL_PROFILE_VAR_STOP(FlatStuff);
@@ -729,7 +729,7 @@ cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
                stride = blockDim.x * gridDim.x;
            icell < udata->ncells; icell += stride) {
         fKernelSpec(
-          icell, udata->dt_save, udata->ireactor_type, yvec_d, ydot_d,
+          icell, udata->ncells, udata->dt_save, udata->ireactor_type, yvec_d, ydot_d,
           udata->rhoe_init_d, udata->rhoesrc_ext_d, udata->rYsrc_d);
       }
     });
@@ -737,7 +737,7 @@ cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
 #else
   for (int icell = 0; icell < udata->ncells; icell++) {
     fKernelSpec(
-      icell, udata->dt_save, udata->ireactor_type, yvec_d, ydot_d,
+      icell, udata->ncells, udata->dt_save, udata->ireactor_type, yvec_d, ydot_d,
       udata->rhoe_init_d, udata->rhoesrc_ext_d, udata->rYsrc_d);
   }
 #endif

--- a/Reactions/cvode/reactor_utils.H
+++ b/Reactions/cvode/reactor_utils.H
@@ -1,0 +1,15 @@
+#ifndef _REACTOR_UTILS_H_
+#define _REACTOR_UTILS_H_
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE int
+sunvec_index(const int specie_idx, const int icell, const int /*ncells*/)
+{
+  return icell * (NUM_SPECIES + 1) + specie_idx;
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE int
+sunspec_index(const int specie_idx, const int icell, const int /*ncells*/)
+{
+  return icell * NUM_SPECIES + specie_idx;
+}
+#endif

--- a/Reactions/reactor.H
+++ b/Reactions/reactor.H
@@ -47,6 +47,7 @@
 #endif
 
 #include "AMReX_SUNMemory.H"
+#include "reactor_utils.H"
 
 extern amrex::Array<double, NUM_SPECIES + 1> typVals;
 extern int eint_rho; // in/out = rhoE/rhoY
@@ -179,12 +180,14 @@ void reactor_close();
   int nbBlocks;
   int nbThreads;
 };
+
 //===================================================================
 //Box flattening functions
 //===================================================================
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void box_flatten(
   int icell,
+  int ncells,
   int i,
   int j,
   int k,
@@ -201,39 +204,39 @@ void box_flatten(
 {
   amrex::Real mass_frac[NUM_SPECIES];
   amrex::Real rho = 0.0;
-  amrex::Real Enrg_loc;
-  amrex::Real temp;
-
-  int offset_yvec = icell * (NUM_SPECIES + 1);
-  int offset_spec = icell * (NUM_SPECIES);
-
   for (int n = 0; n < NUM_SPECIES; n++) {
-    tmp_vect[offset_yvec + n] = rhoY(i, j, k, n);
-    tmp_src_vect[offset_spec + n] = frcExt(i, j, k, n);
-    rho += tmp_vect[offset_yvec + n];
+    const int idx = sunvec_index(n, icell, ncells);
+    const int idx2 = sunspec_index(n, icell, ncells);
+    const amrex::Real rhoYn = rhoY(i, j, k, n);
+    tmp_vect[idx] = rhoYn;
+    tmp_src_vect[idx2] = frcExt(i, j, k, n);
+    rho += rhoYn;
+    mass_frac[n] = rhoYn;
   }
-  amrex::Real rho_inv = 1.0 / rho;
-  temp = temperature(i, j, k, 0);
+  const amrex::Real rho_inv = 1.0 / rho;
+  for (int n = 0; n < NUM_SPECIES; n++) {
+    mass_frac[n] *= rho_inv;
+  }
+
+  amrex::Real temp = temperature(i, j, k, 0);
   tmp_vect_energy[icell] = rhoE(i, j, k, 0);
   tmp_src_vect_energy[icell] = frcEExt(i, j, k, 0);
 
-  for (int n = 0; n < NUM_SPECIES; n++) {
-    mass_frac[n] = tmp_vect[offset_yvec + n] * rho_inv;
-  }
-  Enrg_loc = tmp_vect_energy[icell] / rho;
+  amrex::Real Enrg_loc = tmp_vect_energy[icell] * rho_inv;
   auto eos = pele::physics::PhysicsType::eos();
   if (ireactor_type == 1) {
     eos.EY2T(Enrg_loc, mass_frac, temp);
   } else {
     eos.HY2T(Enrg_loc, mass_frac, temp);
   }
-  tmp_vect[offset_yvec + NUM_SPECIES] = temp;
+  tmp_vect[sunvec_index(NUM_SPECIES, icell, ncells)] = temp;
 }
 //===================================================================
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 box_unflatten(
   int icell,
+  int ncells,
   int i,
   int j,
   int k,
@@ -250,23 +253,21 @@ box_unflatten(
 {
   amrex::Real mass_frac[NUM_SPECIES];
   amrex::Real rho = 0.0;
-  amrex::Real Enrg_loc;
-  amrex::Real temp;
-
-  int offset_yvec = icell * (NUM_SPECIES + 1);
-
   for (int n = 0; n < NUM_SPECIES; n++) {
-    rhoY(i, j, k, n) = tmp_vect[offset_yvec + n];
-    rho += tmp_vect[offset_yvec + n];
+    const amrex::Real rhoYn = tmp_vect[sunvec_index(n, icell, ncells)];
+    rhoY(i, j, k, n) = rhoYn;
+    rho += rhoYn;
+    mass_frac[n] = rhoYn;
   }
-  amrex::Real rho_inv = 1.0 / rho;
-  temp = tmp_vect[offset_yvec + NUM_SPECIES];
+  const amrex::Real rho_inv = 1.0 / rho;
+  for (int n = 0; n < NUM_SPECIES; n++) {
+    mass_frac[n] *= rho_inv;
+  }
+
+  amrex::Real temp = tmp_vect[sunvec_index(NUM_SPECIES, icell, ncells)];
   rhoE(i, j, k, 0) = tmp_vect_energy[icell] + dt * frcEExt(i, j, k, 0);
 
-  for (int n = 0; n < NUM_SPECIES; n++) {
-    mass_frac[n] = rhoY(i, j, k, n) * rho_inv;
-  }
-  Enrg_loc = rhoE(i, j, k, 0) / rho;
+  amrex::Real Enrg_loc = rhoE(i, j, k, 0) * rho_inv;
   auto eos = pele::physics::PhysicsType::eos();
   if (ireactor_type == 1) {
     eos.EY2T(Enrg_loc, mass_frac, temp);
@@ -291,7 +292,7 @@ void SetTolFactODE(amrex::Real relative_tol, amrex::Real absolute_tol);
 static int cF_RHS(realtype t, N_Vector y_in, N_Vector ydot, void* user_data);
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void fKernelSpec(int icell,
+void fKernelSpec(int icell, int ncells,
   double dt_save,
   int reactor_type,
   realtype* yvec_d,
@@ -300,12 +301,10 @@ void fKernelSpec(int icell,
   amrex::Real* rhoesrc_ext,
   amrex::Real* rYs)
 {
-  const int offset = icell * (NUM_SPECIES + 1);
-
   amrex::Real rho_pt = 0.0;
   amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {0.0};
   for (int n = 0; n < NUM_SPECIES; n++) {
-    massfrac[n] = yvec_d[offset + n];
+    massfrac[n] = yvec_d[sunvec_index(n, icell, ncells)];
     rho_pt += massfrac[n];
   }
   const amrex::Real rho_pt_inv = 1.0 / rho_pt;
@@ -317,7 +316,7 @@ void fKernelSpec(int icell,
   const amrex::Real nrg_pt =
     (rhoe_init[icell] + rhoesrc_ext[icell] * dt_save) * rho_pt_inv;
 
-  amrex::Real temp_pt = yvec_d[offset + NUM_SPECIES];
+  amrex::Real temp_pt = yvec_d[sunvec_index(NUM_SPECIES, icell, ncells)];
 
   amrex::Real Cv_pt = 0.0;
   amrex::GpuArray<amrex::Real, NUM_SPECIES> ei_pt = {0.0};
@@ -337,11 +336,11 @@ void fKernelSpec(int icell,
 
   amrex::Real rhoesrc = rhoesrc_ext[icell];
   for (int n = 0; n < NUM_SPECIES; n++) {
-    const amrex::Real cdot_rYs = cdots_pt[n] + rYs[icell * NUM_SPECIES + n];
-    ydot_d[offset + n] = cdot_rYs;
+    const amrex::Real cdot_rYs = cdots_pt[n] + rYs[sunspec_index(n, icell, ncells)];
+    ydot_d[sunvec_index(n, icell, ncells)] = cdot_rYs;
     rhoesrc -= cdot_rYs * ei_pt[n];
   }
-  ydot_d[offset + NUM_SPECIES] = rhoesrc * (rho_pt_inv / Cv_pt);
+  ydot_d[sunvec_index(NUM_SPECIES, icell, ncells)] = rhoesrc * (rho_pt_inv / Cv_pt);
 }
 //===================================================================
 

--- a/Testing/Exec/ReactEval/main.cpp
+++ b/Testing/Exec/ReactEval/main.cpp
@@ -564,7 +564,7 @@ main (int   argc,
             {
               int icell = (k-lo.z)*len.x*len.y + (j-lo.y)*len.x + (i-lo.x);
 
-              box_flatten(icell, i, j, k, ode_iE, 
+              box_flatten(icell, nCells, i, j, k, ode_iE, 
                           rhoY, frcExt, T, rhoE, frcEExt,
                           tmp_vect, tmp_src_vect, tmp_vect_energy, tmp_src_vect_energy);
             });
@@ -611,7 +611,7 @@ main (int   argc,
             [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
               int icell = (k-lo.z)*len.x*len.y + (j-lo.y)*len.x + (i-lo.x);
-              box_unflatten(icell, i, j, k, ode_iE,
+              box_unflatten(icell, nCells, i, j, k, ode_iE,
                             rhoY, T, rhoE, frcEExt, fc,
                             tmp_vect, tmp_vect_energy, tmp_fc[icell], dt);
             });


### PR DESCRIPTION
This ensures that threads have coalesced memory accesses to global memory. It seems to improve `cf_RHS` by 4%. And NCU stops complaining about uncoalesced memory access.