### PR TITLE
open mp compile error fix for rk64

### DIFF
--- a/Reactions/reactor.H
+++ b/Reactions/reactor.H
@@ -80,7 +80,7 @@ extern int rk64_nsubsteps_max;
 #pragma omp threadprivate(time_init)
 #pragma omp threadprivate(typVals)
 #pragma omp threadprivate(relTol, absTol)
-#pragma omp threadprivate(nsubsteps_guess, nsubsteps_min, nsubsteps_max)
+#pragma omp threadprivate(rk64_nsubsteps_guess, rk64_nsubsteps_min, rk64_nsubsteps_max)
 #endif
 
 //===================================================================


### PR DESCRIPTION
minor fix in the variable names