### PR TITLE
EOS calls for Reactions modified to be SRK-compatible

### DIFF
--- a/Eos/Fuego.H
+++ b/Eos/Fuego.H
@@ -198,6 +198,12 @@ struct Fuego
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
+  void RTY2Ei(amrex::Real /*R*/, amrex::Real T, amrex::Real* /*Y[]*/, amrex::Real Ei[]) {
+    T2Ei(T, Ei);
+  }
+
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
   void Y2X(amrex::Real Y[], amrex::Real X[]) { CKYTX(Y, X); }
 
   AMREX_GPU_HOST_DEVICE

--- a/Eos/Fuego.H
+++ b/Eos/Fuego.H
@@ -122,6 +122,13 @@ struct Fuego
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
+  void RHY2T(amrex::Real /*R*/, amrex::Real H, amrex::Real Y[], amrex::Real& T)
+  {
+    HY2T(H, Y, T);
+  }
+  
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
   void RYET2P(
     amrex::Real R,
     amrex::Real Y[],

--- a/Eos/GammaLaw.H
+++ b/Eos/GammaLaw.H
@@ -151,7 +151,14 @@ struct GammaLaw
     const amrex::Real Cv = Constants::RU / (wbar * (gamma - 1.0));
     T = H / (Cv * gamma);
   }
-
+  
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  void RHY2T(amrex::Real /*R*/, amrex::Real H, amrex::Real Y[], amrex::Real& T)
+  {
+    HY2T(H, Y, T);
+  }
+  
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   void RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)

--- a/Eos/GammaLaw.H
+++ b/Eos/GammaLaw.H
@@ -55,6 +55,12 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
+  void RTY2Ei(amrex::Real /*R*/, amrex::Real T, amrex::Real* /*Y[]*/, amrex::Real Ei[]) {
+    T2Ei(T, Ei);
+  }
+
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
   void TY2Cv(amrex::Real /*T*/, amrex::Real Y[], amrex::Real& Cv)
   {
     amrex::Real wbar;

--- a/Eos/SRK.H
+++ b/Eos/SRK.H
@@ -436,10 +436,17 @@ struct SRK
   void HY2T(amrex::Real /*H*/, amrex::Real* /*Y[]*/, amrex::Real& /*T*/)
   {
     // In SRK this  function is not possible
-    // RHY2T would be possible but is not yet supported
     amrex::Error("HY2T not physically possible for this EoS");
   }
 
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  void RHY2T(amrex::Real /*R*/, amrex::Real /*H*/, amrex::Real* /*Y[]*/, amrex::Real& /*T*/)
+  {
+    // RHY2T is possible but is not yet supported
+    amrex::Error("RHY2T not yet supported for this EoS");
+  }
+  
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   void RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)

--- a/Reactions/cvode/reactor_cvode_CPU.cpp
+++ b/Reactions/cvode/reactor_cvode_CPU.cpp
@@ -436,12 +436,12 @@ react(
       for (int n = 0; n < NUM_SPECIES; n++) {
         mass_frac[n] = yvec_d[n] * rho_inv;
       }
-      Enrg_loc = data->rhoX_init[0] / rho;
+      Enrg_loc = data->rhoX_init[0] * rho_inv;
       auto eos = pele::physics::PhysicsType::eos();
       if (data->ireactor_type == 1) {
-        eos.EY2T(Enrg_loc, mass_frac, temp);
+        eos.REY2T(rho, Enrg_loc, mass_frac, temp);
       } else {
-        eos.HY2T(Enrg_loc, mass_frac, temp);
+        eos.RHY2T(rho, Enrg_loc, mass_frac, temp);
       }
       yvec_d[NUM_SPECIES] = temp;
       BL_PROFILE_VAR_STOP(FlatStuff);
@@ -487,9 +487,9 @@ react(
         data->rhoX_init[0] + (dummy_time - time_init) * data->rhoXsrc_ext[0];
       Enrg_loc = rEner_in(i, j, k, 0) * rho_inv;
       if (data->ireactor_type == 1) {
-        eos.EY2T(Enrg_loc, mass_frac, temp);
+        eos.REY2T(rho, Enrg_loc, mass_frac, temp);
       } else {
-        eos.HY2T(Enrg_loc, mass_frac, temp);
+        eos.RHY2T(rho, Enrg_loc, mass_frac, temp);
       }
       T_in(i, j, k, 0) = temp;
       BL_PROFILE_VAR_STOP(FlatStuff);
@@ -761,9 +761,9 @@ react(
     temp = rY_in[offset + NUM_SPECIES];
     auto eos = pele::physics::PhysicsType::eos();
     if (reactor_type == eint_rho) {
-      eos.EY2T(nrg_loc, mass_frac, temp);
+      eos.REY2T(rho, nrg_loc, mass_frac, temp);
     } else {
-      eos.HY2T(nrg_loc, mass_frac, temp);
+      eos.RHY2T(rho, nrg_loc, mass_frac, temp);
     }
     // store T in y
     yvec_d[offset + NUM_SPECIES] = temp;
@@ -824,9 +824,9 @@ react(
     // recompute T
     auto eos = pele::physics::PhysicsType::eos();
     if (reactor_type == eint_rho) {
-      eos.EY2T(nrg_loc, mass_frac, temp);
+      eos.REY2T(rho, nrg_loc, mass_frac, temp);
     } else {
-      eos.HY2T(nrg_loc, mass_frac, temp);
+      eos.RHY2T(rho, nrg_loc, mass_frac, temp);
     }
     // store T in rY_in
     rY_in[offset + NUM_SPECIES] = temp;
@@ -915,14 +915,14 @@ fKernelSpec(realtype* t, realtype* yvec_d, realtype* ydot_d, void* user_data)
     auto eos = pele::physics::PhysicsType::eos();
     if (data_wk->ireactor_type == eint_rho) {
       // UV REACTOR
-      eos.EY2T(energy, massfrac, temp);
-      eos.TY2Cv(temp, massfrac, cX);
-      eos.T2Ei(temp, Xi);
+      eos.REY2T(rho, energy, massfrac, temp);
+      eos.RTY2Cv(rho, temp, massfrac, cX);
+      eos.RTY2Ei(rho, temp, massfrac, Xi);
     } else if (data_wk->ireactor_type == enth_rho) {
       // HP REACTOR
-      eos.HY2T(energy, massfrac, temp);
-      eos.TY2Cp(temp, massfrac, cX);
-      eos.T2Hi(temp, Xi);
+      eos.RHY2T(rho, energy, massfrac, temp);
+      eos.RTY2Cp(rho, temp, massfrac, cX);
+      eos.RTY2Hi(rho, temp, massfrac, Xi);
     }
     eos.RTY2WDOT(rho, temp, massfrac, cdot);
 

--- a/Reactions/null/reactor.cpp
+++ b/Reactions/null/reactor.cpp
@@ -66,9 +66,9 @@ react(
     amrex::Real T_loc = T_in(i, j, k, 0);
     auto eos = pele::physics::PhysicsType::eos();
     if (reactor_type == eint_rho) {
-      eos.EY2T(energy_loc, Y_loc, T_loc);
+      eos.REY2T(rho_loc, energy_loc, Y_loc, T_loc);
     } else {
-      eos.HY2T(energy_loc, Y_loc, T_loc);
+      eos.RHY2T(rho_loc, energy_loc, Y_loc, T_loc);
     }
     T_in(i, j, k, 0) = T_loc;
     FC_in(i, j, k, 0) = 0.0;
@@ -176,9 +176,9 @@ react(
     amrex::Real T_loc = T_in(i, j, k, 0);
     auto eos = pele::physics::PhysicsType::eos();
     if (reactor_type == eint_rho) {
-      eos.EY2T(energy_loc, Y_loc, T_loc);
+      eos.EY2T(rho_loc, energy_loc, Y_loc, T_loc);
     } else {
-      eos.HY2T(energy_loc, Y_loc, T_loc);
+      eos.HY2T(rho_loc, energy_loc, Y_loc, T_loc);
     }
     T_in(i, j, k, 0) = T_loc;
     FC_in(i, j, k, 0) = 0.0;

--- a/Reactions/null/reactor.cpp
+++ b/Reactions/null/reactor.cpp
@@ -176,9 +176,9 @@ react(
     amrex::Real T_loc = T_in(i, j, k, 0);
     auto eos = pele::physics::PhysicsType::eos();
     if (reactor_type == eint_rho) {
-      eos.EY2T(rho_loc, energy_loc, Y_loc, T_loc);
+      eos.REY2T(rho_loc, energy_loc, Y_loc, T_loc);
     } else {
-      eos.HY2T(rho_loc, energy_loc, Y_loc, T_loc);
+      eos.RHY2T(rho_loc, energy_loc, Y_loc, T_loc);
     }
     T_in(i, j, k, 0) = T_loc;
     FC_in(i, j, k, 0) = 0.0;

--- a/Reactions/reactor.H
+++ b/Reactions/reactor.H
@@ -237,9 +237,9 @@ box_flatten(
   amrex::Real Enrg_loc = tmp_vect_energy[icell] * rho_inv;
   auto eos = pele::physics::PhysicsType::eos();
   if (ireactor_type == 1) {
-    eos.EY2T(Enrg_loc, mass_frac, temp);
+    eos.REY2T(rho, Enrg_loc, mass_frac, temp);
   } else {
-    eos.HY2T(Enrg_loc, mass_frac, temp);
+    eos.RHY2T(rho, Enrg_loc, mass_frac, temp);
   }
   tmp_vect[sunvec_index(NUM_SPECIES, icell, ncells)] = temp;
 }
@@ -281,9 +281,9 @@ box_unflatten(
   amrex::Real Enrg_loc = rhoE(i, j, k, 0) * rho_inv;
   auto eos = pele::physics::PhysicsType::eos();
   if (ireactor_type == 1) {
-    eos.EY2T(Enrg_loc, mass_frac, temp);
+    eos.REY2T(rho, Enrg_loc, mass_frac, temp);
   } else {
-    eos.HY2T(Enrg_loc, mass_frac, temp);
+    eos.RHY2T(rho, Enrg_loc, mass_frac, temp);
   }
   T_in(i, j, k, 0) = temp;
   FC_in(i, j, k, 0) = tmp_FCunt;
@@ -336,13 +336,13 @@ fKernelSpec(
   amrex::GpuArray<amrex::Real, NUM_SPECIES> ei_pt = {0.0};
   auto eos = pele::physics::PhysicsType::eos();
   if (reactor_type == 1) {
-    eos.EY2T(nrg_pt, massfrac.arr, temp_pt);
-    eos.T2Ei(temp_pt, ei_pt.arr);
-    eos.TY2Cv(temp_pt, massfrac.arr, Cv_pt);
+    eos.REY2T(rho_pt, nrg_pt, massfrac.arr, temp_pt);
+    eos.RTY2Ei(rho_pt, temp_pt, massfrac.arr, ei_pt.arr);
+    eos.RTY2Cv(rho_pt, temp_pt, massfrac.arr, Cv_pt);
   } else {
-    eos.HY2T(nrg_pt, massfrac.arr, temp_pt);
-    eos.TY2Cp(temp_pt, massfrac.arr, Cv_pt);
-    eos.T2Hi(temp_pt, ei_pt.arr);
+    eos.RHY2T(rho_pt, nrg_pt, massfrac.arr, temp_pt);
+    eos.RTY2Hi(rho_pt, temp_pt, massfrac.arr, ei_pt.arr);
+    eos.RTY2Cp(rho_pt, temp_pt, massfrac.arr, Cv_pt);
   }
 
   amrex::GpuArray<amrex::Real, NUM_SPECIES> cdots_pt = {0.0};

--- a/Reactions/rk64/reactor_rk64.cpp
+++ b/Reactions/rk64/reactor_rk64.cpp
@@ -198,12 +198,12 @@ react(
     error_reg[NUM_SPECIES] = 0.0;
     amrex::Real temp = T_in(i, j, k, 0);
 
-    amrex::Real Enrg_loc = rEner_in(i, j, k, 0) / rho;
+    amrex::Real Enrg_loc = rEner_in(i, j, k, 0) * rho_inv;
     auto eos = pele::physics::PhysicsType::eos();
     if (captured_reactor_type == 1) {
-      eos.EY2T(Enrg_loc, mass_frac, temp);
+      eos.REY2T(rho, Enrg_loc, mass_frac, temp);
     } else {
-      eos.HY2T(Enrg_loc, mass_frac, temp);
+      eos.RHY2T(rho, Enrg_loc, mass_frac, temp);
     }
     soln_reg[NUM_SPECIES] = temp;
     carryover_reg[NUM_SPECIES] = soln_reg[NUM_SPECIES];
@@ -274,9 +274,9 @@ react(
     Enrg_loc = rEner_in(i, j, k, 0) * rho_inv;
 
     if (captured_reactor_type == 1) {
-      eos.EY2T(Enrg_loc, mass_frac, temp);
+      eos.REY2T(rho, Enrg_loc, mass_frac, temp);
     } else {
-      eos.HY2T(Enrg_loc, mass_frac, temp);
+      eos.RHY2T(rho, Enrg_loc, mass_frac, temp);
     }
     T_in(i, j, k, 0) = temp;
     FC_in(i, j, k, 0) = nsteps;


### PR DESCRIPTION
This pull requests modifies the EOS calls used in the various chemical reaction integrators in PelePhysics to be compatible with real gas equations of state. This should enable PeleC with SRK EOS to use any of the PelePhysics integrators, with the exception of CVODE with analytical jacobian. Also, SRK can only be used with constant volume chemistry integration for now because the RHY2T function has not been implemented for that EOS yet.

So far, integration based on T is still used for SRK.  This involves some additional EOS calls that would not be required for energy-based integration (which may have nontrivial computational cost for SRK). I plan to do some testing to evaluate this before finalizing the pull request.

The changes here are basically just converting calls like eos.EY2T to eos.REY2T, which simply wraps around the former for Fuego and GammaLaw EOS. A few additional wrapper functions were needed to complete this.