### PR TITLE
Capture udata pointer data explicitly and avoid global memory access

### DIFF
--- a/Reactions/arkode/reactor_arkode.cpp
+++ b/Reactions/arkode/reactor_arkode.cpp
@@ -440,7 +440,7 @@ int cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
 //          udata->rhoe_init_d, udata->rhoesrc_ext_d, udata->rYsrc_d);
 //      }
 //    });
-  auto ncells_d = udata->ncells_d;
+  auto ncells = udata->ncells_d;
   auto dt_save = udata->dt_save;
   auto reactor_type = udata->ireactor_type;
   auto rhoe_init = udata->rhoe_init_d;
@@ -448,7 +448,7 @@ int cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
   auto rYsrc = udata->rYsrc_d;
   amrex::ParallelFor(udata->ncells_d, [=] AMREX_GPU_DEVICE(int icell) noexcept {
     fKernelSpec(
-      icell, ncells_d, dt_save, reactor_type, yvec_d, ydot_d,
+      icell, ncells, dt_save, reactor_type, yvec_d, ydot_d,
       rhoe_init, rhoesrc_ext, rYsrc);
   });
 

--- a/Reactions/arkode/reactor_arkode.cpp
+++ b/Reactions/arkode/reactor_arkode.cpp
@@ -448,7 +448,7 @@ int cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
   auto rYsrc = udata->rYsrc_d;
   amrex::ParallelFor(udata->ncells_d, [=] AMREX_GPU_DEVICE(int icell) noexcept {
     fKernelSpec(
-      icell, ncells_d, dt_save, ireactor_type, yvec_d, ydot_d,
+      icell, ncells_d, dt_save, reactor_type, yvec_d, ydot_d,
       rhoe_init, rhoesrc_ext, rYsrc);
   });
 

--- a/Reactions/arkode/reactor_arkode.cpp
+++ b/Reactions/arkode/reactor_arkode.cpp
@@ -440,10 +440,16 @@ int cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
 //          udata->rhoe_init_d, udata->rhoesrc_ext_d, udata->rYsrc_d);
 //      }
 //    });
+  auto ncells_d = udata->ncells_d;
+  auto dt_save = udata->dt_save;
+  auto reactor_type = udata->ireactor_type;
+  auto rhoe_init = udata->rhoe_init_d;
+  auto rhoesrc_ext = udata->rhoesrc_ext_d;
+  auto rYsrc = udata->rYsrc_d;
   amrex::ParallelFor(udata->ncells_d, [=] AMREX_GPU_DEVICE(int icell) noexcept {
     fKernelSpec(
-      icell, udata->ncells_d, udata->dt_save, udata->ireactor_type, yvec_d, ydot_d,
-      udata->rhoe_init_d, udata->rhoesrc_ext_d, udata->rYsrc_d);
+      icell, ncells_d, dt_save, ireactor_type, yvec_d, ydot_d,
+      rhoe_init, rhoesrc_ext, rYsrc);
   });
 
   amrex::Gpu::Device::streamSynchronize();

--- a/Reactions/cvode/reactor_cvode_GPU.cpp
+++ b/Reactions/cvode/reactor_cvode_GPU.cpp
@@ -718,13 +718,12 @@ cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
   CVODEUserData * udata = static_cast<CVODEUserData*>(user_data);
   udata->dt_save = t;
 
-  auto ncells_d = udata->ncells_d;
+  auto ncells = udata->ncells;
   auto dt_save = udata->dt_save;
   auto reactor_type = udata->ireactor_type;
   auto rhoe_init = udata->rhoe_init_d;
   auto rhoesrc_ext = udata->rhoesrc_ext_d;
   auto rYsrc = udata->rYsrc_d;
-
 #ifdef AMREX_USE_GPU
   const auto ec = Gpu::ExecutionConfig(udata->ncells);
   // launch_global<<<ec.numBlocks, ec.numThreads, ec.sharedMem,

--- a/Reactions/cvode/reactor_cvode_GPU.cpp
+++ b/Reactions/cvode/reactor_cvode_GPU.cpp
@@ -736,7 +736,7 @@ cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
                stride = blockDim.x * gridDim.x;
            icell < udata->ncells; icell += stride) {
         fKernelSpec(
-          icell, ncells, dt_save, ireactor_type, yvec_d, ydot_d,
+          icell, ncells, dt_save, reactor_type, yvec_d, ydot_d,
           rhoe_init, rhoesrc_ext, rYsrc);
       }
     });
@@ -744,7 +744,7 @@ cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
 #else
   for (int icell = 0; icell < udata->ncells; icell++) {
     fKernelSpec(
-      icell, ncells, dt_save, ireactor_type, yvec_d, ydot_d,
+      icell, ncells, dt_save, reactor_type, yvec_d, ydot_d,
       rhoe_init, rhoesrc_ext, rYsrc);
   }
 #endif

--- a/Reactions/cvode/reactor_cvode_GPU.cpp
+++ b/Reactions/cvode/reactor_cvode_GPU.cpp
@@ -718,6 +718,13 @@ cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
   CVODEUserData * udata = static_cast<CVODEUserData*>(user_data);
   udata->dt_save = t;
 
+  auto ncells_d = udata->ncells_d;
+  auto dt_save = udata->dt_save;
+  auto reactor_type = udata->ireactor_type;
+  auto rhoe_init = udata->rhoe_init_d;
+  auto rhoesrc_ext = udata->rhoesrc_ext_d;
+  auto rYsrc = udata->rYsrc_d;
+
 #ifdef AMREX_USE_GPU
   const auto ec = Gpu::ExecutionConfig(udata->ncells);
   // launch_global<<<ec.numBlocks, ec.numThreads, ec.sharedMem,
@@ -729,16 +736,16 @@ cF_RHS(realtype t, N_Vector y_in, N_Vector ydot_in, void* user_data)
                stride = blockDim.x * gridDim.x;
            icell < udata->ncells; icell += stride) {
         fKernelSpec(
-          icell, udata->ncells, udata->dt_save, udata->ireactor_type, yvec_d, ydot_d,
-          udata->rhoe_init_d, udata->rhoesrc_ext_d, udata->rYsrc_d);
+          icell, ncells, dt_save, ireactor_type, yvec_d, ydot_d,
+          rhoe_init, rhoesrc_ext, rYsrc);
       }
     });
   Gpu::Device::streamSynchronize();
 #else
   for (int icell = 0; icell < udata->ncells; icell++) {
     fKernelSpec(
-      icell, udata->ncells, udata->dt_save, udata->ireactor_type, yvec_d, ydot_d,
-      udata->rhoe_init_d, udata->rhoesrc_ext_d, udata->rYsrc_d);
+      icell, ncells, dt_save, ireactor_type, yvec_d, ydot_d,
+      rhoe_init, rhoesrc_ext, rYsrc);
   }
 #endif
 


### PR DESCRIPTION
Either the compiler or AMRex decides to copy the object pointed by
udata into GPU global memory and caused the stalls. Our Rice
University collaborators found that this leads to a 7% improvement.