### PR TITLE
Cleanup Transport and SRK

### DIFF
--- a/Eos/SRK.H
+++ b/Eos/SRK.H
@@ -26,7 +26,7 @@ struct SRK
     am = 0.0;
     bm = 0.0;
     AMREX_ASSERT(T > 0.0);
-    amrex::Real sqrtT = std::sqrt(T);
+    const amrex::Real sqrtT = std::sqrt(T);
     amrex::Real amloc[NUM_SPECIES];
 
     // Combine as follows: add diagonal to am in first loop, loop upper triang
@@ -50,7 +50,7 @@ struct SRK
   {
     am = 0.0;
     AMREX_ASSERT(T > 0.0);
-    amrex::Real sqrtT = std::sqrt(T);
+    const amrex::Real sqrtT = std::sqrt(T);
     amrex::Real amloc[NUM_SPECIES];
 
     // Combine as follows: add diagonal to am in first loop, loop upper triang
@@ -83,8 +83,8 @@ struct SRK
   {
     dAmdT = 0.0;
     AMREX_ASSERT(T > 0.0);
-    amrex::Real oneOverT = 1.0 / T;
-    amrex::Real sqrtT = std::sqrt(T);
+    const amrex::Real oneOverT = 1.0 / T;
+    const amrex::Real sqrtT = std::sqrt(T);
     amrex::Real amloc[NUM_SPECIES];
     amrex::Real amlocder[NUM_SPECIES];
 
@@ -108,7 +108,7 @@ struct SRK
   void Calc_dAmdY(amrex::Real T, amrex::Real Y[], amrex::Real dAmdY[])
   {
     AMREX_ASSERT(T > 0.0);
-    amrex::Real sqrtT = std::sqrt(T);
+    const amrex::Real sqrtT = std::sqrt(T);
     amrex::Real amloc[NUM_SPECIES];
 
     for (int ii = 0; ii < NUM_SPECIES; ii++) {
@@ -130,7 +130,7 @@ struct SRK
     amrex::Real T, amrex::Real* /*Y[]*/, amrex::Real d2AmdY2[][NUM_SPECIES])
   {
     AMREX_ASSERT(T > 0.0);
-    amrex::Real sqrtT = std::sqrt(T);
+    const amrex::Real sqrtT = std::sqrt(T);
     amrex::Real amloc[NUM_SPECIES];
 
     for (int ii = 0; ii < NUM_SPECIES; ii++) {
@@ -150,8 +150,8 @@ struct SRK
   void Calc_d2AmdTY(amrex::Real T, amrex::Real Y[], amrex::Real d2AmdTY[])
   {
     AMREX_ASSERT(T > 0.0);
-    amrex::Real oneOverT = 1.0 / T;
-    amrex::Real sqrtT = std::sqrt(T);
+    const amrex::Real oneOverT = 1.0 / T;
+    const amrex::Real sqrtT = std::sqrt(T);
     amrex::Real amloc[NUM_SPECIES];
     amrex::Real amlocder[NUM_SPECIES];
 
@@ -181,7 +181,6 @@ struct SRK
     amrex::Real T,
     amrex::Real Wbar)
   {
-    amrex::Real theta, Z1, Z2, Z3, sqrtQ, third;
     amrex::Real RmT = Constants::RU / Wbar * T;
     amrex::Real B1 = bm * P / RmT;
     amrex::Real R1 = RmT;
@@ -193,18 +192,18 @@ struct SRK
     amrex::Real Q = (alpha * alpha - 3.0 * beta) / 9.0;
     amrex::Real R =
       (2.0 * alpha * alpha * alpha - 9.0 * alpha * beta + 27.0 * gamma) / 54.0;
-    amrex::Real PIval = 3.1415926535897932;
 
     // Multiple roots of cubic
-    third = 1.0 / 3.0;
+    const amrex::Real third = 1.0 / 3.0;
     if ((Q * Q * Q - R * R) > 0) {
-      sqrtQ = std::sqrt(Q);
-      theta = std::acos(R / (Q * sqrtQ));
-      Z1 = -2.0 * sqrtQ * std::cos(theta * third) - alpha * third;
-      Z2 =
-        -2.0 * sqrtQ * std::cos((theta + 2.0 * PIval) * third) - alpha * third;
-      Z3 =
-        -2.0 * sqrtQ * std::cos((theta + 4.0 * PIval) * third) - alpha * third;
+      const amrex::Real sqrtQ = std::sqrt(Q);
+      const amrex::Real theta = std::acos(R / (Q * sqrtQ));
+      const amrex::Real Z1 =
+        -2.0 * sqrtQ * std::cos(theta * third) - alpha * third;
+      const amrex::Real Z2 =
+        -2.0 * sqrtQ * std::cos((theta + 2.0 * M_PI) * third) - alpha * third;
+      const amrex::Real Z3 =
+        -2.0 * sqrtQ * std::cos((theta + 4.0 * M_PI) * third) - alpha * third;
       Z = std::max(Z1, Z2);
       Z = std::max(Z, Z3);
     } else {
@@ -220,9 +219,9 @@ struct SRK
   void Calc_d2AmdT2(amrex::Real T, amrex::Real Y[], amrex::Real& d2AmdT2)
   {
     AMREX_ASSERT(T > 0.0);
-    amrex::Real oneOverT = 1.0 / T;
-    amrex::Real tmp1 = -0.5 * oneOverT;
-    amrex::Real sqrtT = std::sqrt(T);
+    const amrex::Real oneOverT = 1.0 / T;
+    const amrex::Real tmp1 = -0.5 * oneOverT;
+    const amrex::Real sqrtT = std::sqrt(T);
     amrex::Real amloc[NUM_SPECIES];
     amrex::Real amlocder[NUM_SPECIES];
 
@@ -254,15 +253,11 @@ struct SRK
     amrex::Real& d2AmdT2)
   {
     AMREX_ASSERT(T > 0.0);
-    amrex::Real oneOverT = 1.0 / T;
-    amrex::Real tmp1 = -0.5 * oneOverT;
-    amrex::Real sqrtT = std::sqrt(T);
+    const amrex::Real oneOverT = 1.0 / T;
+    const amrex::Real tmp1 = -0.5 * oneOverT;
+    const amrex::Real sqrtT = std::sqrt(T);
     amrex::Real amloc[NUM_SPECIES];
     amrex::Real amlocder[NUM_SPECIES];
-
-    am = 0.0;
-    dAmdT = 0.0;
-    d2AmdT2 = 0.0;
 
     // Compute species-dependent intermediates
     for (int ii = 0; ii < NUM_SPECIES; ii++) {

--- a/Transport/Constant.H
+++ b/Transport/Constant.H
@@ -19,6 +19,9 @@ struct ConstTransport
     const bool wtr_get_mu,
     const bool wtr_get_lam,
     const bool wtr_get_Ddiag,
+    const amrex::Real /*Tloc*/,
+    const amrex::Real /*rholoc*/,
+    amrex::Real* /*Yloc*/,
     amrex::Real* Ddiag,
     amrex::Real& mu,
     amrex::Real& xi,
@@ -73,8 +76,8 @@ struct ConstTransport
           amrex::Real muloc, xiloc, lamloc;
           amrex::Real Ddiag[NUM_SPECIES] = {0.0};
           transport(
-            wtr_get_xi, wtr_get_mu, wtr_get_lam, wtr_get_Ddiag, Ddiag, muloc,
-            xiloc, lamloc, tparm);
+            wtr_get_xi, wtr_get_mu, wtr_get_lam, wtr_get_Ddiag, 0.0, 0.0, NULL,
+            Ddiag, muloc, xiloc, lamloc, tparm);
 
           // mu, xi and lambda are stored after D in the diffusion multifab
           for (int n = 0; n < NUM_SPECIES; ++n) {

--- a/Transport/Constant.H
+++ b/Transport/Constant.H
@@ -15,13 +15,10 @@ struct ConstTransport
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   void transport(
-    bool wtr_get_xi,
-    bool wtr_get_mu,
-    bool wtr_get_lam,
-    bool wtr_get_Ddiag,
-    amrex::Real& /*Tloc*/,
-    amrex::Real& /*rholoc*/,
-    amrex::Real* /*Yloc*/,
+    const bool wtr_get_xi,
+    const bool wtr_get_mu,
+    const bool wtr_get_lam,
+    const bool wtr_get_Ddiag,
     amrex::Real* Ddiag,
     amrex::Real& mu,
     amrex::Real& xi,
@@ -52,9 +49,9 @@ struct ConstTransport
   AMREX_FORCE_INLINE
   void get_transport_coeffs(
     amrex::Box const& bx,
-    amrex::Array4<const amrex::Real> const& Y_in,
-    amrex::Array4<const amrex::Real> const& T_in,
-    amrex::Array4<const amrex::Real> const& Rho_in,
+    amrex::Array4<const amrex::Real> const& /*Y_in*/,
+    amrex::Array4<const amrex::Real> const& /*T_in*/,
+    amrex::Array4<const amrex::Real> const& /*Rho_in*/,
     amrex::Array4<amrex::Real> const& D_out,
     amrex::Array4<amrex::Real> const& mu_out,
     amrex::Array4<amrex::Real> const& xi_out,
@@ -64,33 +61,20 @@ struct ConstTransport
     const auto lo = amrex::lbound(bx);
     const auto hi = amrex::ubound(bx);
 
-    bool wtr_get_xi, wtr_get_mu, wtr_get_lam, wtr_get_Ddiag;
-
-    wtr_get_xi = true;
-    wtr_get_mu = true;
-    wtr_get_lam = true;
-    wtr_get_Ddiag = true;
-
-    amrex::Real T;
-    amrex::Real rho;
-    amrex::Real massloc[NUM_SPECIES];
-
-    amrex::Real muloc, xiloc, lamloc;
-    amrex::Real Ddiag[NUM_SPECIES];
+    const bool wtr_get_xi = true;
+    const bool wtr_get_mu = true;
+    const bool wtr_get_lam = true;
+    const bool wtr_get_Ddiag = true;
 
     for (int k = lo.z; k <= hi.z; ++k) {
       for (int j = lo.y; j <= hi.y; ++j) {
         for (int i = lo.x; i <= hi.x; ++i) {
 
-          T = T_in(i, j, k);
-          rho = Rho_in(i, j, k);
-          for (int n = 0; n < NUM_SPECIES; ++n) {
-            massloc[n] = Y_in(i, j, k, n);
-          }
-
+          amrex::Real muloc, xiloc, lamloc;
+          amrex::Real Ddiag[NUM_SPECIES] = {0.0};
           transport(
-            wtr_get_xi, wtr_get_mu, wtr_get_lam, wtr_get_Ddiag, T, rho, massloc,
-            Ddiag, muloc, xiloc, lamloc, tparm);
+            wtr_get_xi, wtr_get_mu, wtr_get_lam, wtr_get_Ddiag, Ddiag, muloc,
+            xiloc, lamloc, tparm);
 
           // mu, xi and lambda are stored after D in the diffusion multifab
           for (int n = 0; n < NUM_SPECIES; ++n) {

--- a/Transport/Simple.H
+++ b/Transport/Simple.H
@@ -141,19 +141,19 @@ struct BinaryDiff
     amrex::Real* Ddiag,
     TransParm<EOSType, SimpleTransport> const* tparm)
   {
-    amrex::Real term1, term2, dbintemp;
     for (int i = 0; i < NUM_SPECIES; ++i) {
-      term1 = 0.0;
-      term2 = 0.0;
+      amrex::Real term1 = 0.0;
+      amrex::Real term2 = 0.0;
       for (int j = 0; j < NUM_SPECIES; ++j) {
         if (i != j) {
-          dbintemp =
-            tparm->trans_fitdbin[4 * (i + NUM_SPECIES * j)] +
-            tparm->trans_fitdbin[1 + 4 * (i + NUM_SPECIES * j)] * logT[0] +
-            tparm->trans_fitdbin[2 + 4 * (i + NUM_SPECIES * j)] * logT[1] +
-            tparm->trans_fitdbin[3 + 4 * (i + NUM_SPECIES * j)] * logT[2];
-          term1 = term1 + Yloc[j];
-          term2 = term2 + Xloc[j] / std::exp(dbintemp);
+          const int four_idx_ij = 4 * (i + NUM_SPECIES * j);
+          const amrex::Real dbintemp =
+            tparm->trans_fitdbin[four_idx_ij] +
+            tparm->trans_fitdbin[1 + four_idx_ij] * logT[0] +
+            tparm->trans_fitdbin[2 + four_idx_ij] * logT[1] +
+            tparm->trans_fitdbin[3 + four_idx_ij] * logT[2];
+          term1 += Yloc[j];
+          term2 += Xloc[j] * std::exp(-dbintemp);
         }
       }
       Ddiag[i] = tparm->trans_wt[i] * term1 / term2 / wbar;
@@ -184,55 +184,41 @@ struct BinaryDiff<eos::SRK>
     amrex::Real* Ddiag,
     TransParm<eos::SRK, SimpleTransport> const* tparm)
   {
-    amrex::Real term1, term2, Upsilonij;
-    amrex::Real dbintemp;
-    const amrex::Real Pst = 1013250.00;
-    int idx_ij, idx_ik, idx_jk;
     for (int i = 0; i < NUM_SPECIES; ++i) {
-      term1 = 0.0;
-      term2 = 0.0;
+      amrex::Real term1 = 0.0;
+      amrex::Real term2 = 0.0;
       for (int j = 0; j < NUM_SPECIES; ++j) {
-        idx_ij = i + NUM_SPECIES * j;
         if (i != j) {
-          dbintemp = tparm->trans_fitdbin[4 * (idx_ij)] +
-                     tparm->trans_fitdbin[1 + 4 * (idx_ij)] * logT[0] +
-                     tparm->trans_fitdbin[2 + 4 * (idx_ij)] * logT[1] +
-                     tparm->trans_fitdbin[3 + 4 * (idx_ij)] * logT[2];
+          const int idx_ij = i + NUM_SPECIES * j;
+          amrex::Real dbintemp =
+            tparm->trans_fitdbin[4 * idx_ij] +
+            tparm->trans_fitdbin[1 + 4 * idx_ij] * logT[0] +
+            tparm->trans_fitdbin[2 + 4 * idx_ij] * logT[1] +
+            tparm->trans_fitdbin[3 + 4 * idx_ij] * logT[2];
           dbintemp = std::exp(dbintemp);
 
-          Upsilonij = 0.0;
+          amrex::Real Upsilonij = 0.0;
+          const amrex::Real S_ij = tparm->Sigmaij[idx_ij];
           for (int k = 0; k < NUM_SPECIES; ++k) {
-            idx_ik = i + NUM_SPECIES * k;
-            idx_jk = j + NUM_SPECIES * k;
+            const amrex::Real S_ik = tparm->Sigmaij[i + NUM_SPECIES * k];
+            const amrex::Real S_jk = tparm->Sigmaij[j + NUM_SPECIES * k];
+
             Upsilonij +=
               tparm->trans_iwt[k] * Yloc[k] *
-              (8.0 * (tparm->Sigmaij[idx_ik] * tparm->Sigmaij[idx_ik] *
-                        tparm->Sigmaij[idx_ik] +
-                      tparm->Sigmaij[idx_jk] * tparm->Sigmaij[idx_jk] *
-                        tparm->Sigmaij[idx_jk]) -
-               6.0 *
-                 (tparm->Sigmaij[idx_ik] * tparm->Sigmaij[idx_ik] +
-                  tparm->Sigmaij[idx_jk] * tparm->Sigmaij[idx_jk]) *
-                 tparm->Sigmaij[idx_ij] -
+              (8.0 * (S_ik * S_ik * S_ik + S_jk * S_jk * S_jk) -
+               6.0 * (S_ik * S_ik + S_jk * S_jk) * S_ij -
                3.0 *
-                 std::pow(
-                   (tparm->Sigmaij[idx_ik] * tparm->Sigmaij[idx_ik] -
-                    tparm->Sigmaij[idx_jk] * tparm->Sigmaij[idx_jk]),
-                   2.0) /
-                 tparm->Sigmaij[idx_ij] +
-               tparm->Sigmaij[idx_ij] * tparm->Sigmaij[idx_ij] *
-                 tparm->Sigmaij[idx_ij]);
+                 ((S_ik * S_ik - S_jk * S_jk) * (S_ik * S_ik - S_jk * S_jk)) /
+                 S_ij +
+               S_ij * S_ij * S_ij);
           }
-          Upsilonij =
-            Upsilonij * rholoc * Constants::Avna * 3.141592653589793 / 12.0 +
-            1.0;
-          dbintemp = dbintemp * Pst /
-                     (Constants::RU * Tloc * Upsilonij); // * wbar/rholoc
+          Upsilonij = Upsilonij * rholoc * Constants::Avna * M_PI / 12.0 + 1.0;
+          dbintemp *= Constants::PATM / (Constants::RU * Tloc * Upsilonij);
           term1 += Yloc[j];
           term2 += Xloc[j] / dbintemp;
         }
       }
-      Ddiag[i] = tparm->trans_wt[i] * term1 / term2; // * rholoc / wbar
+      Ddiag[i] = tparm->trans_wt[i] * term1 / term2;
     }
   }
 };

--- a/Transport/Simple.H
+++ b/Transport/Simple.H
@@ -23,11 +23,11 @@ struct NonIdealChungCorrections<eos::SRK>
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   void operator()(
-    bool wtr_get_mu,
-    bool wtr_get_lam,
-    amrex::Real& Temp,
+    const bool wtr_get_mu,
+    const bool wtr_get_lam,
+    const amrex::Real Temp,
     amrex::Real* Xloc,
-    amrex::Real& rholoc,
+    const amrex::Real rholoc,
     amrex::Real& wbar,
     amrex::Real& mu,
     amrex::Real& lam,

--- a/Transport/Simple.H
+++ b/Transport/Simple.H
@@ -30,7 +30,6 @@ struct NonIdealChungCorrections<eos::SRK>
     amrex::Real& rholoc,
     amrex::Real& wbar,
     amrex::Real& mu,
-    amrex::Real& /*xi*/,
     amrex::Real& lam,
     TransParm<eos::SRK, SimpleTransport> const* trans_parm)
   {
@@ -45,19 +44,20 @@ struct NonIdealChungCorrections<eos::SRK>
 
     for (int i = 0; i < NUM_SPECIES; ++i) {
       for (int j = 0; j < NUM_SPECIES; ++j) {
-        amrex::Real T2 = trans_parm->trans_sig[i] * trans_parm->trans_sig[j];
-        amrex::Real T3 = T2 * std::sqrt(T2);
+        const amrex::Real T2 =
+          trans_parm->trans_sig[i] * trans_parm->trans_sig[j];
+        const amrex::Real T3 = T2 * std::sqrt(T2);
         sigma_M_3 += Xloc[i] * Xloc[j] * T3;
 
-        amrex::Real Epsilon_ij =
+        const amrex::Real Epsilon_ij =
           std::sqrt(trans_parm->trans_eps[i] * trans_parm->trans_eps[j]);
         Epsilon_M += Xloc[i] * Xloc[j] * Epsilon_ij * T3;
 
-        amrex::Real Omega_ij =
+        const amrex::Real Omega_ij =
           0.5 * (trans_parm->omega[i] + trans_parm->omega[j]);
         Omega_M += Xloc[i] * Xloc[j] * Omega_ij * T3;
 
-        amrex::Real MW_ij =
+        const amrex::Real MW_ij =
           2.0 / (trans_parm->trans_iwt[i] + trans_parm->trans_iwt[j]);
         MW_m += Xloc[i] * Xloc[j] * Epsilon_ij * T2 * std::sqrt(MW_ij);
 
@@ -71,29 +71,31 @@ struct NonIdealChungCorrections<eos::SRK>
     }
 
     MW_m *= MW_m;
-    amrex::Real sigma_M = std::cbrt(sigma_M_3);
-    amrex::Real InvSigma1 = 1.0 / sigma_M;
-    amrex::Real InvSigma3 = 1.0 / sigma_M_3;
+    const amrex::Real sigma_M = std::cbrt(sigma_M_3);
+    const amrex::Real InvSigma1 = 1.0 / sigma_M;
+    const amrex::Real InvSigma3 = 1.0 / sigma_M_3;
     Epsilon_M *= InvSigma3;
-    amrex::Real Tstar = Temp / Epsilon_M;
-    amrex::Real Tcm = 1.2593 * Epsilon_M;
-    amrex::Real Vcm = 1.8887 * sigma_M_3;
+    const amrex::Real Tstar = Temp / Epsilon_M;
+    const amrex::Real Tcm = 1.2593 * Epsilon_M;
+    const amrex::Real Vcm = 1.8887 * sigma_M_3;
     Omega_M *= InvSigma3;
     MW_m = MW_m * InvSigma3 * InvSigma1 / (Epsilon_M * Epsilon_M);
     DP_m_4 = DP_m_4 * sigma_M_3 * Epsilon_M;
-    amrex::Real DP_red_4 = 297.2069113e6 * DP_m_4 / (Vcm * Vcm * Tcm * Tcm);
-    amrex::Real y = Vcm * rholoc / (6.0 * wbar);
+    const amrex::Real DP_red_4 =
+      297.2069113e6 * DP_m_4 / (Vcm * Vcm * Tcm * Tcm);
+    const amrex::Real y = Vcm * rholoc / (6.0 * wbar);
     amrex::Real A[10];
     for (int i = 0; i < 10; ++i) {
       A[i] = trans_parm->Afac[4 * i] + trans_parm->Afac[4 * i + 1] * Omega_M +
              trans_parm->Afac[4 * i + 2] * DP_red_4 +
              trans_parm->Afac[4 * i + 3] * KappaM;
     }
-    amrex::Real G1 = (1.0 - 0.5 * y) / ((1.0 - y) * (1.0 - y) * (1.0 - y));
-    amrex::Real G2 = (A[0] * (1.0 - std::exp(-A[3] * y)) / y +
-                      A[1] * G1 * std::exp(A[4] * y) + A[2] * G1) /
-                     (A[0] * A[3] + A[1] + A[2]);
-    amrex::Real eta_P =
+    const amrex::Real G1 =
+      (1.0 - 0.5 * y) / ((1.0 - y) * (1.0 - y) * (1.0 - y));
+    const amrex::Real G2 = (A[0] * (1.0 - std::exp(-A[3] * y)) / y +
+                            A[1] * G1 * std::exp(A[4] * y) + A[2] * G1) /
+                           (A[0] * A[3] + A[1] + A[2]);
+    const amrex::Real eta_P =
       (36.344e-6 * std::sqrt(MW_m * Tcm) / std::pow(Vcm, 2.0 / 3.0)) * A[6] *
       y * y * G2 * exp(A[7] + A[8] / Tstar + A[9] / (Tstar * Tstar));
 
@@ -117,7 +119,7 @@ struct NonIdealChungCorrections<eos::SRK>
                            std::sqrt(Tstar);
 
     lambda_p *= 4.184e+7; // erg/(cm s K)
-    amrex::Real beta = 1.0 / H2 + B[5] * y;
+    const amrex::Real beta = 1.0 / H2 + B[5] * y;
 
     // Set nonideal conductivity
     if (wtr_get_lam) {
@@ -132,15 +134,15 @@ struct BinaryDiff
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   void operator()(
-    const amrex::Real wbar,
     amrex::Real* Xloc,
     amrex::Real* Yloc,
     amrex::Real* logT,
-    amrex::Real& rholoc,
-    amrex::Real& Tloc,
+    const amrex::Real /*rholoc*/,
+    const amrex::Real Tloc,
     amrex::Real* Ddiag,
     TransParm<EOSType, SimpleTransport> const* tparm)
   {
+    const amrex::Real scale = Constants::PATM / (Constants::RU * Tloc);
     for (int i = 0; i < NUM_SPECIES; ++i) {
       amrex::Real term1 = 0.0;
       amrex::Real term2 = 0.0;
@@ -156,15 +158,7 @@ struct BinaryDiff
           term2 += Xloc[j] * std::exp(-dbintemp);
         }
       }
-      Ddiag[i] = tparm->trans_wt[i] * term1 / term2 / wbar;
-    }
-
-    // Call CKRP ?
-    const amrex::Real pscale =
-      Constants::PATM * wbar / (Constants::RU * Tloc * rholoc);
-
-    for (int i = 0; i < NUM_SPECIES; ++i) {
-      Ddiag[i] = rholoc * pscale * Ddiag[i];
+      Ddiag[i] = tparm->trans_wt[i] * term1 / term2 * scale;
     }
   }
 };
@@ -175,12 +169,11 @@ struct BinaryDiff<eos::SRK>
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   void operator()(
-    const amrex::Real /*wbar*/,
     amrex::Real* Xloc,
     amrex::Real* Yloc,
     amrex::Real* logT,
-    amrex::Real& rholoc,
-    amrex::Real& Tloc,
+    const amrex::Real rholoc,
+    const amrex::Real Tloc,
     amrex::Real* Ddiag,
     TransParm<eos::SRK, SimpleTransport> const* tparm)
   {
@@ -199,6 +192,7 @@ struct BinaryDiff<eos::SRK>
 
           amrex::Real Upsilonij = 0.0;
           const amrex::Real S_ij = tparm->Sigmaij[idx_ij];
+          const amrex::Real S_ij_inv = 1.0 / S_ij;
           for (int k = 0; k < NUM_SPECIES; ++k) {
             const amrex::Real S_ik = tparm->Sigmaij[i + NUM_SPECIES * k];
             const amrex::Real S_jk = tparm->Sigmaij[j + NUM_SPECIES * k];
@@ -208,8 +202,8 @@ struct BinaryDiff<eos::SRK>
               (8.0 * (S_ik * S_ik * S_ik + S_jk * S_jk * S_jk) -
                6.0 * (S_ik * S_ik + S_jk * S_jk) * S_ij -
                3.0 *
-                 ((S_ik * S_ik - S_jk * S_jk) * (S_ik * S_ik - S_jk * S_jk)) /
-                 S_ij +
+                 ((S_ik * S_ik - S_jk * S_jk) * (S_ik * S_ik - S_jk * S_jk)) *
+                 S_ij_inv +
                S_ij * S_ij * S_ij);
           }
           Upsilonij = Upsilonij * rholoc * Constants::Avna * M_PI / 12.0 + 1.0;
@@ -290,12 +284,12 @@ struct SimpleTransport
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   void transport(
-    bool wtr_get_xi,
-    bool wtr_get_mu,
-    bool wtr_get_lam,
-    bool wtr_get_Ddiag,
-    amrex::Real& Tloc,
-    amrex::Real& rholoc,
+    const bool wtr_get_xi,
+    const bool wtr_get_mu,
+    const bool wtr_get_lam,
+    const bool wtr_get_Ddiag,
+    const amrex::Real Tloc,
+    const amrex::Real rholoc,
     amrex::Real* Yloc,
     amrex::Real* Ddiag,
     amrex::Real& mu,
@@ -304,8 +298,6 @@ struct SimpleTransport
     TransParm<EosType, transport_type> const* tparm)
   {
     amrex::Real trace = 1.e-15;
-    // Call CKRP ?
-    amrex::Real wbar;
     amrex::Real Xloc[NUM_SPECIES];
     amrex::Real muloc[NUM_SPECIES];
     amrex::Real xiloc[NUM_SPECIES];
@@ -316,23 +308,19 @@ struct SimpleTransport
     logT[1] = logT[0] * logT[0];
     logT[2] = logT[0] * logT[1];
 
-    int nspec = NUM_SPECIES;
-
     amrex::Real sum = 0.;
 
-    for (int i = 0; i < nspec; ++i) {
-      sum = sum + Yloc[i];
-    }
-
-    wbar = 0.;
-    amrex::Real real_nspec = NUM_SPECIES;
-
     for (int i = 0; i < NUM_SPECIES; ++i) {
-      Yloc[i] = Yloc[i] + trace * (sum / real_nspec - Yloc[i]);
+      sum += Yloc[i];
     }
 
     for (int i = 0; i < NUM_SPECIES; ++i) {
-      wbar = wbar + Yloc[i] * tparm->trans_iwt[i];
+      Yloc[i] += trace * (sum / NUM_SPECIES - Yloc[i]);
+    }
+
+    amrex::Real wbar = 0.;
+    for (int i = 0; i < NUM_SPECIES; ++i) {
+      wbar += Yloc[i] * tparm->trans_iwt[i];
     }
     wbar = 1.0 / wbar;
     for (int i = 0; i < NUM_SPECIES; ++i) {
@@ -350,8 +338,8 @@ struct SimpleTransport
       mu = 0.0;
 
       for (int i = 0; i < NUM_SPECIES; ++i) {
-        mu = mu + Xloc[i] * (muloc[i] * muloc[i] * muloc[i] * muloc[i] *
-                             muloc[i] * muloc[i]);
+        mu += Xloc[i] *
+              (muloc[i] * muloc[i] * muloc[i] * muloc[i] * muloc[i] * muloc[i]);
       }
       mu = std::cbrt(std::sqrt(mu)); // mu = (sum[ Xloc_i * muloc_i^6])^(1/6)
 
@@ -362,9 +350,9 @@ struct SimpleTransport
         comp_pure_bulk(Tloc, muloc, xiloc, tparm);
         xi = 0.0;
         for (int i = 0; i < NUM_SPECIES; ++i) {
-          xi = xi + Xloc[i] * (std::sqrt(std::sqrt(
-                                xiloc[i] * xiloc[i] *
-                                xiloc[i]))); // xi = sum[Xloc_i*xiloc_i^(3/4)];
+          xi += Xloc[i] * (std::sqrt(std::sqrt(
+                            xiloc[i] * xiloc[i] *
+                            xiloc[i]))); // xi = sum[Xloc_i*xiloc_i^(3/4)];
         }
         xi = std::cbrt(
           xi * xi * xi * xi); // xi = (sum[Xloc_i*xiloc_i^(3/4)])^(4/3)
@@ -381,7 +369,6 @@ struct SimpleTransport
       }
 
       lam = 0.;
-
       for (int i = 0; i < NUM_SPECIES; ++i) {
         lam += Xloc[i] * std::sqrt(std::sqrt(
                            lamloc[i])); // lam = sum[Xloc_i * (lamloc_i)^(1/4)]
@@ -390,10 +377,10 @@ struct SimpleTransport
     }
     // Add nonideal corrections if necessary
     NonIdealChungCorrections<EosType>()(
-      wtr_get_mu, wtr_get_lam, Tloc, Xloc, rholoc, wbar, mu, xi, lam, tparm);
+      wtr_get_mu, wtr_get_lam, Tloc, Xloc, rholoc, wbar, mu, lam, tparm);
 
     if (wtr_get_Ddiag) {
-      BinaryDiff<EosType>()(wbar, Xloc, Yloc, logT, rholoc, Tloc, Ddiag, tparm);
+      BinaryDiff<EosType>()(Xloc, Yloc, logT, rholoc, Tloc, Ddiag, tparm);
     }
   }
 
@@ -413,30 +400,24 @@ struct SimpleTransport
     const auto lo = amrex::lbound(bx);
     const auto hi = amrex::ubound(bx);
 
-    bool wtr_get_xi, wtr_get_mu, wtr_get_lam, wtr_get_Ddiag;
-
-    wtr_get_xi = true;
-    wtr_get_mu = true;
-    wtr_get_lam = true;
-    wtr_get_Ddiag = true;
-
-    amrex::Real T;
-    amrex::Real rho;
-    amrex::Real massloc[NUM_SPECIES];
-
-    amrex::Real muloc, xiloc, lamloc;
-    amrex::Real Ddiag[NUM_SPECIES];
+    const bool wtr_get_xi = true;
+    const bool wtr_get_mu = true;
+    const bool wtr_get_lam = true;
+    const bool wtr_get_Ddiag = true;
 
     for (int k = lo.z; k <= hi.z; ++k) {
       for (int j = lo.y; j <= hi.y; ++j) {
         for (int i = lo.x; i <= hi.x; ++i) {
 
-          T = T_in(i, j, k);
-          rho = Rho_in(i, j, k);
+          const amrex::Real T = T_in(i, j, k);
+          const amrex::Real rho = Rho_in(i, j, k);
+          amrex::Real massloc[NUM_SPECIES] = {0.0};
           for (int n = 0; n < NUM_SPECIES; ++n) {
             massloc[n] = Y_in(i, j, k, n);
           }
 
+          amrex::Real muloc, xiloc, lamloc;
+          amrex::Real Ddiag[NUM_SPECIES] = {0.0};
           transport(
             wtr_get_xi, wtr_get_mu, wtr_get_lam, wtr_get_Ddiag, T, rho, massloc,
             Ddiag, muloc, xiloc, lamloc, tparm);

--- a/Transport/Sutherland.H
+++ b/Transport/Sutherland.H
@@ -15,12 +15,12 @@ struct SutherlandTransport
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   void transport(
-    bool wtr_get_xi,
-    bool wtr_get_mu,
-    bool wtr_get_lam,
-    bool wtr_get_Ddiag,
-    amrex::Real& Tloc,
-    amrex::Real& /*rholoc*/,
+    const bool wtr_get_xi,
+    const bool wtr_get_mu,
+    const bool wtr_get_lam,
+    const bool wtr_get_Ddiag,
+    const amrex::Real Tloc,
+    const amrex::Real /*rholoc*/,
     amrex::Real* Yloc,
     amrex::Real* Ddiag,
     amrex::Real& mu,
@@ -42,8 +42,8 @@ struct SutherlandTransport
                           (tparm->viscosity_T_ref + tparm->viscosity_S) /
                           (Tloc + tparm->viscosity_S);
 
-      amrex::Real Cpmix;
-      CKCPBS(&Tloc, Yloc, &Cpmix);
+      amrex::Real Cpmix, Tloc_cpy = Tloc;
+      CKCPBS(&Tloc_cpy, Yloc, &Cpmix);
       lam = muloc * Cpmix / tparm->Prandtl_number;
     }
 
@@ -64,7 +64,7 @@ struct SutherlandTransport
     amrex::Box const& bx,
     amrex::Array4<const amrex::Real> const& Y_in,
     amrex::Array4<const amrex::Real> const& T_in,
-    amrex::Array4<const amrex::Real> const& Rho_in,
+    amrex::Array4<const amrex::Real> const& /*Rho_in*/,
     amrex::Array4<amrex::Real> const& D_out,
     amrex::Array4<amrex::Real> const& mu_out,
     amrex::Array4<amrex::Real> const& xi_out,
@@ -74,32 +74,25 @@ struct SutherlandTransport
     const auto lo = amrex::lbound(bx);
     const auto hi = amrex::ubound(bx);
 
-    bool wtr_get_xi, wtr_get_mu, wtr_get_lam, wtr_get_Ddiag;
-
-    wtr_get_xi = true;
-    wtr_get_mu = true;
-    wtr_get_lam = true;
-    wtr_get_Ddiag = true;
-
-    amrex::Real T;
-    amrex::Real rho;
-    amrex::Real massloc[NUM_SPECIES];
-
-    amrex::Real muloc, xiloc, lamloc;
-    amrex::Real Ddiag[NUM_SPECIES];
+    const bool wtr_get_xi = true;
+    const bool wtr_get_mu = true;
+    const bool wtr_get_lam = true;
+    const bool wtr_get_Ddiag = true;
 
     for (int k = lo.z; k <= hi.z; ++k) {
       for (int j = lo.y; j <= hi.y; ++j) {
         for (int i = lo.x; i <= hi.x; ++i) {
 
-          T = T_in(i, j, k);
-          rho = Rho_in(i, j, k);
+          amrex::Real T = T_in(i, j, k);
+          amrex::Real massloc[NUM_SPECIES] = {0.0};
           for (int n = 0; n < NUM_SPECIES; ++n) {
             massloc[n] = Y_in(i, j, k, n);
           }
 
+          amrex::Real muloc, xiloc, lamloc;
+          amrex::Real Ddiag[NUM_SPECIES] = {0.0};
           transport(
-            wtr_get_xi, wtr_get_mu, wtr_get_lam, wtr_get_Ddiag, T, rho, massloc,
+            wtr_get_xi, wtr_get_mu, wtr_get_lam, wtr_get_Ddiag, T, 0.0, massloc,
             Ddiag, muloc, xiloc, lamloc, tparm);
 
           // mu, xi and lambda are stored after D in the diffusion multifab


### PR DESCRIPTION
`/ std::exp(dbintemp)` -> `* std::exp(-dbintemp)` gives a 0.5% speedup according to the Rice University collaborators. The rest is just me doing esthetics. 

Co-authored by Xiaozhu Meng <mxz297@gmail.com> at Rice University
