### PR TITLE
Nonideal transport efficiency improvements

### DIFF
--- a/Transport/Simple.H
+++ b/Transport/Simple.H
@@ -44,29 +44,28 @@ struct NonIdealChungCorrections<eos::SRK>
 
     for (int i = 0; i < NUM_SPECIES; ++i) {
       for (int j = 0; j < NUM_SPECIES; ++j) {
-        const amrex::Real T2 =
-          trans_parm->trans_sig[i] * trans_parm->trans_sig[j];
-        const amrex::Real T3 = T2 * std::sqrt(T2);
-        sigma_M_3 += Xloc[i] * Xloc[j] * T3;
+	const amrex::Real Xij = Xloc[i] * Xloc[j];
+	const int idx = i * NUM_SPECIES + j;
+	
+	const amrex::Real sqrtT2 = trans_parm->sqrtT2ij[idx];
+	const amrex::Real T2 = sqrtT2 * sqrtT2;
+        const amrex::Real T3 = T2 * sqrtT2;
+        sigma_M_3 += Xij * T3;
 
-        const amrex::Real Epsilon_ij =
-          std::sqrt(trans_parm->trans_eps[i] * trans_parm->trans_eps[j]);
-        Epsilon_M += Xloc[i] * Xloc[j] * Epsilon_ij * T3;
+        const amrex::Real Epsilon_ij = trans_parm->sqrtEpsilonij[idx];
+        Epsilon_M += Xij * Epsilon_ij * T3;
 
         const amrex::Real Omega_ij =
           0.5 * (trans_parm->omega[i] + trans_parm->omega[j]);
-        Omega_M += Xloc[i] * Xloc[j] * Omega_ij * T3;
+        Omega_M += Xij * Omega_ij * T3;
 
-        const amrex::Real MW_ij =
-          2.0 / (trans_parm->trans_iwt[i] + trans_parm->trans_iwt[j]);
-        MW_m += Xloc[i] * Xloc[j] * Epsilon_ij * T2 * std::sqrt(MW_ij);
+        MW_m += Xij * Epsilon_ij * T2 * trans_parm->sqrtMWij[idx];
 
-        DP_m_4 += Xloc[i] * Xloc[j] * trans_parm->trans_dip[i] *
+        DP_m_4 += Xij* trans_parm->trans_dip[i] *
                   trans_parm->trans_dip[i] * trans_parm->trans_dip[j] *
                   trans_parm->trans_dip[j] / (T3 * Epsilon_ij);
 
-        KappaM += Xloc[i] * Xloc[j] *
-                  std::sqrt(trans_parm->Kappai[i] * trans_parm->Kappai[j]);
+        KappaM += Xij * trans_parm->sqrtKappaij[idx];
       }
     }
 

--- a/Transport/Simple.H
+++ b/Transport/Simple.H
@@ -187,28 +187,16 @@ struct BinaryDiff<eos::SRK>
             tparm->trans_fitdbin[1 + 4 * idx_ij] * logT[0] +
             tparm->trans_fitdbin[2 + 4 * idx_ij] * logT[1] +
             tparm->trans_fitdbin[3 + 4 * idx_ij] * logT[2];
-          dbintemp = std::exp(dbintemp);
+          dbintemp = std::exp(-dbintemp);
 
           amrex::Real Upsilonij = 0.0;
-          const amrex::Real S_ij = tparm->Sigmaij[idx_ij];
-          const amrex::Real S_ij_inv = 1.0 / S_ij;
           for (int k = 0; k < NUM_SPECIES; ++k) {
-            const amrex::Real S_ik = tparm->Sigmaij[i + NUM_SPECIES * k];
-            const amrex::Real S_jk = tparm->Sigmaij[j + NUM_SPECIES * k];
-
-            Upsilonij +=
-              tparm->trans_iwt[k] * Yloc[k] *
-              (8.0 * (S_ik * S_ik * S_ik + S_jk * S_jk * S_jk) -
-               6.0 * (S_ik * S_ik + S_jk * S_jk) * S_ij -
-               3.0 *
-                 ((S_ik * S_ik - S_jk * S_jk) * (S_ik * S_ik - S_jk * S_jk)) *
-                 S_ij_inv +
-               S_ij * S_ij * S_ij);
+            Upsilonij += tparm->Upsilonijk[idx_ij*NUM_SPECIES + k] * Yloc[k];
           }
           Upsilonij = Upsilonij * rholoc * Constants::Avna * M_PI / 12.0 + 1.0;
-          dbintemp *= Constants::PATM / (Constants::RU * Tloc * Upsilonij);
+          dbintemp *= (Constants::RU * Tloc * Upsilonij) / Constants::PATM  ;
           term1 += Yloc[j];
-          term2 += Xloc[j] / dbintemp;
+          term2 += Xloc[j] * dbintemp;
         }
       }
       Ddiag[i] = tparm->trans_wt[i] * term1 / term2;

--- a/Transport/Simple.H
+++ b/Transport/Simple.H
@@ -40,7 +40,7 @@ struct NonIdealChungCorrections<eos::SRK>
     amrex::Real DP_m_4 = 0.0;
     amrex::Real KappaM = 0.0;
 
-    // Note: all the square roots could be precalculated
+    // Note: all the square roots are precalculated for efficiency
 
     for (int i = 0; i < NUM_SPECIES; ++i) {
       for (int j = 0; j < NUM_SPECIES; ++j) {

--- a/Transport/TransportParams.H
+++ b/Transport/TransportParams.H
@@ -158,7 +158,6 @@ struct TransParm<eos::SRK, SimpleTransport>
   int* trans_nlin = nullptr;
   amrex::Real* Afac = nullptr;
   amrex::Real* Bfac = nullptr;
-  amrex::Real* Sigmaij = nullptr;
   amrex::Real* sqrtT2ij = nullptr;
   amrex::Real* sqrtEpsilonij = nullptr;
   amrex::Real* sqrtMWij = nullptr;
@@ -224,8 +223,6 @@ struct TransParm<eos::SRK, SimpleTransport>
         sizeof(amrex::Real) * NUM_SPECIES);
       Kappai = (amrex::Real*)amrex::The_Arena()->alloc(
         sizeof(amrex::Real) * NUM_SPECIES);
-      Sigmaij = (amrex::Real*)amrex::The_Arena()->alloc(
-        sizeof(amrex::Real) * NUM_SPECIES * NUM_SPECIES);
       sqrtT2ij = (amrex::Real*)amrex::The_Arena()->alloc(
         sizeof(amrex::Real) * NUM_SPECIES * NUM_SPECIES);
       sqrtEpsilonij = (amrex::Real*)amrex::The_Arena()->alloc(
@@ -313,13 +310,6 @@ struct TransParm<eos::SRK, SimpleTransport>
       Bfac[26] = -60.84100;
       Bfac[27] = 466.7750;
 
-      for (int i = 0; i < NUM_SPECIES; ++i) {
-        for (int j = 0; j < NUM_SPECIES; ++j) {
-          Sigmaij[i * NUM_SPECIES + j] =
-            0.5 * (trans_sig[i] + trans_sig[j]) * 1e-8; // converted to cm
-        }
-      }
-
       // Initialize Kappa, which has nonzero values only for specific polar
       // species
       for (int i = 0; i < NUM_SPECIES; ++i) {
@@ -355,11 +345,11 @@ struct TransParm<eos::SRK, SimpleTransport>
         for (int j = 0; j < NUM_SPECIES; ++j) {
 	  if (i != j) {
 	    const int idx_ij = i + NUM_SPECIES * j;
-	    const amrex::Real S_ij = Sigmaij[idx_ij];
+	    const amrex::Real S_ij = 0.5 * (trans_sig[i] + trans_sig[j]) * 1e-8;  // converted to cm
 	    const amrex::Real S_ij_inv = 1.0 / S_ij;
 	    for (int k = 0; k < NUM_SPECIES; ++k) {
-	      const amrex::Real S_ik = Sigmaij[i + NUM_SPECIES * k];
-	      const amrex::Real S_jk = Sigmaij[j + NUM_SPECIES * k];
+	      const amrex::Real S_ik = 0.5 * (trans_sig[i] + trans_sig[k]) * 1e-8;  // converted to cm
+	      const amrex::Real S_jk = 0.5 * (trans_sig[j] + trans_sig[k]) * 1e-8;  // converted to cm
 	      Upsilonijk[idx_ij*NUM_SPECIES + k] = 
 	        trans_iwt[k] *
 		(8.0 * (S_ik * S_ik * S_ik + S_jk * S_jk * S_jk) -
@@ -395,7 +385,6 @@ struct TransParm<eos::SRK, SimpleTransport>
       amrex::The_Arena()->free(Afac);
       amrex::The_Arena()->free(Bfac);
       amrex::The_Arena()->free(Kappai);
-      amrex::The_Arena()->free(Sigmaij);
       amrex::The_Arena()->free(sqrtT2ij);
       amrex::The_Arena()->free(sqrtEpsilonij);
       amrex::The_Arena()->free(sqrtMWij);

--- a/Transport/TransportParams.H
+++ b/Transport/TransportParams.H
@@ -163,6 +163,7 @@ struct TransParm<eos::SRK, SimpleTransport>
   amrex::Real* sqrtEpsilonij = nullptr;
   amrex::Real* sqrtMWij = nullptr;
   amrex::Real* sqrtKappaij = nullptr;
+  amrex::Real* Upsilonijk = nullptr;
   amrex::Real* Kappai = nullptr;
   amrex::Real* omega = nullptr;
   bool m_allocated{false};
@@ -233,6 +234,8 @@ struct TransParm<eos::SRK, SimpleTransport>
         sizeof(amrex::Real) * NUM_SPECIES * NUM_SPECIES);
       sqrtKappaij = (amrex::Real*)amrex::The_Arena()->alloc(
         sizeof(amrex::Real) * NUM_SPECIES * NUM_SPECIES);
+      Upsilonijk = (amrex::Real*)amrex::The_Arena()->alloc(
+        sizeof(amrex::Real) * NUM_SPECIES * NUM_SPECIES * NUM_SPECIES);
 
       // Initialize coefficients of model
       {
@@ -347,6 +350,29 @@ struct TransParm<eos::SRK, SimpleTransport>
 	  sqrtKappaij[idx] = std::sqrt(Kappai[i] * Kappai[j]);
         }
       }
+
+      for (int i = 0; i < NUM_SPECIES; ++i) {
+        for (int j = 0; j < NUM_SPECIES; ++j) {
+	  if (i != j) {
+	    const int idx_ij = i + NUM_SPECIES * j;
+	    const amrex::Real S_ij = Sigmaij[idx_ij];
+	    const amrex::Real S_ij_inv = 1.0 / S_ij;
+	    for (int k = 0; k < NUM_SPECIES; ++k) {
+	      const amrex::Real S_ik = Sigmaij[i + NUM_SPECIES * k];
+	      const amrex::Real S_jk = Sigmaij[j + NUM_SPECIES * k];
+	      Upsilonijk[idx_ij*NUM_SPECIES + k] = 
+	        trans_iwt[k] *
+		(8.0 * (S_ik * S_ik * S_ik + S_jk * S_jk * S_jk) -
+		 6.0 * (S_ik * S_ik + S_jk * S_jk) * S_ij -
+		 3.0 *
+                 ((S_ik * S_ik - S_jk * S_jk) * (S_ik * S_ik - S_jk * S_jk)) *
+                 S_ij_inv +
+		 S_ij * S_ij * S_ij);
+	    }
+	  }
+	}
+      }
+      
       m_allocated = true;
     }
   }
@@ -374,6 +400,7 @@ struct TransParm<eos::SRK, SimpleTransport>
       amrex::The_Arena()->free(sqrtEpsilonij);
       amrex::The_Arena()->free(sqrtMWij);
       amrex::The_Arena()->free(sqrtKappaij);
+      amrex::The_Arena()->free(Upsilonijk);
       amrex::The_Arena()->free(omega);
     }
   }

--- a/Transport/TransportParams.H
+++ b/Transport/TransportParams.H
@@ -159,6 +159,10 @@ struct TransParm<eos::SRK, SimpleTransport>
   amrex::Real* Afac = nullptr;
   amrex::Real* Bfac = nullptr;
   amrex::Real* Sigmaij = nullptr;
+  amrex::Real* sqrtT2ij = nullptr;
+  amrex::Real* sqrtEpsilonij = nullptr;
+  amrex::Real* sqrtMWij = nullptr;
+  amrex::Real* sqrtKappaij = nullptr;
   amrex::Real* Kappai = nullptr;
   amrex::Real* omega = nullptr;
   bool m_allocated{false};
@@ -220,6 +224,14 @@ struct TransParm<eos::SRK, SimpleTransport>
       Kappai = (amrex::Real*)amrex::The_Arena()->alloc(
         sizeof(amrex::Real) * NUM_SPECIES);
       Sigmaij = (amrex::Real*)amrex::The_Arena()->alloc(
+        sizeof(amrex::Real) * NUM_SPECIES * NUM_SPECIES);
+      sqrtT2ij = (amrex::Real*)amrex::The_Arena()->alloc(
+        sizeof(amrex::Real) * NUM_SPECIES * NUM_SPECIES);
+      sqrtEpsilonij = (amrex::Real*)amrex::The_Arena()->alloc(
+        sizeof(amrex::Real) * NUM_SPECIES * NUM_SPECIES);
+      sqrtMWij = (amrex::Real*)amrex::The_Arena()->alloc(
+        sizeof(amrex::Real) * NUM_SPECIES * NUM_SPECIES);
+      sqrtKappaij = (amrex::Real*)amrex::The_Arena()->alloc(
         sizeof(amrex::Real) * NUM_SPECIES * NUM_SPECIES);
 
       // Initialize coefficients of model
@@ -326,6 +338,15 @@ struct TransParm<eos::SRK, SimpleTransport>
           }
         }
       }
+      for (int i = 0; i < NUM_SPECIES; ++i) {
+        for (int j = 0; j < NUM_SPECIES; ++j) {
+	  const int idx = i * NUM_SPECIES + j;
+          sqrtT2ij[idx] = std::sqrt(trans_sig[i] + trans_sig[j]);
+	  sqrtEpsilonij[idx] = std::sqrt(trans_eps[i] * trans_eps[j]);
+	  sqrtMWij[idx] = std::sqrt(2.0 / (trans_iwt[i] + trans_iwt[j]));
+	  sqrtKappaij[idx] = std::sqrt(Kappai[i] * Kappai[j]);
+        }
+      }
       m_allocated = true;
     }
   }
@@ -349,6 +370,10 @@ struct TransParm<eos::SRK, SimpleTransport>
       amrex::The_Arena()->free(Bfac);
       amrex::The_Arena()->free(Kappai);
       amrex::The_Arena()->free(Sigmaij);
+      amrex::The_Arena()->free(sqrtT2ij);
+      amrex::The_Arena()->free(sqrtEpsilonij);
+      amrex::The_Arena()->free(sqrtMWij);
+      amrex::The_Arena()->free(sqrtKappaij);
       amrex::The_Arena()->free(omega);
     }
   }

--- a/Transport/TransportParams.H
+++ b/Transport/TransportParams.H
@@ -334,7 +334,7 @@ struct TransParm<eos::SRK, SimpleTransport>
       for (int i = 0; i < NUM_SPECIES; ++i) {
         for (int j = 0; j < NUM_SPECIES; ++j) {
 	  const int idx = i * NUM_SPECIES + j;
-          sqrtT2ij[idx] = std::sqrt(trans_sig[i] + trans_sig[j]);
+          sqrtT2ij[idx] = std::sqrt(trans_sig[i] * trans_sig[j]);
 	  sqrtEpsilonij[idx] = std::sqrt(trans_eps[i] * trans_eps[j]);
 	  sqrtMWij[idx] = std::sqrt(2.0 / (trans_iwt[i] + trans_iwt[j]));
 	  sqrtKappaij[idx] = std::sqrt(Kappai[i] * Kappai[j]);


### PR DESCRIPTION
Speed up Simple transport for SRK EOS by precomputing:
- square roots in an Nspec^2 loop
- a bunch of multiplications in an Nspec^3 loop (most of the performance impact)

Requires storing an Nspec^3 array in trans_parm, but reduces the cost of transport coefficient calculations by about 2x. For PeleC's PMF-SRK with drm19 on CPU and rk64 chemistry, this leads to ~20% overall reduction in cost. On GPU, the speedup is smaller (a few %), but could be larger if Sundials reduces the cost of chemistry integration. 

Draft until tested more thoroughly