### PR TITLE
Add error check for pmf file, add turbinflow files and test code

### DIFF
--- a/Testing/Exec/TurbInflow/GNUmakefile
+++ b/Testing/Exec/TurbInflow/GNUmakefile
@@ -1,0 +1,24 @@
+# AMReX
+DIM        = 3
+PRECISION  = DOUBLE
+PROFILE    = FALSE
+VERBOSE    = FALSE
+DEBUG      = FALSE
+
+# Compiler
+COMP	   = gnu
+USE_MPI    = FALSE
+USE_OMP    = FALSE
+USE_CUDA   = FALSE
+USE_HIP    = FALSE
+
+Eos_Model       = GammaLaw
+Chemistry_Model = Null
+Reactions_dir   = null
+Transport_Model = Constant
+
+CEXE_sources += main.cpp
+Bpack   := $(PELE_PHYSICS_HOME)/Utility/Make.package
+Blocs   := . $(PELE_PHYSICS_HOME)/Utility
+
+include $(PELE_PHYSICS_HOME)/Testing/Exec/Make.PelePhysics

--- a/Testing/Exec/TurbInflow/main.cpp
+++ b/Testing/Exec/TurbInflow/main.cpp
@@ -1,0 +1,252 @@
+#include <iostream>
+
+#include "AMReX_ParmParse.H"
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_DataServices.H>
+#include <PlotFileFromMF.H>
+#include <turbinflow.H>
+
+using namespace amrex;
+
+Vector<int>
+encodeStringForFortran(const std::string& astr)
+{
+  long length = astr.size();
+  Vector<int> result(length);
+  for (int i = 0; i < length; ++i)
+    result[i] = astr[i];
+  return result;
+}
+
+static
+void
+Extend (FArrayBox& xfab,
+        FArrayBox& vfab,
+        const Box& domain)
+{
+  Box tbx = vfab.box();
+
+  tbx.setBig(0, domain.bigEnd(0) + 3);
+
+  const int ygrow = BL_SPACEDIM==3 ? 3 : 1;
+
+  tbx.setBig(1, domain.bigEnd(1) + ygrow);
+
+  xfab.resize(tbx,1);
+
+  Box orig_box = vfab.box();
+  vfab.shift(0, 1);
+  vfab.shift(1, 1);
+  xfab.copy(vfab); // (0,0)
+
+  vfab.shift(0, domain.length(0)); // (1,0)
+  xfab.copy(vfab);
+  vfab.shift(1, domain.length(1)); // (1,1)
+  xfab.copy(vfab);
+  vfab.shift(0, -domain.length(0)); // (0,1)
+  xfab.copy(vfab);
+  vfab.shift(0, -domain.length(0)); // (-1,1)
+  xfab.copy(vfab);
+  vfab.shift(1, -domain.length(1)); // (-1,0)
+  xfab.copy(vfab);
+  vfab.shift(1, -domain.length(1)); // (-1,-1)
+  xfab.copy(vfab);
+  vfab.shift(0, domain.length(0)); // (0,-1)
+  xfab.copy(vfab);
+  vfab.shift(0, domain.length(0)); // (1,-1)
+  xfab.copy(vfab);
+  vfab.shift(0, -domain.length(0) - 1);
+  vfab.shift(1,  domain.length(1) - 1);
+
+  if (vfab.box() != orig_box) Abort("Oops, something bad happened");
+}
+
+int
+main (int   argc,
+      char* argv[])
+{
+  Initialize(argc,argv);
+  {
+    ParmParse pp;
+
+    std::string pltfile("plt");  pp.query("plotfile",pltfile);
+    
+    TurbParm tp;
+    // Hold nose here - required because of dynamically allocated data in tp
+    tp.tph = new TurbParmHost();
+
+    std::string turb_file("Turb");
+    
+    if (pp.countval("turb_file") > 0) {
+      pp.get("turb_file", turb_file);
+    }
+    else
+    { 
+      if (ParallelDescriptor::IOProcessor())
+        if (!UtilCreateDirectory(turb_file, 0755))
+          CreateDirectoryFailed(turb_file);
+
+      std::string Hdr = turb_file; Hdr += "/HDR";
+      std::string Dat = turb_file; Dat += "/DAT";
+
+      std::ofstream ifsd, ifsh;
+
+      ifsh.open(Hdr.c_str(), std::ios::out|std::ios::trunc);
+      if (!ifsh.good())
+        FileOpenFailed(Hdr);
+
+      ifsd.open(Dat.c_str(), std::ios::out|std::ios::trunc);
+      if (!ifsd.good())
+        FileOpenFailed(Dat);
+
+      Box box_turb(IntVect(D_DECL(0,0,0)),
+                   IntVect(D_DECL(63,63,63)));
+      RealBox rb_turb({D_DECL(0,0,0)},
+                      {D_DECL(1,1,1)});
+      int coord_turb(0);
+      Array<int,BL_SPACEDIM> per_turb = {D_DECL(1,1,1)};
+      Geometry geom_turb(box_turb,rb_turb,coord_turb,per_turb);
+      const Real* dx_turb = geom_turb.CellSize();
+
+      //
+      // Write the first part of the Turb header.
+      // Note that this is solely for periodic style inflow files.
+      //
+      Box box_turb_io(box_turb);
+      box_turb_io.setBig(0, box_turb.bigEnd(0) + 3);
+      box_turb_io.setBig(1, box_turb.bigEnd(1) + 3);
+      box_turb_io.setBig(2, box_turb.bigEnd(2) + 1);
+
+      ifsh << box_turb_io.length(0) << ' '
+           << box_turb_io.length(1) << ' '
+           << box_turb_io.length(2) << '\n';
+
+      ifsh << rb_turb.length(0) + 2*dx_turb[0] << ' '
+           << rb_turb.length(1) + 2*dx_turb[1] << ' '
+           << rb_turb.length(2)                << '\n';
+
+      ifsh << per_turb[0] << ' ' << per_turb[1] << ' ' << per_turb[2] << '\n';
+
+      // Create a field to shove in
+      FArrayBox vel_turb(box_turb,BL_SPACEDIM);
+      Array4<Real> const& fab = vel_turb.array();
+      AMREX_PARALLEL_FOR_3D ( box_turb, i, j, k,
+                              {
+                                Real x = (i+0.5)*dx_turb[0] + rb_turb.lo()[0];
+                                Real y = (j+0.5)*dx_turb[1] + rb_turb.lo()[1];
+                                Real z = (k+0.5)*dx_turb[2] + rb_turb.lo()[2];
+                                Real blobr = 0.25 * (rb_turb.hi()[0] - rb_turb.lo()[0]);
+                                Real blobx = 0.5 * (rb_turb.hi()[0] + rb_turb.lo()[0]);
+                                Real bloby = 0.5 * (rb_turb.hi()[0] + rb_turb.lo()[0]);
+                                Real blobz = 0.5 * (rb_turb.hi()[0] + rb_turb.lo()[0]);
+                                Real r = std::sqrt((x-blobx)*(x-blobx) +
+                                                   (y-bloby)*(y-bloby) +
+                                                   (z-blobz)*(z-blobz));
+                                fab(i,j,k,0) = r <= blobr ? 1 : 0;
+                                fab(i,j,k,1) = 2.;
+                                fab(i,j,k,2) = 3.;
+                              });
+
+      BoxArray ba(box_turb);
+      DistributionMapping dm(ba);
+      MultiFab vel(ba,dm,BL_SPACEDIM,0);
+      if (dm[0]==ParallelDescriptor::MyProc()) {
+        vel[0].copy(vel_turb);
+      }
+      PlotFileFromMF(vel,Concatenate(pltfile,0));
+
+      // Dump field as a "turbulence file"
+      IntVect sm = box_turb.smallEnd();
+      IntVect bg = box_turb.bigEnd();
+      int dir = BL_SPACEDIM - 1;
+      FArrayBox xfab,TMP;
+      //
+      // We work on one cell wide Z-planes.
+      // We first do the lo BL_SPACEDIM plane.
+      // And then all the other planes in xhi -> xlo order.
+      //
+      for (int d = 0; d < BL_SPACEDIM; ++d)
+      {
+        bg[dir] = sm[dir];
+        {
+          Box bx(sm,bg);
+          TMP.resize(bx,1);
+          TMP.copy(vel_turb,bx,d,bx,0,1);
+          Extend(xfab, TMP, box_turb);
+          ifsh << ifsd.tellp() << std::endl;
+          xfab.writeOn(ifsd);
+        }
+        for (int i = box_turb.bigEnd(dir); i >= box_turb.smallEnd(dir); i--)
+        {
+          sm[dir] = i;
+          bg[dir] = i;
+          Box bx(sm,bg);
+          TMP.resize(bx,1);
+          TMP.copy(vel_turb,bx,d,bx,0,1);
+          Extend(xfab, TMP, box_turb);
+          ifsh << ifsd.tellp() << std::endl;
+          xfab.writeOn(ifsd);
+        }
+      }
+    }
+    // Now that turbulence file written, read from it to fill the result
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+    {
+      amrex::Real turb_scale_loc = 1.0;
+      pp.query("turb_scale_loc", turb_scale_loc);
+      amrex::Real turb_scale_vel = 1.0;
+      pp.query("turb_scale_vel", turb_scale_vel);
+
+      amrex::Vector<amrex::Real> turb_center = {{0,0}}; //{{0.5 * (probhi[0] + problo[0]), 0.5 * (probhi[1] + problo[1])}};
+      pp.queryarr("turb_center",turb_center);
+      AMREX_ASSERT_WITH_MESSAGE(turb_center.size()==2,"turb_center must have two elements");
+      for (int n=0; n<turb_center.size(); ++n) {
+        turb_center[n] *= turb_scale_loc;
+      }
+      int turb_nplane = 32;
+      pp.query("turb_nplane",turb_nplane);
+      AMREX_ASSERT(turb_nplane > 0);
+      amrex::Real turb_conv_vel = 1;
+      pp.query("turb_conv_vel",turb_conv_vel);
+      AMREX_ASSERT(turb_conv_vel > 0);
+      init_turbinflow(turb_file,turb_scale_loc,turb_scale_vel,turb_center,turb_conv_vel,turb_nplane,tp);
+    }
+    
+    Box box_res(IntVect(D_DECL(0,0,0)),
+                IntVect(D_DECL(255,255,127)));
+    RealBox rb_res({D_DECL(-1,-1,0)},
+                   {D_DECL(1,1,1)});
+    pp.query("box_res",box_res);
+    Vector<Real> dlo(BL_SPACEDIM), dhi(BL_SPACEDIM);
+    if (pp.countval("dlo")>0) {
+      pp.getarr("dlo",dlo,0,BL_SPACEDIM);
+      pp.getarr("dhi",dhi,0,BL_SPACEDIM);
+      rb_res = RealBox(&(dlo[0]),&(dhi[0]));
+    }
+    int coord_res(0);
+    Array<int,BL_SPACEDIM> per_res = {D_DECL(1,1,1)};
+    Geometry geom_res(box_res,rb_res,coord_res,per_res);
+    Box domain = geom_res.Domain();
+    BoxArray ba_res(domain);
+    ba_res.maxSize(16);
+    DistributionMapping dmap_res(ba_res);
+    MultiFab mf_res(ba_res,dmap_res,BL_SPACEDIM,0);
+
+    mf_res.setVal(0);
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+    for (MFIter mfi(mf_res,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+      const Box& box = mfi.tilebox();
+
+      fill_with_turb(box,mf_res[mfi],0,geom_res,tp);
+    }
+    
+    std::string outfile = Concatenate(pltfile,1); // Need a number other than zero for reg test to pass
+    PlotFileFromMF(mf_res,outfile);
+  }
+  Finalize();
+}

--- a/Utility/Make.package
+++ b/Utility/Make.package
@@ -1,5 +1,5 @@
-CEXE_sources += pmf.cpp pmf_data.cpp
-CEXE_headers += pmf.H pmf_data.H
+CEXE_sources += pmf.cpp pmf_data.cpp turbinflow.cpp
+CEXE_headers += pmf.H pmf_data.H turbinflow.H
 
 VPATH_LOCATIONS += $(PELE_PHYSICS_HOME)/Utility
 INCLUDE_LOCATIONS += $(PELE_PHYSICS_HOME)/Utility

--- a/Utility/pmf.cpp
+++ b/Utility/pmf.cpp
@@ -45,6 +45,9 @@ PMF::read_pmf(const std::string& myfile, bool do_average)
   int variable_count, line_count;
 
   std::ifstream infile(myfile);
+  if (!infile.is_open()) {
+    amrex::Abort("Unable to open pmf input file " + myfile);
+  }
   const std::string memfile = read_pmf_file(infile);
   infile.close();
   std::istringstream iss(memfile);

--- a/Utility/turbinflow.H
+++ b/Utility/turbinflow.H
@@ -1,0 +1,64 @@
+#ifndef _turbinflow_H_
+#define _turbinflow_H_
+
+#include <AMReX_FArrayBox.H>
+#include <AMReX_GpuMemory.H>
+#include <AMReX_Geometry.H>
+
+struct TurbParmHost
+{
+  amrex::Gpu::DeviceVector<long> offset_dv;
+  std::string turb_file = "";
+};
+
+struct TurbParm
+{
+  amrex::GpuArray<int, AMREX_SPACEDIM> npboxcells = {{0}};
+  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> pboxlo = {{0.0}};
+  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = {{0.0}};
+  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dxinv = {{0.0}};
+  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> pboxsize = {{0.0}};
+
+  int nplane = 32;
+  amrex::FArrayBox* sdata = nullptr;
+  amrex::Real szlo = 0.0;
+  amrex::Real szhi = 0.0;
+  bool isswirltype = false;
+  amrex::Real turb_scale_loc = 1.;
+  amrex::Real turb_scale_vel = 1.;
+  amrex::Real turb_conv_vel = 1.;
+  bool turbinflow_initialized = false;
+  bool turbinflow_planes_initialized = false;
+  int kmax;
+  long* offset;
+  long offset_size;
+  TurbParmHost* tph = nullptr;
+};
+
+void
+init_turbinflow(const std::string& turb_file,
+                amrex::Real        turb_scale_loc,
+                amrex::Real        turb_scale_vel,
+                const amrex::Vector<amrex::Real>& turb_center,
+                amrex::Real        turb_conv_vel,
+                int                nplane,
+                TurbParm&          tp);
+
+void
+add_turb(amrex::Box const&               bx,
+         amrex::FArrayBox&               data,
+         const int                       dcomp,
+         amrex::Geometry const&          geom,
+         const amrex::Real               time,
+         const int                       dir,
+         const amrex::Orientation::Side& side,
+         TurbParm&                       tp);
+
+void
+fill_with_turb(amrex::Box const&      bx,
+               amrex::FArrayBox&      data,
+               const int              dcomp,
+               amrex::Geometry const& geom,
+               TurbParm&              tp);
+
+#endif

--- a/Utility/turbinflow.cpp
+++ b/Utility/turbinflow.cpp
@@ -1,0 +1,302 @@
+#include <turbinflow.H>
+
+void
+init_turbinflow(const std::string& turb_file,
+                amrex::Real        turb_scale_loc,
+                amrex::Real        turb_scale_vel,
+                const amrex::Vector<amrex::Real>& turb_center,
+                amrex::Real        turb_conv_vel,
+                int                nplane,
+                TurbParm&          tp)
+{
+  amrex::Print() << "Initializing turbulence file: " << turb_file
+                 << " (location coordinates in will be scaled by " << turb_scale_loc
+                 << " and velocity out to be scaled by " << turb_scale_vel << ")" << std::endl;
+
+  tp.tph->turb_file = turb_file;
+  tp.nplane = nplane;
+  tp.turb_conv_vel = turb_conv_vel;
+  tp.turb_scale_loc = turb_scale_loc;
+  tp.turb_scale_vel = turb_scale_vel;
+
+  std::string turb_header = tp.tph->turb_file + "/HDR";
+  std::ifstream is(turb_header.c_str());
+  if (!is.is_open()) {
+    amrex::Abort("Unable to open input file " + turb_header);
+  }
+  amrex::Array<int, AMREX_SPACEDIM> npts = {{0}};
+  amrex::Array<amrex::Real, AMREX_SPACEDIM> probsize = {{0}};
+  amrex::Array<int, AMREX_SPACEDIM> iper = {{0}};
+  is >> npts[0] >> npts[1] >> npts[2];
+  is >> probsize[0] >> probsize[1] >> probsize[2];
+  is >> iper[0] >> iper[1] >> iper[2]; // Unused - we assume it is always fully periodic
+
+  for (int n=0; n<AMREX_SPACEDIM; ++n) {
+    tp.dx[n] = probsize[n] / amrex::Real(npts[n]-1);
+    tp.dxinv[n] = 1.0/tp.dx[n];
+  }
+
+  // one ghost point on each side, tangential to inflow face
+  tp.pboxsize[0] = probsize[0] - 2.0*tp.dx[0];
+  tp.pboxsize[1] = probsize[1] - 2.0*tp.dx[1];
+  tp.pboxsize[2] = probsize[2];
+  
+  tp.npboxcells[0] = npts[0] - 3;
+  tp.npboxcells[1] = npts[1] - 3;
+  tp.npboxcells[2] = npts[2];
+
+  // Center the turbulence)
+  tp.pboxlo[0] = turb_center[0] - 0.5 * tp.pboxsize[0];
+  tp.pboxlo[1] = turb_center[1] - 0.5 * tp.pboxsize[1];
+  tp.pboxlo[2] = 0.;
+
+  amrex::Box sbx(amrex::IntVect(AMREX_D_DECL(1,1,1)),
+                 amrex::IntVect(AMREX_D_DECL(npts[0], npts[1], tp.nplane)));
+
+  tp.sdata = new amrex::FArrayBox(sbx,3);
+
+  tp.kmax = npts[2];
+
+  amrex::Real rdummy;
+  if (tp.isswirltype) {
+    for (int i = 0; i < tp.kmax; i++) {
+      is >> rdummy; // Time for each plane - unused at the moment
+    }
+  }
+  tp.tph->offset_dv.resize(tp.kmax*AMREX_SPACEDIM);
+  tp.offset = tp.tph->offset_dv.data();
+  tp.offset_size = tp.tph->offset_dv.size();
+  for (int i = 0; i < tp.offset_size; i++) {
+    is >> tp.offset[i];
+  }  
+  is.close();
+
+  tp.turbinflow_initialized = true;
+}
+
+void
+read_one_turb_plane(int       iplane,
+                    int       k,
+                    TurbParm& tp)
+{
+  //
+  // There are AMREX_SPACEDIM * kmax planes of FABs.
+  // The first component are in the first kmax planes,
+  // the second component in the next kmax planes, ....
+  // Note also that both (*plane) and (*ncomp) start from
+  // 1 not 0 since they're passed from Fortran.
+  //
+  std::string turb_data = tp.tph->turb_file + "/DAT";
+  std::ifstream ifs(turb_data.c_str());
+  if (!ifs.is_open()) {
+    amrex::Abort("Unable to open input file " + turb_data);
+  }
+  
+  amrex::Box dstBox = tp.sdata->box();
+  dstBox.setSmall(2,iplane);
+  dstBox.setBig(  2,iplane);
+
+  for (int n=0; n<AMREX_SPACEDIM; ++n) {
+
+    const long offset_idx = (k + 1) + (n * tp.kmax);
+    AMREX_ASSERT_WITH_MESSAGE(offset_idx < tp.offset_size, "Bad turb fab offset idx");
+    
+    const long start = tp.offset[offset_idx];
+
+    ifs.seekg(start, std::ios::beg);
+
+    if (!ifs.good())
+      amrex::Abort("getplane(): seekg() failed");
+  
+    amrex::FArrayBox tmp;
+    tmp.readFrom(ifs);
+    amrex::Box srcBox = tmp.box();
+
+    tp.sdata->copy<amrex::RunOn::Device>(tmp,srcBox,0,dstBox,n,1);
+  }
+  ifs.close();
+}
+
+void
+read_turb_planes(amrex::Real z,
+                 TurbParm&   tp)
+{
+  int izlo = (int)(round(z * tp.dxinv[2])) - 1;
+  int izhi = izlo+tp.nplane-1;
+  tp.szlo = izlo*tp.dx[2];
+  tp.szhi = izhi*tp.dx[2];
+
+#if 0
+  amrex::Print() << "read_turb_planes filling " << izlo << " to " << izhi
+                 << " covering " << tp.szlo + 0.5 * tp.dx[2]
+                 << " to "       << tp.szhi - 0.5 * tp.dx[2] << " for z = " << z << std::endl;
+#endif  
+
+  for (int iplane=1; iplane<=tp.nplane; ++iplane) {
+    int k = (izlo+iplane-1) % (tp.npboxcells[2] - 2);
+    read_one_turb_plane(iplane,k,tp);
+  }
+  tp.turbinflow_planes_initialized = true;
+}
+
+void
+fill_turb_plane(const amrex::Vector<amrex::Real>& x,
+                const amrex::Vector<amrex::Real>& y,
+                amrex::Real                       z,
+                amrex::FArrayBox&                 v,
+                TurbParm&                         tp)
+{
+  if ((!tp.turbinflow_planes_initialized) || 
+      (z < tp.szlo + 0.5 * tp.dx[2])     ||
+      (z > tp.szhi - 0.5 * tp.dx[2]) )
+  {
+#if 0
+    if (!tp.turbinflow_planes_initialized) {
+      amrex::Print() << "Reading new data because planes uninitialized at z: " << z << std::endl;
+    }
+    else {
+      amrex::Print() << "Reading new data because z " << z << " is outside " << tp.szlo + 0.5 * tp.dx[2] << " and "
+                     << tp.szhi - 0.5 * tp.dx[2] << std::endl;
+    }
+#endif
+    read_turb_planes(z,tp);
+  }
+
+  const auto& bx = v.box();
+  const auto& vd = v.array();
+  const auto& sd = tp.sdata->array();
+
+  amrex::Gpu::DeviceVector<amrex::Real> x_dev(x.size());
+  amrex::Gpu::DeviceVector<amrex::Real> y_dev(y.size());
+  amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, x.begin(), x.end(), x_dev.begin());
+  amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, y.begin(), y.end(), y_dev.begin());
+  amrex::Real* xd = x_dev.data();
+  amrex::Real* yd = y_dev.data();
+  amrex::ParallelFor(bx, [z, sd, vd, tp, bx, xd, yd]
+  AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+  {
+    amrex::Real cx[3], cy[3], cz[3], ydata[3];
+    amrex::Real zdata[3][3];
+
+    amrex::Real zz = (z - tp.szlo) * tp.dxinv[2];
+    int k0 = (int)(std::round(zz)) - 1;
+    zz -= amrex::Real(k0);
+    cz[0] = 0.5 * (zz-1.0) * (zz - 2.0);
+    cz[1] = zz * (2.0 - zz);
+    cz[2] = 0.5 * zz * (zz - 1.0);
+    k0 += 2;
+    k0 = amrex::min(amrex::max(k0,1),tp.nplane-2);
+
+    for (int n=0; n<3; ++n) {
+      amrex::Real xx = (xd[i-bx.smallEnd(0)] - tp.pboxlo[0]) * tp.dxinv[0];
+      amrex::Real yy = (yd[j-bx.smallEnd(1)] - tp.pboxlo[1]) * tp.dxinv[1];
+      int i0 = (int)(std::round(xx));
+      int j0 = (int)(std::round(yy));
+      xx -= amrex::Real(i0);
+      yy -= amrex::Real(j0);
+      cx[0] = 0.5 * (xx - 1.0) * (xx - 2.0);
+      cy[0] = 0.5 * (yy - 1.0) * (yy - 2.0);
+      cx[1] = xx * (2.0 - xx);
+      cy[1] = yy * (2.0 - yy);
+      cx[2] = 0.5 * xx * (xx - 1.0);
+      cy[2] = 0.5 * yy * (yy - 1.0);
+
+      if (i0>=0 && i0<tp.npboxcells[0] && j0>=0 && j0<tp.npboxcells[1]) {
+        i0 += 2;
+        j0 += 2;
+        for (int ii=0; ii<=2; ++ii) {
+          for (int jj=0; jj<=2; ++jj) {
+            zdata[ii][jj] = cz[0]*sd(i0+ii,j0+jj,k0  ,n) 
+              +             cz[1]*sd(i0+ii,j0+jj,k0+1,n)
+              +             cz[2]*sd(i0+ii,j0+jj,k0+2,n);
+          }
+        }
+        for (int ii=0; ii<=2; ++ii) {
+          ydata[ii] = cy[0]*zdata[ii][0] + cy[1]*zdata[ii][1] + cy[2]*zdata[ii][2];
+        }
+        vd(i,j,k,n) = cx[0]*ydata[0] + cx[1]*ydata[1] + cx[2]*ydata[2];
+      }
+      else {
+        vd(i,j,k,n) = 0.0;
+      }
+    }
+  });
+  amrex::Gpu::synchronize(); // Ensure that DeviceVector's don't leave scope early
+}
+
+void
+add_turb(amrex::Box const&               bx,
+         amrex::FArrayBox&               data,
+         const int                       dcomp,
+         amrex::Geometry const&          geom,
+         const amrex::Real               time,
+         const int                       dir,
+         const amrex::Orientation::Side& side,
+         TurbParm&                       tp)
+{
+  AMREX_ASSERT_WITH_MESSAGE(dir == 2, "Sadly, the fluctuation code currently only works in the third dimension");
+  AMREX_ASSERT(tp.turbinflow_initialized);
+  
+  amrex::Box bvalsBox = bx;
+  int planeLoc = ( side == amrex::Orientation::low
+                   ? geom.Domain().smallEnd()[dir]-1
+                   : geom.Domain().bigEnd()[dir]  +1 );
+  bvalsBox.setSmall(dir,planeLoc);
+  bvalsBox.setBig(  dir,planeLoc);
+
+  amrex::FArrayBox v(bvalsBox,3);
+
+  amrex::Vector<amrex::Real> x(bvalsBox.size()[0]), y(bvalsBox.size()[1]);
+  for (int i=bvalsBox.smallEnd()[0]; i<=bvalsBox.bigEnd()[0]; ++i) {
+    x[i-bvalsBox.smallEnd()[0]] = (geom.ProbLo()[0] + (i+0.5)*geom.CellSize(0)) * tp.turb_scale_loc;
+  }
+  for (int j=bvalsBox.smallEnd()[1]; j<=bvalsBox.bigEnd()[1]; ++j) {
+    y[j-bvalsBox.smallEnd()[1]] = (geom.ProbLo()[1] + (j+0.5)*geom.CellSize(1)) * tp.turb_scale_loc;
+  }
+
+  v.setVal<amrex::RunOn::Device>(0);
+  amrex::Real z = time * tp.turb_conv_vel * tp.turb_scale_loc;
+  fill_turb_plane(x, y, z, v, tp);
+  if (side == amrex::Orientation::high) {
+    v.mult<amrex::RunOn::Device>(-tp.turb_scale_vel);
+  } else {
+    v.mult<amrex::RunOn::Device>( tp.turb_scale_vel);
+  }
+  amrex::Box ovlp = bvalsBox & data.box();
+  data.plus<amrex::RunOn::Device>(v,ovlp,0,dcomp,AMREX_SPACEDIM);
+}
+
+void
+fill_with_turb(amrex::Box const&      bx,
+               amrex::FArrayBox&      data,
+               const int              dcomp,
+               amrex::Geometry const& geom,
+               TurbParm&              tp)
+{
+  int dir = 2;
+  AMREX_ASSERT(tp.turbinflow_initialized);
+
+  for (int planeloc = bx.smallEnd()[2]; planeloc<=bx.bigEnd()[2]; ++planeloc) {
+    amrex::Box bvalsBox = bx;
+    bvalsBox.setSmall(dir,planeloc);
+    bvalsBox.setBig(  dir,planeloc);
+
+    amrex::FArrayBox v(bvalsBox,3);
+    v.setVal<amrex::RunOn::Device>(0);
+
+    amrex::Vector<amrex::Real> x(bvalsBox.size()[0]), y(bvalsBox.size()[1]);
+    for (int i=bvalsBox.smallEnd()[0]; i<=bvalsBox.bigEnd()[0]; ++i) {
+      x[i-bvalsBox.smallEnd()[0]] = (geom.ProbLo()[0] + (i+0.5)*geom.CellSize(0)) * tp.turb_scale_loc;
+    }
+    for (int j=bvalsBox.smallEnd()[1]; j<=bvalsBox.bigEnd()[1]; ++j) {
+      y[j-bvalsBox.smallEnd()[1]] = (geom.ProbLo()[1] + (j+0.5)*geom.CellSize(1)) * tp.turb_scale_loc;
+    }
+
+    amrex::Real z = (geom.ProbLo()[2] + (planeloc+0.5)*geom.CellSize(2)) * tp.turb_scale_loc;
+    fill_turb_plane(x, y, z, v, tp);
+    v.mult<amrex::RunOn::Device>(tp.turb_scale_vel);
+    amrex::Box ovlp = bvalsBox & data.box();
+    data.copy<amrex::RunOn::Device>(v,ovlp,0,ovlp,dcomp,AMREX_SPACEDIM);
+  }
+}
+


### PR DESCRIPTION
The test code reads a turbulence file and uses it to initialize a MultiFab and write it as a plot file.  If run without specifying the turb_dir, it will create a "turbulence" file first (actually, just a simple 3-component field), write it in the correct format, then read that file and create the output.  Thus, the test demonstrates how to create the data file expected by the turbinflow code, and then how to set up the interpolation stuff to read it and initialize data with it.  This commit adds turbinflow.{H,cpp} to the PeleC build (always).  I also added an unrelated error check to ensure the pmf datafile is properly opened.