### PR TITLE
static_asserts for transport and eos models

### DIFF
--- a/Eos/EOS.H
+++ b/Eos/EOS.H
@@ -22,7 +22,7 @@ using EosType = eos::Fuego;
 #elif USE_SRK_EOS
 using EosType = eos::SRK;
 #else
-static_assert(true, "Invalid EOS specified");
+static_assert(false, "Invalid EOS specified");
 #endif
 namespace eos {
 

--- a/Transport/TransportTypes.H
+++ b/Transport/TransportTypes.H
@@ -15,7 +15,7 @@ using TransportType = transport::SimpleTransport;
 #elif USE_SUTHERLAND_TRANSPORT
 using TransportType = transport::SutherlandTransport;
 #else
-static_assert(true, "Invalid Transport specified");
+static_assert(false, "Invalid Transport specified");
 #endif
 } // namespace physics
 } // namespace pele


### PR DESCRIPTION
Fixes error checking for when invalid transport or EOS models are specified.