### PR TITLE
Fix Analytical Jacobian options on GPU.

### DIFF
--- a/Reactions/ReactorCvode.cpp
+++ b/Reactions/ReactorCvode.cpp
@@ -1137,7 +1137,7 @@ ReactorCvode::react(
 
   amrex::Gpu::streamSynchronize();
   SUNMatrix A = NULL;
-  CVODEUserData* user_data = new CVODEUserData{};
+  CVODEUserData* user_data = (CVODEUserData*)amrex::The_Arena()->alloc(sizeof(struct CVODEUserData));
   allocUserData(user_data, ncells, A, stream);
 
   // Fill data
@@ -1758,7 +1758,7 @@ ReactorCvode::freeUserData(CVODEUserData* data_wk)
     cudaFree(data_wk->buffer_qr);
 #endif
   }
-  delete data_wk;
+  amrex::The_Arena()->free(data_wk);
 
 #else
   amrex::The_Arena()->free(data_wk->FCunt);

--- a/Reactions/ReactorCvode.cpp
+++ b/Reactions/ReactorCvode.cpp
@@ -1137,7 +1137,8 @@ ReactorCvode::react(
 
   amrex::Gpu::streamSynchronize();
   SUNMatrix A = NULL;
-  CVODEUserData* user_data = (CVODEUserData*)amrex::The_Arena()->alloc(sizeof(struct CVODEUserData));
+  CVODEUserData* user_data =
+    (CVODEUserData*)amrex::The_Arena()->alloc(sizeof(struct CVODEUserData));
   allocUserData(user_data, ncells, A, stream);
 
   // Fill data
@@ -1408,7 +1409,8 @@ ReactorCvode::react(
 
   // Fill user_data
   amrex::Gpu::streamSynchronize();
-  CVODEUserData* user_data = new CVODEUserData{};
+  CVODEUserData* user_data =
+    (CVODEUserData*)amrex::The_Arena()->alloc(sizeof(struct CVODEUserData));
   allocUserData(user_data, ncells, A, stream);
 
   // Solution vector and execution policy


### PR DESCRIPTION
CVODEUserdata need to allocated with The_Arena when working on GPU otherwise the analytical jacobian data are not accessible.