### PR TITLE
clip C before reaction rate calculations

### DIFF
--- a/Eos/Fuego.H
+++ b/Eos/Fuego.H
@@ -168,7 +168,7 @@ struct Fuego
 
     // Do not allow negative C for wdot calculation
     for (int ii = 0; ii < NUM_SPECIES; ++ii) {
-      C[ii] = amrex::max(C[ii],0.0);
+      C[ii] = amrex::max(C[ii], 0.0);
     }
 
     CKWC(&T, C, WDOT);

--- a/Eos/Fuego.H
+++ b/Eos/Fuego.H
@@ -165,6 +165,12 @@ struct Fuego
     // CKWYR(&R, &T, Y, WDOT);
     amrex::Real C[NUM_SPECIES];
     CKYTCR(&R, &T, Y, C);
+
+    // Do not allow negative C for wdot calculation
+    for (int ii = 0; ii < NUM_SPECIES; ++ii) {
+      C[ii] = amrex::max(C[ii],0.0);
+    }
+
     CKWC(&T, C, WDOT);
 
     amrex::Real mw[NUM_SPECIES];

--- a/Eos/SRK.H
+++ b/Eos/SRK.H
@@ -555,6 +555,12 @@ struct SRK
   {
     amrex::Real C[NUM_SPECIES];
     RTY2C(R, T, Y, C);
+
+    // Do not allow negative C for wdot calculation
+    for (int ii = 0; ii < NUM_SPECIES; ++ii) {
+      C[ii] = amrex::max(C[ii],0.0);
+    }
+
     CKWC(&T, C, WDOT);
 
     amrex::Real mw[NUM_SPECIES];

--- a/Eos/SRK.H
+++ b/Eos/SRK.H
@@ -558,7 +558,7 @@ struct SRK
 
     // Do not allow negative C for wdot calculation
     for (int ii = 0; ii < NUM_SPECIES; ++ii) {
-      C[ii] = amrex::max(C[ii],0.0);
+      C[ii] = amrex::max(C[ii], 0.0);
     }
 
     CKWC(&T, C, WDOT);


### PR DESCRIPTION
Opening this for discussion in conjunction with Marc's PeleC pull requests https://github.com/AMReX-Combustion/PeleC/pull/381 and https://github.com/AMReX-Combustion/PeleC/pull/380

Don't allow negative C when computing WDOT. This is similar in spirit to the "clean_massfrac" function in PeleC, but applies only to reaction rates and only clips negatives. clean_massfrac seems to help things often, but can create issues of its own - perhaps due to rescaling. In contrast, I think this is something that can be safely left on all the time.

Say you have a reaction `A + A -> products` and A is negative, or `A + B -> products` and A,B are both small negative values for whatever reason. Then the consumption rate of A is positive (k_f*negative*negative), so A will get smaller - making it more negative, and leading to a runaway. This change prevents that - once A became negative it's consumption rate would always be 0, preventing runaway. A downside is that for unimolecular consumption of A, allowing negative mass fractions for reaction rate computation has a stabilizing effect (A would have a negative consumption rate, aka production, driving it toward 0/positivity).