### PR TITLE
Remove virtual call from PMF destructor.

### DIFF
--- a/Utility/PMF/PMFData.H
+++ b/Utility/PMF/PMFData.H
@@ -16,7 +16,7 @@ class PmfData
 public:
   PmfData() {}
 
-  ~PmfData() { deallocate(); }
+  ~PmfData() {}
 
   void initialize()
   {


### PR DESCRIPTION
since it caused `pure virtual method called` when PMF goes out of scope. One needs to explicitly call PMFData.deallocate().