### PR TITLE
Refactor turbulence inflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: DoozyX/clang-format-lint-action@v0.11
         with:
-          source: './Eos ./Transport ./Reactions ./Utility/PMF'
+          source: './Eos ./Transport ./Reactions ./Utility/PMF ./Utility/TurbInflow'
           exclude: '.'
           extensions: 'H,h,cpp'
           clangFormatVersion: 11

--- a/Utility/TurbInflow/turbinflow.H
+++ b/Utility/TurbInflow/turbinflow.H
@@ -50,7 +50,6 @@ public:
 
   bool is_initialized() const { return turbinflow_initialized; }
 
-private:
   void read_turb_planes(amrex::Real z);
 
   void read_one_turb_plane(int iplane, int k);
@@ -75,6 +74,7 @@ private:
     amrex::FArrayBox& data,
     const int dcomp);
 
+private:
   std::string m_turb_file = "";
 
   TurbParm tp;

--- a/Utility/TurbInflow/turbinflow.H
+++ b/Utility/TurbInflow/turbinflow.H
@@ -4,12 +4,11 @@
 #include <AMReX_FArrayBox.H>
 #include <AMReX_GpuMemory.H>
 #include <AMReX_Geometry.H>
+#include <AMReX_ParmParse.H>
 
-struct TurbParmHost
-{
-  amrex::Gpu::DeviceVector<long> offset_dv;
-  std::string turb_file = "";
-};
+namespace pele {
+namespace physics {
+namespace turbinflow {
 
 struct TurbParm
 {
@@ -18,7 +17,6 @@ struct TurbParm
   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = {{0.0}};
   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dxinv = {{0.0}};
   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> pboxsize = {{0.0}};
-
   int nplane = 32;
   amrex::FArrayBox* sdata = nullptr;
   amrex::Real szlo = 0.0;
@@ -27,42 +25,69 @@ struct TurbParm
   amrex::Real turb_scale_loc = 1.;
   amrex::Real turb_scale_vel = 1.;
   amrex::Real turb_conv_vel = 1.;
-  bool turbinflow_initialized = false;
-  bool turbinflow_planes_initialized = false;
   int kmax;
   long* offset;
   long offset_size;
-  TurbParmHost* tph = nullptr;
 };
 
-void init_turbinflow(
-  const std::string& turb_file,
-  amrex::Real turb_scale_loc,
-  amrex::Real turb_scale_vel,
-  const amrex::Vector<amrex::Real>& turb_center,
-  amrex::Real turb_conv_vel,
-  int nplane,
-  TurbParm& tp);
+struct TurbInflow
+{
+public:
+  TurbInflow(){};
 
-void add_turb(
-  amrex::Box const& bx,
-  amrex::FArrayBox& data,
-  const int dcomp,
-  amrex::Geometry const& geom,
-  const amrex::Real time,
-  const int dir,
-  const amrex::Orientation::Side& side,
-  TurbParm& tp);
+  ~TurbInflow() = default;
 
-void fill_with_turb(
-  amrex::Box const& bx,
-  amrex::FArrayBox& data,
-  const int dcomp,
-  amrex::Geometry const& geom,
-  TurbParm& tp);
+  void init(const amrex::Vector<amrex::Real>& turb_center_in);
 
-void set_turb(int nDir, int trDir1, int trDir2,
-              amrex::FArrayBox& v,
-              amrex::FArrayBox& data,
-              const int dcomp);
+  void add_turb(
+    amrex::Box const& bx,
+    amrex::FArrayBox& data,
+    const int dcomp,
+    amrex::Geometry const& geom,
+    const amrex::Real time,
+    const int dir,
+    const amrex::Orientation::Side& side);
+
+  bool is_initialized() const { return turbinflow_initialized; }
+
+private:
+  void read_turb_planes(amrex::Real z);
+
+  void read_one_turb_plane(int iplane, int k);
+
+  void fill_turb_plane(
+    const amrex::Vector<amrex::Real>& x,
+    const amrex::Vector<amrex::Real>& y,
+    amrex::Real z,
+    amrex::FArrayBox& v);
+
+  void fill_with_turb(
+    amrex::Box const& bx,
+    amrex::FArrayBox& data,
+    const int dcomp,
+    amrex::Geometry const& geom);
+
+  void set_turb(
+    int nDir,
+    int trDir1,
+    int trDir2,
+    amrex::FArrayBox& v,
+    amrex::FArrayBox& data,
+    const int dcomp);
+
+  std::string m_turb_file = "";
+
+  TurbParm tp;
+
+  amrex::Gpu::DeviceVector<long> m_offset_dv;
+
+  bool turbinflow_initialized = false;
+
+  bool turbinflow_planes_initialized = false;
+};
+} // namespace turbinflow
+
+} // namespace physics
+} // namespace pele
+
 #endif

--- a/Utility/TurbInflow/turbinflow.H
+++ b/Utility/TurbInflow/turbinflow.H
@@ -37,7 +37,7 @@ public:
 
   ~TurbInflow() = default;
 
-  void init(const amrex::Vector<amrex::Real>& turb_center_in);
+  void init(amrex::Geometry const& geom);
 
   void add_turb(
     amrex::Box const& bx,

--- a/Utility/TurbInflow/turbinflow.cpp
+++ b/Utility/TurbInflow/turbinflow.cpp
@@ -33,7 +33,7 @@ TurbInflow::init(const amrex::Vector<amrex::Real>& turb_center_in)
     pp.query("turb_nplane", tp.nplane);
     AMREX_ASSERT(tp.nplane > 0);
     pp.query("turb_conv_vel", tp.turb_conv_vel);
-    AMREX_ASSERT(turb_conv_vel > 0);
+    AMREX_ASSERT(tp.turb_conv_vel > 0);
 
     // Set other stuff
     std::string turb_header = m_turb_file + "/HDR";

--- a/Utility/TurbInflow/turbinflow.cpp
+++ b/Utility/TurbInflow/turbinflow.cpp
@@ -122,7 +122,9 @@ TurbInflow::add_turb(
   int tr1Hi = bvalsBox.bigEnd()[tdir1];
   int tr2Lo = bvalsBox.smallEnd()[tdir2];
   int tr2Hi = bvalsBox.bigEnd()[tdir2];
-  amrex::Box turbBox({tr1Lo, tr2Lo, planeLoc}, {tr1Hi, tr2Hi, planeLoc});
+  amrex::Box turbBox(
+    {AMREX_D_DECL(tr1Lo, tr2Lo, planeLoc)},
+    {AMREX_D_DECL(tr1Hi, tr2Hi, planeLoc)});
   amrex::FArrayBox v(turbBox, 3);
 
   amrex::Vector<amrex::Real> x(turbBox.size()[0]), y(turbBox.size()[1]);

--- a/Utility/TurbInflow/turbinflow.cpp
+++ b/Utility/TurbInflow/turbinflow.cpp
@@ -1,85 +1,225 @@
 #include <turbinflow.H>
 
+namespace pele {
+namespace physics {
+namespace turbinflow {
 void
-init_turbinflow(
-  const std::string& turb_file,
-  amrex::Real turb_scale_loc,
-  amrex::Real turb_scale_vel,
-  const amrex::Vector<amrex::Real>& turb_center,
-  amrex::Real turb_conv_vel,
-  int nplane,
-  TurbParm& tp)
+TurbInflow::init(const amrex::Vector<amrex::Real>& turb_center_in)
 {
-  amrex::Print() << "Initializing turbulence file: " << turb_file
-                 << " (location coordinates in will be scaled by "
-                 << turb_scale_loc << " and velocity out to be scaled by "
-                 << turb_scale_vel << ")" << std::endl;
+  amrex::ParmParse pp("turbinflow");
 
-  tp.tph->turb_file = turb_file;
-  tp.nplane = nplane;
-  tp.turb_conv_vel = turb_conv_vel;
-  tp.turb_scale_loc = turb_scale_loc;
-  tp.turb_scale_vel = turb_scale_vel;
+  if (pp.countval("turb_file") > 0) {
 
-  std::string turb_header = tp.tph->turb_file + "/HDR";
-  std::ifstream is(turb_header.c_str());
-  if (!is.is_open()) {
-    amrex::Abort("Unable to open input file " + turb_header);
-  }
-  amrex::Array<int, AMREX_SPACEDIM> npts = {{0}};
-  amrex::Array<amrex::Real, AMREX_SPACEDIM> probsize = {{0}};
-  amrex::Array<int, AMREX_SPACEDIM> iper = {{0}};
-  is >> npts[0] >> npts[1] >> npts[2];
-  is >> probsize[0] >> probsize[1] >> probsize[2];
-  is >> iper[0] >> iper[1] >>
-    iper[2]; // Unused - we assume it is always fully periodic
+    // Query data
+    pp.query("turb_file", m_turb_file);
+    pp.query("turb_scale_loc", tp.turb_scale_loc);
+    pp.query("turb_scale_vel", tp.turb_scale_vel);
+    amrex::Print() << "Initializing turbulence file: " << m_turb_file
+                   << " (location coordinates in will be scaled by "
+                   << tp.turb_scale_loc << " and velocity out to be scaled by "
+                   << tp.turb_scale_vel << ")" << std::endl;
 
-  for (int n = 0; n < AMREX_SPACEDIM; ++n) {
-    tp.dx[n] = probsize[n] / amrex::Real(npts[n] - 1);
-    tp.dxinv[n] = 1.0 / tp.dx[n];
-  }
-
-  // one ghost point on each side, tangential to inflow face
-  tp.pboxsize[0] = probsize[0] - 2.0 * tp.dx[0];
-  tp.pboxsize[1] = probsize[1] - 2.0 * tp.dx[1];
-  tp.pboxsize[2] = probsize[2];
-
-  tp.npboxcells[0] = npts[0] - 3;
-  tp.npboxcells[1] = npts[1] - 3;
-  tp.npboxcells[2] = npts[2];
-
-  // Center the turbulence)
-  tp.pboxlo[0] = turb_center[0] - 0.5 * tp.pboxsize[0];
-  tp.pboxlo[1] = turb_center[1] - 0.5 * tp.pboxsize[1];
-  tp.pboxlo[2] = 0.;
-
-  amrex::Box sbx(
-    amrex::IntVect(AMREX_D_DECL(1, 1, 1)),
-    amrex::IntVect(AMREX_D_DECL(npts[0], npts[1], tp.nplane)));
-
-  tp.sdata = new amrex::FArrayBox(sbx, 3);
-
-  tp.kmax = npts[2];
-
-  amrex::Real rdummy;
-  if (tp.isswirltype) {
-    for (int i = 0; i < tp.kmax; i++) {
-      is >> rdummy; // Time for each plane - unused at the moment
+    amrex::Vector<amrex::Real> turb_center(turb_center_in);
+    for (int n = 0; n < turb_center.size(); ++n) {
+      turb_center[n] = turb_center_in[n];
     }
-  }
-  tp.tph->offset_dv.resize(tp.kmax * AMREX_SPACEDIM);
-  tp.offset = tp.tph->offset_dv.data();
-  tp.offset_size = tp.tph->offset_dv.size();
-  for (int i = 0; i < tp.offset_size; i++) {
-    is >> tp.offset[i];
-  }
-  is.close();
+    pp.queryarr("turb_center", turb_center);
+    AMREX_ASSERT_WITH_MESSAGE(
+      turb_center.size() == 2, "turb_center must have two elements");
+    for (int n = 0; n < turb_center.size(); ++n) {
+      turb_center[n] *= tp.turb_scale_loc;
+    }
 
-  tp.turbinflow_initialized = true;
+    pp.query("turb_nplane", tp.nplane);
+    AMREX_ASSERT(tp.nplane > 0);
+    pp.query("turb_conv_vel", tp.turb_conv_vel);
+    AMREX_ASSERT(turb_conv_vel > 0);
+
+    // Set other stuff
+    std::string turb_header = m_turb_file + "/HDR";
+    std::ifstream is(turb_header.c_str());
+    if (!is.is_open()) {
+      amrex::Abort("Unable to open input file " + turb_header);
+    }
+    amrex::Array<int, AMREX_SPACEDIM> npts = {{0}};
+    amrex::Array<amrex::Real, AMREX_SPACEDIM> probsize = {{0}};
+    amrex::Array<int, AMREX_SPACEDIM> iper = {{0}};
+    is >> npts[0] >> npts[1] >> npts[2];
+    is >> probsize[0] >> probsize[1] >> probsize[2];
+    is >> iper[0] >> iper[1] >>
+      iper[2]; // Unused - we assume it is always fully periodic
+
+    for (int n = 0; n < AMREX_SPACEDIM; ++n) {
+      tp.dx[n] = probsize[n] / amrex::Real(npts[n] - 1);
+      tp.dxinv[n] = 1.0 / tp.dx[n];
+    }
+
+    // one ghost point on each side, tangential to inflow face
+    tp.pboxsize[0] = probsize[0] - 2.0 * tp.dx[0];
+    tp.pboxsize[1] = probsize[1] - 2.0 * tp.dx[1];
+    tp.pboxsize[2] = probsize[2];
+
+    tp.npboxcells[0] = npts[0] - 3;
+    tp.npboxcells[1] = npts[1] - 3;
+    tp.npboxcells[2] = npts[2];
+
+    // Center the turbulence)
+    tp.pboxlo[0] = turb_center[0] - 0.5 * tp.pboxsize[0];
+    tp.pboxlo[1] = turb_center[1] - 0.5 * tp.pboxsize[1];
+    tp.pboxlo[2] = 0.;
+
+    amrex::Box sbx(
+      amrex::IntVect(AMREX_D_DECL(1, 1, 1)),
+      amrex::IntVect(AMREX_D_DECL(npts[0], npts[1], tp.nplane)));
+
+    tp.sdata = new amrex::FArrayBox(sbx, 3);
+
+    tp.kmax = npts[2];
+
+    amrex::Real rdummy;
+    if (tp.isswirltype) {
+      for (int i = 0; i < tp.kmax; i++) {
+        is >> rdummy; // Time for each plane - unused at the moment
+      }
+    }
+    m_offset_dv.resize(tp.kmax * AMREX_SPACEDIM);
+    tp.offset = m_offset_dv.data();
+    tp.offset_size = m_offset_dv.size();
+    for (int i = 0; i < tp.offset_size; i++) {
+      is >> tp.offset[i];
+    }
+    is.close();
+
+    turbinflow_initialized = true;
+  }
 }
 
 void
-read_one_turb_plane(int iplane, int k, TurbParm& tp)
+TurbInflow::add_turb(
+  amrex::Box const& bx,
+  amrex::FArrayBox& data,
+  const int dcomp,
+  amrex::Geometry const& geom,
+  const amrex::Real time,
+  const int dir,
+  const amrex::Orientation::Side& side)
+{
+  AMREX_ASSERT(turbinflow_initialized);
+
+  // Box on which we will access data
+  amrex::Box bvalsBox = bx;
+  int planeLoc =
+    (side == amrex::Orientation::low ? geom.Domain().smallEnd()[dir] - 1
+                                     : geom.Domain().bigEnd()[dir] + 1);
+  bvalsBox.setSmall(dir, planeLoc);
+  bvalsBox.setBig(dir, planeLoc);
+
+  // Define box that we will fill with turb: need to be z-normal
+  // Get transverse directions
+  int tdir1 = (dir != 0) ? 0 : 1;
+  int tdir2 = (dir != 0) ? ((dir == 2) ? 1 : 2) : 2;
+  int tr1Lo = bvalsBox.smallEnd()[tdir1];
+  int tr1Hi = bvalsBox.bigEnd()[tdir1];
+  int tr2Lo = bvalsBox.smallEnd()[tdir2];
+  int tr2Hi = bvalsBox.bigEnd()[tdir2];
+  amrex::Box turbBox({tr1Lo, tr2Lo, planeLoc}, {tr1Hi, tr2Hi, planeLoc});
+  amrex::FArrayBox v(turbBox, 3);
+
+  amrex::Vector<amrex::Real> x(turbBox.size()[0]), y(turbBox.size()[1]);
+  for (int i = turbBox.smallEnd()[0]; i <= turbBox.bigEnd()[0]; ++i) {
+    x[i - turbBox.smallEnd()[0]] =
+      (geom.ProbLo()[tdir1] + (i + 0.5) * geom.CellSize(tdir1)) *
+      tp.turb_scale_loc;
+  }
+  for (int j = turbBox.smallEnd()[1]; j <= turbBox.bigEnd()[1]; ++j) {
+    y[j - turbBox.smallEnd()[1]] =
+      (geom.ProbLo()[tdir2] + (j + 0.5) * geom.CellSize(tdir2)) *
+      tp.turb_scale_loc;
+  }
+
+  // Get the turbulence
+  v.setVal<amrex::RunOn::Device>(0);
+  amrex::Real z = time * tp.turb_conv_vel * tp.turb_scale_loc;
+  fill_turb_plane(x, y, z, v);
+  if (side == amrex::Orientation::high) {
+    v.mult<amrex::RunOn::Device>(-tp.turb_scale_vel);
+  } else {
+    v.mult<amrex::RunOn::Device>(tp.turb_scale_vel);
+  }
+
+  // Moving it into data
+  set_turb(dir, tdir1, tdir2, v, data, dcomp);
+}
+
+void
+TurbInflow::set_turb(
+  int normDir,
+  int transDir1,
+  int transDir2,
+  amrex::FArrayBox& v,
+  amrex::FArrayBox& data,
+  const int dcomp)
+{
+  // copy velocity fluctuations from plane into data
+  const auto& box = v.box(); // z-normal plane
+  const auto& v_in = v.array();
+  const auto& v_out = data.array(dcomp);
+
+  amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+    // From z-normal box index to data box index
+    int idx[3] = {0};
+    idx[transDir1] = i;
+    idx[transDir2] = j;
+    idx[normDir] = k;
+    v_out(idx[0], idx[1], idx[2], transDir1) =
+      v_in(i, j, k, 0); // transverse velocity 1
+    v_out(idx[0], idx[1], idx[2], transDir2) =
+      v_in(i, j, k, 1); // transverse velocity 2
+    v_out(idx[0], idx[1], idx[2], normDir) =
+      v_in(i, j, k, 2); // normal velocity
+  });
+}
+
+void
+TurbInflow::fill_with_turb(
+  amrex::Box const& bx,
+  amrex::FArrayBox& data,
+  const int dcomp,
+  amrex::Geometry const& geom)
+{
+  int dir = 2;
+  AMREX_ASSERT(turbinflow_initialized);
+
+  for (int planeloc = bx.smallEnd()[2]; planeloc <= bx.bigEnd()[2];
+       ++planeloc) {
+    amrex::Box bvalsBox = bx;
+    bvalsBox.setSmall(dir, planeloc);
+    bvalsBox.setBig(dir, planeloc);
+
+    amrex::FArrayBox v(bvalsBox, 3);
+    v.setVal<amrex::RunOn::Device>(0);
+
+    amrex::Vector<amrex::Real> x(bvalsBox.size()[0]), y(bvalsBox.size()[1]);
+    for (int i = bvalsBox.smallEnd()[0]; i <= bvalsBox.bigEnd()[0]; ++i) {
+      x[i - bvalsBox.smallEnd()[0]] =
+        (geom.ProbLo()[0] + (i + 0.5) * geom.CellSize(0)) * tp.turb_scale_loc;
+    }
+    for (int j = bvalsBox.smallEnd()[1]; j <= bvalsBox.bigEnd()[1]; ++j) {
+      y[j - bvalsBox.smallEnd()[1]] =
+        (geom.ProbLo()[1] + (j + 0.5) * geom.CellSize(1)) * tp.turb_scale_loc;
+    }
+
+    amrex::Real z = (geom.ProbLo()[2] + (planeloc + 0.5) * geom.CellSize(2)) *
+                    tp.turb_scale_loc;
+    fill_turb_plane(x, y, z, v);
+    v.mult<amrex::RunOn::Device>(tp.turb_scale_vel);
+    amrex::Box ovlp = bvalsBox & data.box();
+    data.copy<amrex::RunOn::Device>(v, ovlp, 0, ovlp, dcomp, AMREX_SPACEDIM);
+  }
+}
+
+void
+TurbInflow::read_one_turb_plane(int iplane, int k)
 {
   //
   // There are AMREX_SPACEDIM * kmax planes of FABs.
@@ -88,7 +228,7 @@ read_one_turb_plane(int iplane, int k, TurbParm& tp)
   // Note also that both (*plane) and (*ncomp) start from
   // 1 not 0 since they're passed from Fortran.
   //
-  std::string turb_data = tp.tph->turb_file + "/DAT";
+  std::string turb_data = m_turb_file + "/DAT";
   std::ifstream ifs(turb_data.c_str());
   if (!ifs.is_open()) {
     amrex::Abort("Unable to open input file " + turb_data);
@@ -121,7 +261,7 @@ read_one_turb_plane(int iplane, int k, TurbParm& tp)
 }
 
 void
-read_turb_planes(amrex::Real z, TurbParm& tp)
+TurbInflow::read_turb_planes(amrex::Real z)
 {
   int izlo = (int)(round(z * tp.dxinv[2])) - 1;
   int izhi = izlo + tp.nplane - 1;
@@ -136,24 +276,23 @@ read_turb_planes(amrex::Real z, TurbParm& tp)
 
   for (int iplane = 1; iplane <= tp.nplane; ++iplane) {
     int k = (izlo + iplane - 1) % (tp.npboxcells[2] - 2);
-    read_one_turb_plane(iplane, k, tp);
+    read_one_turb_plane(iplane, k);
   }
-  tp.turbinflow_planes_initialized = true;
+  turbinflow_planes_initialized = true;
 }
 
 void
-fill_turb_plane(
+TurbInflow::fill_turb_plane(
   const amrex::Vector<amrex::Real>& x,
   const amrex::Vector<amrex::Real>& y,
   amrex::Real z,
-  amrex::FArrayBox& v,
-  TurbParm& tp)
+  amrex::FArrayBox& v)
 {
   if (
-    (!tp.turbinflow_planes_initialized) || (z < tp.szlo + 0.5 * tp.dx[2]) ||
+    (!turbinflow_planes_initialized) || (z < tp.szlo + 0.5 * tp.dx[2]) ||
     (z > tp.szhi - 0.5 * tp.dx[2])) {
 #if 0
-    if (!tp.turbinflow_planes_initialized) {
+    if (!turbinflow_planes_initialized) {
       amrex::Print() << "Reading new data because planes uninitialized at z: " << z << std::endl;
     }
     else {
@@ -161,12 +300,11 @@ fill_turb_plane(
                      << tp.szhi - 0.5 * tp.dx[2] << std::endl;
     }
 #endif
-    read_turb_planes(z, tp);
+    read_turb_planes(z);
   }
 
   const auto& bx = v.box();
   const auto& vd = v.array();
-  const auto& sd = tp.sdata->array();
 
   amrex::Gpu::DeviceVector<amrex::Real> x_dev(x.size());
   amrex::Gpu::DeviceVector<amrex::Real> y_dev(y.size());
@@ -176,175 +314,63 @@ fill_turb_plane(
     amrex::Gpu::hostToDevice, y.begin(), y.end(), y_dev.begin());
   amrex::Real* xd = x_dev.data();
   amrex::Real* yd = y_dev.data();
-  amrex::ParallelFor(
-    bx,
-    [z, sd, vd, tp, bx, xd, yd] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-      amrex::Real cx[3], cy[3], cz[3], ydata[3];
-      amrex::Real zdata[3][3];
 
-      amrex::Real zz = (z - tp.szlo) * tp.dxinv[2];
-      int k0 = (int)(std::round(zz)) - 1;
-      zz -= amrex::Real(k0);
-      cz[0] = 0.5 * (zz - 1.0) * (zz - 2.0);
-      cz[1] = zz * (2.0 - zz);
-      cz[2] = 0.5 * zz * (zz - 1.0);
-      k0 += 2;
-      k0 = amrex::min(amrex::max(k0, 1), tp.nplane - 2);
+  const auto& nplane = tp.nplane;
+  const auto& npboxcells = tp.npboxcells;
+  const auto& pboxlo = tp.pboxlo;
+  const auto& szlo = tp.szlo;
+  const auto& dxinv = tp.dxinv;
+  const auto& sd = tp.sdata->array();
+  amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+    amrex::Real cx[3], cy[3], cz[3], ydata[3];
+    amrex::Real zdata[3][3];
 
-      for (int n = 0; n < 3; ++n) {
-        amrex::Real xx = (xd[i - bx.smallEnd(0)] - tp.pboxlo[0]) * tp.dxinv[0];
-        amrex::Real yy = (yd[j - bx.smallEnd(1)] - tp.pboxlo[1]) * tp.dxinv[1];
-        int i0 = (int)(std::round(xx));
-        int j0 = (int)(std::round(yy));
-        xx -= amrex::Real(i0);
-        yy -= amrex::Real(j0);
-        cx[0] = 0.5 * (xx - 1.0) * (xx - 2.0);
-        cy[0] = 0.5 * (yy - 1.0) * (yy - 2.0);
-        cx[1] = xx * (2.0 - xx);
-        cy[1] = yy * (2.0 - yy);
-        cx[2] = 0.5 * xx * (xx - 1.0);
-        cy[2] = 0.5 * yy * (yy - 1.0);
+    amrex::Real zz = (z - szlo) * dxinv[2];
+    int k0 = (int)(std::round(zz)) - 1;
+    zz -= amrex::Real(k0);
+    cz[0] = 0.5 * (zz - 1.0) * (zz - 2.0);
+    cz[1] = zz * (2.0 - zz);
+    cz[2] = 0.5 * zz * (zz - 1.0);
+    k0 += 2;
+    k0 = amrex::min(amrex::max(k0, 1), nplane - 2);
 
-        if (
-          i0 >= 0 && i0 < tp.npboxcells[0] && j0 >= 0 &&
-          j0 < tp.npboxcells[1]) {
-          i0 += 2;
-          j0 += 2;
-          for (int ii = 0; ii <= 2; ++ii) {
-            for (int jj = 0; jj <= 2; ++jj) {
-              zdata[ii][jj] = cz[0] * sd(i0 + ii, j0 + jj, k0, n) +
-                              cz[1] * sd(i0 + ii, j0 + jj, k0 + 1, n) +
-                              cz[2] * sd(i0 + ii, j0 + jj, k0 + 2, n);
-            }
+    for (int n = 0; n < 3; ++n) {
+      amrex::Real xx = (xd[i - bx.smallEnd(0)] - pboxlo[0]) * dxinv[0];
+      amrex::Real yy = (yd[j - bx.smallEnd(1)] - pboxlo[1]) * dxinv[1];
+      int i0 = (int)(std::round(xx));
+      int j0 = (int)(std::round(yy));
+      xx -= amrex::Real(i0);
+      yy -= amrex::Real(j0);
+      cx[0] = 0.5 * (xx - 1.0) * (xx - 2.0);
+      cy[0] = 0.5 * (yy - 1.0) * (yy - 2.0);
+      cx[1] = xx * (2.0 - xx);
+      cy[1] = yy * (2.0 - yy);
+      cx[2] = 0.5 * xx * (xx - 1.0);
+      cy[2] = 0.5 * yy * (yy - 1.0);
+
+      if (i0 >= 0 && i0 < npboxcells[0] && j0 >= 0 && j0 < npboxcells[1]) {
+        i0 += 2;
+        j0 += 2;
+        for (int ii = 0; ii <= 2; ++ii) {
+          for (int jj = 0; jj <= 2; ++jj) {
+            zdata[ii][jj] = cz[0] * sd(i0 + ii, j0 + jj, k0, n) +
+                            cz[1] * sd(i0 + ii, j0 + jj, k0 + 1, n) +
+                            cz[2] * sd(i0 + ii, j0 + jj, k0 + 2, n);
           }
-          for (int ii = 0; ii <= 2; ++ii) {
-            ydata[ii] = cy[0] * zdata[ii][0] + cy[1] * zdata[ii][1] +
-                        cy[2] * zdata[ii][2];
-          }
-          vd(i, j, k, n) =
-            cx[0] * ydata[0] + cx[1] * ydata[1] + cx[2] * ydata[2];
-        } else {
-          vd(i, j, k, n) = 0.0;
         }
+        for (int ii = 0; ii <= 2; ++ii) {
+          ydata[ii] =
+            cy[0] * zdata[ii][0] + cy[1] * zdata[ii][1] + cy[2] * zdata[ii][2];
+        }
+        vd(i, j, k, n) = cx[0] * ydata[0] + cx[1] * ydata[1] + cx[2] * ydata[2];
+      } else {
+        vd(i, j, k, n) = 0.0;
       }
-    });
+    }
+  });
   amrex::Gpu::synchronize(); // Ensure that DeviceVector's don't leave scope
                              // early
 }
-
-void
-add_turb(amrex::Box const& bx,
-         amrex::FArrayBox& data,
-         const int dcomp,
-         amrex::Geometry const& geom,
-         const amrex::Real time,
-         const int dir,
-         const amrex::Orientation::Side& side,
-         TurbParm& tp)
-{
-  AMREX_ASSERT(tp.turbinflow_initialized);
-
-  // Box on which we will access data
-  amrex::Box bvalsBox = bx;
-  int planeLoc =
-    (side == amrex::Orientation::low ? geom.Domain().smallEnd()[dir] - 1
-                                     : geom.Domain().bigEnd()[dir] + 1);
-  bvalsBox.setSmall(dir, planeLoc);
-  bvalsBox.setBig(dir, planeLoc);
-
-  // Define box that we will fill with turb: need to be z-normal
-  // Get transverse directions
-  int tdir1 = ( dir != 0 ) ? 0 : 1 ;
-  int tdir2 = ( dir != 0 ) ? ( ( dir == 2 ) ? 1 : 2 ) : 2 ;
-  int tr1Lo = bvalsBox.smallEnd()[tdir1];
-  int tr1Hi = bvalsBox.bigEnd()[tdir1];
-  int tr2Lo = bvalsBox.smallEnd()[tdir2];
-  int tr2Hi = bvalsBox.bigEnd()[tdir2];
-  amrex::Box turbBox({tr1Lo, tr2Lo, planeLoc},
-                     {tr1Hi, tr2Hi, planeLoc});
-  amrex::FArrayBox v(turbBox, 3);
-
-  amrex::Vector<amrex::Real> x(turbBox.size()[0]), y(turbBox.size()[1]);
-  for (int i = turbBox.smallEnd()[0]; i <= turbBox.bigEnd()[0]; ++i) {
-    x[i - turbBox.smallEnd()[0]] =
-      (geom.ProbLo()[tdir1] + (i + 0.5) * geom.CellSize(tdir1)) * tp.turb_scale_loc;
-  }
-  for (int j = turbBox.smallEnd()[1]; j <= turbBox.bigEnd()[1]; ++j) {
-    y[j - turbBox.smallEnd()[1]] =
-      (geom.ProbLo()[tdir2] + (j + 0.5) * geom.CellSize(tdir2)) * tp.turb_scale_loc;
-  }
-
-  // Get the turbulence
-  v.setVal<amrex::RunOn::Device>(0);
-  amrex::Real z = time * tp.turb_conv_vel * tp.turb_scale_loc;
-  fill_turb_plane(x, y, z, v, tp);
-  if (side == amrex::Orientation::high) {
-    v.mult<amrex::RunOn::Device>(-tp.turb_scale_vel);
-  } else {
-    v.mult<amrex::RunOn::Device>(tp.turb_scale_vel);
-  }
-
-  // Moving it into data
-  set_turb(dir,tdir1,tdir2,v,data,dcomp);
-}
-
-void set_turb(int normDir, int transDir1, int transDir2,
-              amrex::FArrayBox& v,
-              amrex::FArrayBox& data,
-              const int dcomp)
-{
-  // copy velocity fluctuations from plane into data
-  const auto& box   = v.box();   // z-normal plane
-  const auto& v_in  = v.array();
-  const auto& v_out = data.array(dcomp);
-
-  amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                     // From z-normal box index to data box index
-                     int idx[3] = {0};
-                     idx[transDir1] = i;
-                     idx[transDir2] = j;
-                     idx[normDir] = k;
-                     v_out(idx[0],idx[1],idx[2],transDir1) =  v_in(i,j,k,0);  // transverse velocity 1
-                     v_out(idx[0],idx[1],idx[2],transDir2) =  v_in(i,j,k,1);  // transverse velocity 2
-                     v_out(idx[0],idx[1],idx[2],normDir)   =  v_in(i,j,k,2);  // normal velocity
-  });
-}
-
-void
-fill_with_turb(
-  amrex::Box const& bx,
-  amrex::FArrayBox& data,
-  const int dcomp,
-  amrex::Geometry const& geom,
-  TurbParm& tp)
-{
-  int dir = 2;
-  AMREX_ASSERT(tp.turbinflow_initialized);
-
-  for (int planeloc = bx.smallEnd()[2]; planeloc <= bx.bigEnd()[2];
-       ++planeloc) {
-    amrex::Box bvalsBox = bx;
-    bvalsBox.setSmall(dir, planeloc);
-    bvalsBox.setBig(dir, planeloc);
-
-    amrex::FArrayBox v(bvalsBox, 3);
-    v.setVal<amrex::RunOn::Device>(0);
-
-    amrex::Vector<amrex::Real> x(bvalsBox.size()[0]), y(bvalsBox.size()[1]);
-    for (int i = bvalsBox.smallEnd()[0]; i <= bvalsBox.bigEnd()[0]; ++i) {
-      x[i - bvalsBox.smallEnd()[0]] =
-        (geom.ProbLo()[0] + (i + 0.5) * geom.CellSize(0)) * tp.turb_scale_loc;
-    }
-    for (int j = bvalsBox.smallEnd()[1]; j <= bvalsBox.bigEnd()[1]; ++j) {
-      y[j - bvalsBox.smallEnd()[1]] =
-        (geom.ProbLo()[1] + (j + 0.5) * geom.CellSize(1)) * tp.turb_scale_loc;
-    }
-
-    amrex::Real z = (geom.ProbLo()[2] + (planeloc + 0.5) * geom.CellSize(2)) *
-                    tp.turb_scale_loc;
-    fill_turb_plane(x, y, z, v, tp);
-    v.mult<amrex::RunOn::Device>(tp.turb_scale_vel);
-    amrex::Box ovlp = bvalsBox & data.box();
-    data.copy<amrex::RunOn::Device>(v, ovlp, 0, ovlp, dcomp, AMREX_SPACEDIM);
-  }
-}
+} // namespace turbinflow
+} // namespace physics
+} // namespace pele

--- a/Utility/TurbInflow/turbinflow.cpp
+++ b/Utility/TurbInflow/turbinflow.cpp
@@ -4,7 +4,7 @@ namespace pele {
 namespace physics {
 namespace turbinflow {
 void
-TurbInflow::init(const amrex::Vector<amrex::Real>& turb_center_in)
+TurbInflow::init(amrex::Geometry const& geom)
 {
   amrex::ParmParse pp("turbinflow");
 
@@ -19,10 +19,10 @@ TurbInflow::init(const amrex::Vector<amrex::Real>& turb_center_in)
                    << tp.turb_scale_loc << " and velocity out to be scaled by "
                    << tp.turb_scale_vel << ")" << std::endl;
 
-    amrex::Vector<amrex::Real> turb_center(turb_center_in);
-    for (int n = 0; n < turb_center.size(); ++n) {
-      turb_center[n] = turb_center_in[n];
-    }
+    const auto prob_lo = geom.ProbLoArray();
+    const auto prob_hi = geom.ProbHiArray();
+    amrex::Vector<amrex::Real> turb_center = {
+      {0.5 * (prob_hi[0] + prob_lo[0]), 0.5 * (prob_hi[1] + prob_lo[1])}};
     pp.queryarr("turb_center", turb_center);
     AMREX_ASSERT_WITH_MESSAGE(
       turb_center.size() == 2, "turb_center must have two elements");

--- a/Utility/TurbInflow/turbinflow.cpp
+++ b/Utility/TurbInflow/turbinflow.cpp
@@ -72,7 +72,7 @@ TurbInflow::init(amrex::Geometry const& geom)
       amrex::IntVect(AMREX_D_DECL(1, 1, 1)),
       amrex::IntVect(AMREX_D_DECL(npts[0], npts[1], tp.nplane)));
 
-    tp.sdata = new amrex::FArrayBox(sbx, 3);
+    tp.sdata = new amrex::FArrayBox(sbx, 3, amrex::The_Async_Arena());
 
     tp.kmax = npts[2];
 
@@ -125,7 +125,7 @@ TurbInflow::add_turb(
   const amrex::IntVect lo(AMREX_D_DECL(tr1Lo, tr2Lo, planeLoc));
   const amrex::IntVect hi(AMREX_D_DECL(tr1Hi, tr2Hi, planeLoc));
   amrex::Box turbBox(lo, hi);
-  amrex::FArrayBox v(turbBox, 3);
+  amrex::FArrayBox v(turbBox, 3, amrex::The_Async_Arena());
 
   amrex::Vector<amrex::Real> x(turbBox.size()[0]), y(turbBox.size()[1]);
   for (int i = turbBox.smallEnd()[0]; i <= turbBox.bigEnd()[0]; ++i) {
@@ -198,7 +198,7 @@ TurbInflow::fill_with_turb(
     bvalsBox.setSmall(dir, planeloc);
     bvalsBox.setBig(dir, planeloc);
 
-    amrex::FArrayBox v(bvalsBox, 3);
+    amrex::FArrayBox v(bvalsBox, 3, amrex::The_Async_Arena());
     v.setVal<amrex::RunOn::Device>(0);
 
     amrex::Vector<amrex::Real> x(bvalsBox.size()[0]), y(bvalsBox.size()[1]);

--- a/Utility/TurbInflow/turbinflow.cpp
+++ b/Utility/TurbInflow/turbinflow.cpp
@@ -122,9 +122,9 @@ TurbInflow::add_turb(
   int tr1Hi = bvalsBox.bigEnd()[tdir1];
   int tr2Lo = bvalsBox.smallEnd()[tdir2];
   int tr2Hi = bvalsBox.bigEnd()[tdir2];
-  amrex::Box turbBox(
-    {AMREX_D_DECL(tr1Lo, tr2Lo, planeLoc)},
-    {AMREX_D_DECL(tr1Hi, tr2Hi, planeLoc)});
+  const amrex::IntVect lo(AMREX_D_DECL(tr1Lo, tr2Lo, planeLoc));
+  const amrex::IntVect hi(AMREX_D_DECL(tr1Hi, tr2Hi, planeLoc));
+  amrex::Box turbBox(lo, hi);
   amrex::FArrayBox v(turbBox, 3);
 
   amrex::Vector<amrex::Real> x(turbBox.size()[0]), y(turbBox.size()[1]);


### PR DESCRIPTION
This simplifies the turbulence inflow, encapsulates it better, makes it more modular. The user will have to switch to a new PP querry prefix (`turbinflow` instead of `prob`).

@esclapez can you give this a shot on a problem that works for you in LM? You can see what I did to PeleC in the PR referred below.