### PR TITLE
Make functions more consistent in Eos and Transport

### DIFF
--- a/Eos/Fuego.H
+++ b/Eos/Fuego.H
@@ -19,53 +19,50 @@ struct Fuego
   static std::string identifier() { return "Fuego"; }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void molecular_weight(amrex::Real mw[])
-  {
-    get_mw(mw);
-  }
+  AMREX_FORCE_INLINE
+  static void molecular_weight(amrex::Real mw[]) { get_mw(mw); }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void inv_molecular_weight(amrex::Real imw[])
-  {
-    get_imw(imw);
-  }
+  AMREX_FORCE_INLINE
+  static void inv_molecular_weight(amrex::Real imw[]) { get_imw(imw); }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  TY2Cp(amrex::Real T, amrex::Real Y[], amrex::Real& Cp)
+  AMREX_FORCE_INLINE
+  static void TY2Cp(amrex::Real T, amrex::Real Y[], amrex::Real& Cp)
   {
     CKCPBS(&T, Y, &Cp);
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RTY2Cp(amrex::Real /*R*/, amrex::Real T, amrex::Real Y[], amrex::Real& Cp)
   {
     TY2Cp(T, Y, Cp);
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  TY2Cv(amrex::Real T, amrex::Real Y[], amrex::Real& Cv)
+  AMREX_FORCE_INLINE
+  static void TY2Cv(amrex::Real T, amrex::Real Y[], amrex::Real& Cv)
   {
     CKCVBS(&T, Y, &Cv);
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RTY2Cv(amrex::Real /*R*/, amrex::Real T, amrex::Real Y[], amrex::Real& Cv)
   {
     TY2Cv(T, Y, Cv);
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void T2Cpi(amrex::Real T, amrex::Real Cpi[])
-  {
-    CKCPMS(&T, Cpi);
-  }
+  AMREX_FORCE_INLINE
+  static void T2Cpi(amrex::Real T, amrex::Real Cpi[]) { CKCPMS(&T, Cpi); }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RPY2Cs(amrex::Real R, amrex::Real P, amrex::Real Y[], amrex::Real& Cs)
   {
     amrex::Real tmp[NUM_SPECIES];
@@ -82,7 +79,8 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RTY2Cs(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cs)
   {
     amrex::Real tmp[NUM_SPECIES];
@@ -100,8 +98,8 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  EY2T(amrex::Real E, amrex::Real Y[], amrex::Real& T)
+  AMREX_FORCE_INLINE
+  static void EY2T(amrex::Real E, amrex::Real Y[], amrex::Real& T)
   {
     // For Fuego this function is really just a wrapper for GET_T_GIVEN_EY
     // In SRK this will be different probably
@@ -110,15 +108,16 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   REY2T(amrex::Real /*R*/, amrex::Real E, amrex::Real Y[], amrex::Real& T)
   {
     EY2T(E, Y, T);
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  HY2T(amrex::Real H, amrex::Real Y[], amrex::Real& T)
+  AMREX_FORCE_INLINE
+  static void HY2T(amrex::Real H, amrex::Real Y[], amrex::Real& T)
   {
     // For Fuego this function is really just a wrapper for GET_T_GIVEN_HY
     // In SRK this will be different probably
@@ -127,14 +126,16 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RHY2T(amrex::Real /*R*/, amrex::Real H, amrex::Real Y[], amrex::Real& T)
   {
     HY2T(H, Y, T);
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RYET2P(
+  AMREX_FORCE_INLINE
+  static void RYET2P(
     amrex::Real R,
     amrex::Real Y[],
     amrex::Real& E,
@@ -147,14 +148,16 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
   {
     CKPY(&R, &T, Y, &P);
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RYP2T(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& T)
   {
     amrex::Real wbar;
@@ -163,7 +166,8 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RTY2WDOT(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real WDOT[])
   {
     // CKWYR(&R, &T, Y, WDOT);
@@ -179,7 +183,8 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RTY2JAC(
+  AMREX_FORCE_INLINE
+  static void RTY2JAC(
     amrex::Real R,
     amrex::Real T,
     amrex::Real Y[],
@@ -192,39 +197,36 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RTY2C(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real acti[])
   {
     CKYTCR(&R, &T, Y, acti);
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void T2Ei(amrex::Real T, amrex::Real Ei[])
-  {
-    CKUMS(&T, Ei);
-  }
+  AMREX_FORCE_INLINE
+  static void T2Ei(amrex::Real T, amrex::Real Ei[]) { CKUMS(&T, Ei); }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RTY2Ei(
+  AMREX_FORCE_INLINE
+  static void RTY2Ei(
     amrex::Real /*R*/, amrex::Real T, amrex::Real* /*Y[]*/, amrex::Real Ei[])
   {
     T2Ei(T, Ei);
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void Y2X(amrex::Real Y[], amrex::Real X[])
-  {
-    CKYTX(Y, X);
-  }
+  AMREX_FORCE_INLINE
+  static void Y2X(amrex::Real Y[], amrex::Real X[]) { CKYTX(Y, X); }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void X2Y(amrex::Real X[], amrex::Real Y[])
-  {
-    CKXTY(X, Y);
-  }
+  AMREX_FORCE_INLINE
+  static void X2Y(amrex::Real X[], amrex::Real Y[]) { CKXTY(X, Y); }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void PYT2RE(
+  AMREX_FORCE_INLINE
+  static void PYT2RE(
     amrex::Real P,
     amrex::Real Y[],
     amrex::Real T,
@@ -241,14 +243,16 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   PYT2R(amrex::Real P, amrex::Real Y[], amrex::Real T, amrex::Real& R)
   {
     CKRHOY(&P, &T, Y, &R);
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RYP2E(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& E)
   {
     amrex::Real wbar;
@@ -263,8 +267,8 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  TY2E(amrex::Real T, const amrex::Real Y[], amrex::Real& E)
+  AMREX_FORCE_INLINE
+  static void TY2E(amrex::Real T, const amrex::Real Y[], amrex::Real& E)
   {
     amrex::Real ei[NUM_SPECIES];
     T2Ei(T, ei);
@@ -275,31 +279,32 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RTY2E(amrex::Real /*R*/, amrex::Real T, amrex::Real Y[], amrex::Real& E)
   {
     TY2E(T, Y, E);
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void T2Hi(amrex::Real T, amrex::Real Hi[])
-  {
-    CKHMS(&T, Hi);
-  }
+  AMREX_FORCE_INLINE
+  static void T2Hi(amrex::Real T, amrex::Real Hi[]) { CKHMS(&T, Hi); }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RTY2Hi(
+  AMREX_FORCE_INLINE
+  static void RTY2Hi(
     amrex::Real /*R*/, amrex::Real T, amrex::Real* /*Y[]*/, amrex::Real Hi[])
   {
     T2Hi(T, Hi);
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void S(amrex::Real& s) { s = 1.0; }
+  AMREX_FORCE_INLINE
+  static void S(amrex::Real& s) { s = 1.0; }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  TY2G(amrex::Real T, amrex::Real Y[NUM_SPECIES], amrex::Real& G)
+  AMREX_FORCE_INLINE
+  static void TY2G(amrex::Real T, amrex::Real Y[NUM_SPECIES], amrex::Real& G)
   {
     amrex::Real wbar, Cv, Cvx;
     TY2Cv(T, Y, Cv);
@@ -309,7 +314,8 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RTY2G(
+  AMREX_FORCE_INLINE
+  static void RTY2G(
     amrex::Real /*R*/,
     amrex::Real T,
     amrex::Real Y[NUM_SPECIES],
@@ -319,7 +325,8 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   TY2H(amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
   {
     amrex::Real hi[NUM_SPECIES];
@@ -331,8 +338,8 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  Y2WBAR(const amrex::Real Y[], amrex::Real& WBAR)
+  AMREX_FORCE_INLINE
+  static void Y2WBAR(const amrex::Real Y[], amrex::Real& WBAR)
   {
     amrex::Real tmp[NUM_SPECIES];
     get_imw(tmp);
@@ -344,21 +351,23 @@ struct Fuego
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RPE2dpdr_e(
+  AMREX_FORCE_INLINE
+  static void RPE2dpdr_e(
     amrex::Real R, amrex::Real P, amrex::Real /* E */, amrex::Real& dpdr_e)
   {
     dpdr_e = P / R;
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  RG2dpde(amrex::Real R, amrex::Real G, amrex::Real& dpde)
+  AMREX_FORCE_INLINE
+  static void RG2dpde(amrex::Real R, amrex::Real G, amrex::Real& dpde)
   {
     dpde = (G - 1.0) * R;
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RTY2dpde_dpdre(
+  AMREX_FORCE_INLINE
+  static void RTY2dpde_dpdre(
     amrex::Real R,
     amrex::Real T,
     amrex::Real Y[],

--- a/Eos/GammaLaw.H
+++ b/Eos/GammaLaw.H
@@ -21,7 +21,8 @@ struct GammaLaw
   static std::string identifier() { return "GammaLaw"; }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void molecular_weight(amrex::Real mw[])
+  AMREX_FORCE_INLINE
+  static void molecular_weight(amrex::Real mw[])
   {
     for (int n = 0; n < NUM_SPECIES; n++) {
       mw[n] = Constants::AIRMW;
@@ -29,7 +30,8 @@ struct GammaLaw
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void inv_molecular_weight(amrex::Real imw[])
+  AMREX_FORCE_INLINE
+  static void inv_molecular_weight(amrex::Real imw[])
   {
     for (int n = 0; n < NUM_SPECIES; n++) {
       imw[n] = 1. / Constants::AIRMW;
@@ -37,14 +39,15 @@ struct GammaLaw
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void Y2WBAR(amrex::Real* /*Y*/, amrex::Real& WBAR)
+  AMREX_FORCE_INLINE
+  static void Y2WBAR(amrex::Real* /*Y*/, amrex::Real& WBAR)
   {
     WBAR = Constants::AIRMW;
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void T2Ei(amrex::Real T, amrex::Real Ei[]) const
+  static void T2Ei(amrex::Real T, amrex::Real Ei[]) const
   {
     amrex::Real wbar = Constants::AIRMW;
     const amrex::Real Cv = Constants::RU / (wbar * (gamma - 1.0));
@@ -55,7 +58,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2Ei(
+  static void RTY2Ei(
     amrex::Real /*R*/,
     amrex::Real T,
     amrex::Real* /*Y[]*/,
@@ -66,7 +69,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void TY2Cv(amrex::Real /*T*/, amrex::Real Y[], amrex::Real& Cv)
+  static void TY2Cv(amrex::Real /*T*/, amrex::Real Y[], amrex::Real& Cv)
   {
     amrex::Real wbar;
     Y2WBAR(Y, wbar);
@@ -75,7 +78,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void
+  static void
   RTY2Cv(amrex::Real /*R*/, amrex::Real T, amrex::Real Y[], amrex::Real& Cv)
   {
     TY2Cv(T, Y, Cv);
@@ -83,7 +86,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void TY2Cp(amrex::Real T, amrex::Real Y[], amrex::Real& Cp)
+  static void TY2Cp(amrex::Real T, amrex::Real Y[], amrex::Real& Cp)
   {
     amrex::Real cv;
     TY2Cv(T, Y, cv);
@@ -92,7 +95,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void
+  static void
   RTY2Cp(amrex::Real /*R*/, amrex::Real T, amrex::Real Y[], amrex::Real& Cp)
   {
     TY2Cp(T, Y, Cp);
@@ -100,7 +103,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void T2Cpi(amrex::Real /*T*/, amrex::Real Cpi[]) const
+  static void T2Cpi(amrex::Real /*T*/, amrex::Real Cpi[]) const
   {
     for (int n = 0; n < NUM_SPECIES; n++) {
       Cpi[n] = gamma * Constants::RU / (Constants::AIRMW * (gamma - 1.0));
@@ -109,7 +112,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RYET2P(
+  static void RYET2P(
     amrex::Real R,
     amrex::Real* /*Y*/,
     amrex::Real& E,
@@ -121,7 +124,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RPY2Cs(
+  static void RPY2Cs(
     amrex::Real R, amrex::Real P, amrex::Real* /*Y*/, amrex::Real& Cs) const
   {
     Cs = std::sqrt(gamma * P / R);
@@ -129,7 +132,8 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2Cs(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cs)
+  static void
+  RTY2Cs(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cs)
   {
     amrex::Real wbar, P;
     Y2WBAR(Y, wbar);
@@ -141,7 +145,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void EY2T(amrex::Real E, amrex::Real Y[], amrex::Real& T)
+  static void EY2T(amrex::Real E, amrex::Real Y[], amrex::Real& T)
   {
     amrex::Real poverrho, wbar;
     poverrho = (gamma - 1.0) * E;
@@ -151,14 +155,15 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void REY2T(amrex::Real /*R*/, amrex::Real E, amrex::Real Y[], amrex::Real& T)
+  static void
+  REY2T(amrex::Real /*R*/, amrex::Real E, amrex::Real Y[], amrex::Real& T)
   {
     EY2T(E, Y, T);
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void HY2T(amrex::Real H, amrex::Real* /*Y*/, amrex::Real& T) const
+  static void HY2T(amrex::Real H, amrex::Real* /*Y*/, amrex::Real& T) const
   {
     amrex::Real wbar = Constants::AIRMW;
     const amrex::Real Cv = Constants::RU / (wbar * (gamma - 1.0));
@@ -167,7 +172,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void
+  static void
   RHY2T(amrex::Real /*R*/, amrex::Real H, amrex::Real Y[], amrex::Real& T) const
   {
     HY2T(H, Y, T);
@@ -175,7 +180,8 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
+  static void
+  RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
   {
     amrex::Real Cv, E;
     TY2Cv(T, Y, Cv);
@@ -184,7 +190,8 @@ struct GammaLaw
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RYP2T(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& T)
   {
     amrex::Real wbar;
@@ -193,7 +200,8 @@ struct GammaLaw
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RTY2WDOT(
+  AMREX_FORCE_INLINE
+  static void RTY2WDOT(
     amrex::Real /*R*/,
     amrex::Real /*T*/,
     amrex::Real* /*Y[]*/,
@@ -203,7 +211,8 @@ struct GammaLaw
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RTY2JAC(
+  AMREX_FORCE_INLINE
+  static void RTY2JAC(
     amrex::Real /*R*/,
     amrex::Real /*T*/,
     amrex::Real* /*Y[]*/,
@@ -214,7 +223,8 @@ struct GammaLaw
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RTY2C(
+  AMREX_FORCE_INLINE
+  static void RTY2C(
     amrex::Real /*R*/,
     amrex::Real /*T*/,
     amrex::Real* /*Y[]*/,
@@ -224,7 +234,8 @@ struct GammaLaw
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void Y2X(const amrex::Real Y[], amrex::Real X[])
+  AMREX_FORCE_INLINE
+  static void Y2X(const amrex::Real Y[], amrex::Real X[])
   {
     for (int n = 0; n < NUM_SPECIES; n++) {
       X[n] = Y[n];
@@ -232,7 +243,8 @@ struct GammaLaw
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void X2Y(const amrex::Real X[], amrex::Real Y[])
+  AMREX_FORCE_INLINE
+  static void X2Y(const amrex::Real X[], amrex::Real Y[])
   {
     for (int n = 0; n < NUM_SPECIES; n++) {
       Y[n] = X[n];
@@ -241,7 +253,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void PYT2RE(
+  static void PYT2RE(
     amrex::Real P,
     amrex::Real Y[],
     amrex::Real T,
@@ -255,7 +267,8 @@ struct GammaLaw
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   PYT2R(amrex::Real P, amrex::Real Y[], amrex::Real T, amrex::Real& R)
   {
     amrex::Real wbar;
@@ -265,7 +278,8 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RYP2E(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& E)
+  static void
+  RYP2E(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& E)
   {
     amrex::Real wbar;
     Y2WBAR(Y, wbar);
@@ -274,7 +288,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void TY2E(amrex::Real T, const amrex::Real Y[], amrex::Real& E) const
+  static void TY2E(amrex::Real T, const amrex::Real Y[], amrex::Real& E) const
   {
     amrex::Real ei[NUM_SPECIES];
     T2Ei(T, ei);
@@ -286,7 +300,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void
+  static void
   RTY2E(amrex::Real /*R*/, amrex::Real T, amrex::Real Y[], amrex::Real& E) const
   {
     TY2E(T, Y, E);
@@ -294,7 +308,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void T2Hi(amrex::Real T, amrex::Real Hi[]) const
+  static void T2Hi(amrex::Real T, amrex::Real Hi[]) const
   {
     amrex::Real wbar = Constants::AIRMW;
     const amrex::Real Cv = Constants::RU / (wbar * (gamma - 1.0));
@@ -305,7 +319,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2Hi(
+  static void RTY2Hi(
     amrex::Real /*R*/,
     amrex::Real T,
     amrex::Real* /*Y[]*/,
@@ -315,18 +329,19 @@ struct GammaLaw
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void S(amrex::Real& s) { s = 1.0; }
+  AMREX_FORCE_INLINE
+  static void S(amrex::Real& s) { s = 1.0; }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void TY2G(amrex::Real /*T*/, amrex::Real* /*Y*/, amrex::Real& G) const
+  static void TY2G(amrex::Real /*T*/, amrex::Real* /*Y*/, amrex::Real& G) const
   {
     G = gamma;
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void
+  static void
   RTY2G(amrex::Real /*R*/, amrex::Real T, amrex::Real* Y, amrex::Real& G) const
   {
     TY2G(T, Y, G);
@@ -334,7 +349,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void
+  static void
   TY2H(amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H) const
   {
     amrex::Real Hi[NUM_SPECIES];
@@ -349,7 +364,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RPE2dpdr_e(
+  static void RPE2dpdr_e(
     amrex::Real /*R*/,
     amrex::Real /*P*/,
     amrex::Real E,
@@ -360,14 +375,14 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RG2dpde(amrex::Real R, amrex::Real /*G*/, amrex::Real& dpde) const
+  static void RG2dpde(amrex::Real R, amrex::Real /*G*/, amrex::Real& dpde) const
   {
     dpde = (gamma - 1.0) * R;
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2dpde_dpdre(
+  static void RTY2dpde_dpdre(
     amrex::Real R,
     amrex::Real T,
     amrex::Real Y[],

--- a/Eos/GammaLaw.H
+++ b/Eos/GammaLaw.H
@@ -50,7 +50,7 @@ struct GammaLaw
   static void T2Ei(amrex::Real T, amrex::Real Ei[]) const
   {
     amrex::Real wbar = Constants::AIRMW;
-    const amrex::Real Cv = Constants::RU / (wbar * (gamma - 1.0));
+    const amrex::Real Cv = Constants::RU / (wbar * (Constants::gamma - 1.0));
     for (int n = 0; n < NUM_SPECIES; n++) {
       Ei[n] = Cv * T;
     }
@@ -73,7 +73,7 @@ struct GammaLaw
   {
     amrex::Real wbar;
     Y2WBAR(Y, wbar);
-    Cv = Constants::RU / (wbar * (gamma - 1.0));
+    Cv = Constants::RU / (wbar * (Constants::gamma - 1.0));
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -90,7 +90,7 @@ struct GammaLaw
   {
     amrex::Real cv;
     TY2Cv(T, Y, cv);
-    Cp = gamma * cv;
+    Cp = Constants::gamma * cv;
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -106,7 +106,8 @@ struct GammaLaw
   static void T2Cpi(amrex::Real /*T*/, amrex::Real Cpi[]) const
   {
     for (int n = 0; n < NUM_SPECIES; n++) {
-      Cpi[n] = gamma * Constants::RU / (Constants::AIRMW * (gamma - 1.0));
+      Cpi[n] = Constants::gamma * Constants::RU /
+               (Constants::AIRMW * (Constants::gamma - 1.0));
     }
   }
 
@@ -119,7 +120,7 @@ struct GammaLaw
     amrex::Real& /*T*/,
     amrex::Real& P) const
   {
-    P = (gamma - 1.0) * R * E;
+    P = (Constants::gamma - 1.0) * R * E;
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -127,7 +128,7 @@ struct GammaLaw
   static void RPY2Cs(
     amrex::Real R, amrex::Real P, amrex::Real* /*Y*/, amrex::Real& Cs) const
   {
-    Cs = std::sqrt(gamma * P / R);
+    Cs = std::sqrt(Constants::gamma * P / R);
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -137,10 +138,10 @@ struct GammaLaw
   {
     amrex::Real wbar, P;
     Y2WBAR(Y, wbar);
-    amrex::Real Cv = Constants::RU / (wbar * (gamma - 1.0));
+    amrex::Real Cv = Constants::RU / (wbar * (Constants::gamma - 1.0));
     amrex::Real E = Cv * T;
     RYET2P(R, Y, E, T, P);
-    Cs = std::sqrt(gamma * P / R);
+    Cs = std::sqrt(Constants::gamma * P / R);
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -148,7 +149,7 @@ struct GammaLaw
   static void EY2T(amrex::Real E, amrex::Real Y[], amrex::Real& T)
   {
     amrex::Real poverrho, wbar;
-    poverrho = (gamma - 1.0) * E;
+    poverrho = (Constants::gamma - 1.0) * E;
     Y2WBAR(Y, wbar);
     T = poverrho * wbar / Constants::RU;
   }
@@ -166,8 +167,8 @@ struct GammaLaw
   static void HY2T(amrex::Real H, amrex::Real* /*Y*/, amrex::Real& T) const
   {
     amrex::Real wbar = Constants::AIRMW;
-    const amrex::Real Cv = Constants::RU / (wbar * (gamma - 1.0));
-    T = H / (Cv * gamma);
+    const amrex::Real Cv = Constants::RU / (wbar * (Constants::gamma - 1.0));
+    T = H / (Cv * Constants::gamma);
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -186,7 +187,7 @@ struct GammaLaw
     amrex::Real Cv, E;
     TY2Cv(T, Y, Cv);
     E = Cv * T;
-    P = (gamma - 1.0) * R * E;
+    P = (Constants::gamma - 1.0) * R * E;
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -263,7 +264,7 @@ struct GammaLaw
     amrex::Real wbar;
     Y2WBAR(Y, wbar);
     R = P * wbar / (Constants::RU * T);
-    E = P / (R * (gamma - 1.0));
+    E = P / (R * (Constants::gamma - 1.0));
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -283,7 +284,7 @@ struct GammaLaw
   {
     amrex::Real wbar;
     Y2WBAR(Y, wbar);
-    E = P / (R * (gamma - 1.0));
+    E = P / (R * (Constants::gamma - 1.0));
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -311,9 +312,9 @@ struct GammaLaw
   static void T2Hi(amrex::Real T, amrex::Real Hi[]) const
   {
     amrex::Real wbar = Constants::AIRMW;
-    const amrex::Real Cv = Constants::RU / (wbar * (gamma - 1.0));
+    const amrex::Real Cv = Constants::RU / (wbar * (Constants::gamma - 1.0));
     for (int n = 0; n < NUM_SPECIES; n++) {
-      Hi[n] = Cv * T * gamma;
+      Hi[n] = Cv * T * Constants::gamma;
     }
   }
 
@@ -336,7 +337,7 @@ struct GammaLaw
   AMREX_FORCE_INLINE
   static void TY2G(amrex::Real /*T*/, amrex::Real* /*Y*/, amrex::Real& G) const
   {
-    G = gamma;
+    G = Constants::gamma;
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -354,10 +355,10 @@ struct GammaLaw
   {
     amrex::Real Hi[NUM_SPECIES];
     amrex::Real wbar = Constants::AIRMW;
-    const amrex::Real Cv = Constants::RU / (wbar * (gamma - 1.0));
+    const amrex::Real Cv = Constants::RU / (wbar * (Constants::gamma - 1.0));
     H = 0.0;
     for (int n = 0; n < NUM_SPECIES; n++) {
-      Hi[n] = Cv * T * gamma;
+      Hi[n] = Cv * T * Constants::gamma;
       H = H + Y[n] * Hi[n];
     }
   }
@@ -370,14 +371,14 @@ struct GammaLaw
     amrex::Real E,
     amrex::Real& dpdr_e) const
   {
-    dpdr_e = (gamma - 1.0) * E;
+    dpdr_e = (Constants::gamma - 1.0) * E;
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void RG2dpde(amrex::Real R, amrex::Real /*G*/, amrex::Real& dpde) const
   {
-    dpde = (gamma - 1.0) * R;
+    dpde = (Constants::gamma - 1.0) * R;
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -400,7 +401,6 @@ struct GammaLaw
   AMREX_GPU_HOST_DEVICE GammaLaw(Args... /*unused*/)
   {
   }
-  amrex::Real gamma{Constants::gamma};
 };
 
 } // namespace eos

--- a/Eos/GammaLaw.H
+++ b/Eos/GammaLaw.H
@@ -47,7 +47,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void T2Ei(amrex::Real T, amrex::Real Ei[]) const
+  static void T2Ei(amrex::Real T, amrex::Real Ei[])
   {
     amrex::Real wbar = Constants::AIRMW;
     const amrex::Real Cv = Constants::RU / (wbar * (Constants::gamma - 1.0));
@@ -59,10 +59,7 @@ struct GammaLaw
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void RTY2Ei(
-    amrex::Real /*R*/,
-    amrex::Real T,
-    amrex::Real* /*Y[]*/,
-    amrex::Real Ei[]) const
+    amrex::Real /*R*/, amrex::Real T, amrex::Real* /*Y[]*/, amrex::Real Ei[])
   {
     T2Ei(T, Ei);
   }
@@ -103,7 +100,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void T2Cpi(amrex::Real /*T*/, amrex::Real Cpi[]) const
+  static void T2Cpi(amrex::Real /*T*/, amrex::Real Cpi[])
   {
     for (int n = 0; n < NUM_SPECIES; n++) {
       Cpi[n] = Constants::gamma * Constants::RU /
@@ -118,15 +115,15 @@ struct GammaLaw
     amrex::Real* /*Y*/,
     amrex::Real& E,
     amrex::Real& /*T*/,
-    amrex::Real& P) const
+    amrex::Real& P)
   {
     P = (Constants::gamma - 1.0) * R * E;
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void RPY2Cs(
-    amrex::Real R, amrex::Real P, amrex::Real* /*Y*/, amrex::Real& Cs) const
+  static void
+  RPY2Cs(amrex::Real R, amrex::Real P, amrex::Real* /*Y*/, amrex::Real& Cs)
   {
     Cs = std::sqrt(Constants::gamma * P / R);
   }
@@ -164,7 +161,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void HY2T(amrex::Real H, amrex::Real* /*Y*/, amrex::Real& T) const
+  static void HY2T(amrex::Real H, amrex::Real* /*Y*/, amrex::Real& T)
   {
     amrex::Real wbar = Constants::AIRMW;
     const amrex::Real Cv = Constants::RU / (wbar * (Constants::gamma - 1.0));
@@ -174,7 +171,7 @@ struct GammaLaw
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void
-  RHY2T(amrex::Real /*R*/, amrex::Real H, amrex::Real Y[], amrex::Real& T) const
+  RHY2T(amrex::Real /*R*/, amrex::Real H, amrex::Real Y[], amrex::Real& T)
   {
     HY2T(H, Y, T);
   }
@@ -289,7 +286,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void TY2E(amrex::Real T, const amrex::Real Y[], amrex::Real& E) const
+  static void TY2E(amrex::Real T, const amrex::Real Y[], amrex::Real& E)
   {
     amrex::Real ei[NUM_SPECIES];
     T2Ei(T, ei);
@@ -302,14 +299,14 @@ struct GammaLaw
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void
-  RTY2E(amrex::Real /*R*/, amrex::Real T, amrex::Real Y[], amrex::Real& E) const
+  RTY2E(amrex::Real /*R*/, amrex::Real T, amrex::Real Y[], amrex::Real& E)
   {
     TY2E(T, Y, E);
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void T2Hi(amrex::Real T, amrex::Real Hi[]) const
+  static void T2Hi(amrex::Real T, amrex::Real Hi[])
   {
     amrex::Real wbar = Constants::AIRMW;
     const amrex::Real Cv = Constants::RU / (wbar * (Constants::gamma - 1.0));
@@ -321,10 +318,7 @@ struct GammaLaw
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void RTY2Hi(
-    amrex::Real /*R*/,
-    amrex::Real T,
-    amrex::Real* /*Y[]*/,
-    amrex::Real Hi[]) const
+    amrex::Real /*R*/, amrex::Real T, amrex::Real* /*Y[]*/, amrex::Real Hi[])
   {
     T2Hi(T, Hi);
   }
@@ -335,7 +329,7 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void TY2G(amrex::Real /*T*/, amrex::Real* /*Y*/, amrex::Real& G) const
+  static void TY2G(amrex::Real /*T*/, amrex::Real* /*Y*/, amrex::Real& G)
   {
     G = Constants::gamma;
   }
@@ -343,7 +337,7 @@ struct GammaLaw
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void
-  RTY2G(amrex::Real /*R*/, amrex::Real T, amrex::Real* Y, amrex::Real& G) const
+  RTY2G(amrex::Real /*R*/, amrex::Real T, amrex::Real* Y, amrex::Real& G)
   {
     TY2G(T, Y, G);
   }
@@ -351,7 +345,7 @@ struct GammaLaw
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void
-  TY2H(amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H) const
+  TY2H(amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
   {
     amrex::Real Hi[NUM_SPECIES];
     amrex::Real wbar = Constants::AIRMW;
@@ -366,17 +360,14 @@ struct GammaLaw
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void RPE2dpdr_e(
-    amrex::Real /*R*/,
-    amrex::Real /*P*/,
-    amrex::Real E,
-    amrex::Real& dpdr_e) const
+    amrex::Real /*R*/, amrex::Real /*P*/, amrex::Real E, amrex::Real& dpdr_e)
   {
     dpdr_e = (Constants::gamma - 1.0) * E;
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void RG2dpde(amrex::Real R, amrex::Real /*G*/, amrex::Real& dpde) const
+  static void RG2dpde(amrex::Real R, amrex::Real /*G*/, amrex::Real& dpde)
   {
     dpde = (Constants::gamma - 1.0) * R;
   }

--- a/Eos/SRK.H
+++ b/Eos/SRK.H
@@ -20,7 +20,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void MixingRuleAmBm(
+  void MixingRuleAmBm(
     amrex::Real T, const amrex::Real Y[], amrex::Real& am, amrex::Real& bm)
   {
     am = 0.0;
@@ -46,8 +46,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  MixingRuleAm(amrex::Real T, const amrex::Real Y[], amrex::Real& am)
+  void MixingRuleAm(amrex::Real T, const amrex::Real Y[], amrex::Real& am)
   {
     am = 0.0;
     AMREX_ASSERT(T > 0.0);
@@ -70,7 +69,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void MixingRuleBm(const amrex::Real Y[], amrex::Real& bm)
+  void MixingRuleBm(const amrex::Real Y[], amrex::Real& bm)
   {
     bm = 0.0;
     for (int ii = 0; ii < NUM_SPECIES; ii++) {
@@ -80,8 +79,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  Calc_dAmdT(amrex::Real T, const amrex::Real Y[], amrex::Real& dAmdT)
+  void Calc_dAmdT(amrex::Real T, const amrex::Real Y[], amrex::Real& dAmdT)
   {
     dAmdT = 0.0;
     AMREX_ASSERT(T > 0.0);
@@ -107,8 +105,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  Calc_dAmdY(amrex::Real T, const amrex::Real Y[], amrex::Real dAmdY[])
+  void Calc_dAmdY(amrex::Real T, const amrex::Real Y[], amrex::Real dAmdY[])
   {
     AMREX_ASSERT(T > 0.0);
     const amrex::Real sqrtT = std::sqrt(T);
@@ -129,7 +126,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void Calc_d2AmdY2(
+  void Calc_d2AmdY2(
     amrex::Real T, amrex::Real* /*Y[]*/, amrex::Real d2AmdY2[][NUM_SPECIES])
   {
     AMREX_ASSERT(T > 0.0);
@@ -150,8 +147,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  Calc_d2AmdTY(amrex::Real T, const amrex::Real Y[], amrex::Real d2AmdTY[])
+  void Calc_d2AmdTY(amrex::Real T, const amrex::Real Y[], amrex::Real d2AmdTY[])
   {
     AMREX_ASSERT(T > 0.0);
     const amrex::Real oneOverT = 1.0 / T;
@@ -220,8 +216,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  Calc_d2AmdT2(amrex::Real T, const amrex::Real Y[], amrex::Real& d2AmdT2)
+  void Calc_d2AmdT2(amrex::Real T, const amrex::Real Y[], amrex::Real& d2AmdT2)
   {
     AMREX_ASSERT(T > 0.0);
     const amrex::Real oneOverT = 1.0 / T;
@@ -250,7 +245,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void Calc_Am_and_derivs(
+  void Calc_Am_and_derivs(
     amrex::Real T,
     const amrex::Real Y[],
     amrex::Real& am,
@@ -324,8 +319,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RTY2Cp(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cp)
+  void RTY2Cp(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cp)
   {
     amrex::Real bm, am, dAmdT, d2AmdT2;
     amrex::Real K1, Cpig, wbar, tau, Rm;
@@ -365,8 +359,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RTY2Cv(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cv)
+  void RTY2Cv(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cv)
   {
     amrex::Real am, bm, d2AmdT2;
     // Alternative: MixingRuleBm then Calc_Am_and_derivs
@@ -394,8 +387,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  REY2T(amrex::Real R, amrex::Real E, amrex::Real Y[], amrex::Real& T)
+  void REY2T(amrex::Real R, amrex::Real E, amrex::Real Y[], amrex::Real& T)
   {
     // NOTE: for this function T is the output, but the input T serves as the
     // initial guess for Newton iteration, so it must be initialized to
@@ -458,8 +450,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
+  void RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
   {
     amrex::Real wbar, tau, am, bm;
     tau = 1.0 / R;
@@ -470,7 +461,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void RYET2P(
+  void RYET2P(
     amrex::Real R,
     amrex::Real Y[],
     amrex::Real& E,
@@ -490,8 +481,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RYP2T(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& T)
+  void RYP2T(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& T)
   {
     amrex::Real am, bm, dAmdT;
     amrex::Real tau, wbar, Rm, Pnp1, dpdT;
@@ -530,8 +520,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RTY2C(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real acti[])
+  void RTY2C(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real acti[])
   {
     amrex::Real am, bm, dAmdY[NUM_SPECIES];
     amrex::Real inv_mwt[NUM_SPECIES], mwt[NUM_SPECIES];
@@ -563,7 +552,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
+  void
   RTY2WDOT(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real WDOT[])
   {
     amrex::Real C[NUM_SPECIES];
@@ -598,8 +587,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RTY2Ei(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real Ei[])
+  void RTY2Ei(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real Ei[])
   {
     amrex::Real am, bm, dAmdT, dAmdY[NUM_SPECIES], d2AmdTY[NUM_SPECIES];
     amrex::Real K1, inv_bm, InvEosT3Denom;
@@ -626,8 +614,7 @@ struct SRK
   // Function added for SRK
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RTY2E(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& E)
+  void RTY2E(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& E)
   {
     amrex::Real Ei[NUM_SPECIES];
     amrex::Real am, bm, dAmdT, K1;
@@ -657,7 +644,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void PYT2RE(
+  void PYT2RE(
     amrex::Real P,
     amrex::Real Y[],
     amrex::Real T,
@@ -685,8 +672,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  PYT2R(amrex::Real P, amrex::Real Y[], amrex::Real T, amrex::Real& R)
+  void PYT2R(amrex::Real P, amrex::Real Y[], amrex::Real T, amrex::Real& R)
   {
     amrex::Real am, bm, Z, wbar;
     MixingRuleAmBm(T, Y, am, bm);
@@ -697,8 +683,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RYP2E(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& E)
+  void RYP2E(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& E)
   {
     amrex::Real T;
     // Note: could get away with one fewer MixingRuleAm by writing this
@@ -717,8 +702,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RTY2Hi(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real Hi[])
+  void RTY2Hi(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real Hi[])
   {
     amrex::Real am, bm, dAmdT, d2AmdT2;
     amrex::Real dAmdY[NUM_SPECIES], d2AmdTY[NUM_SPECIES], inv_mwt[NUM_SPECIES];
@@ -778,7 +762,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void RTY2G(
+  void RTY2G(
     amrex::Real R, amrex::Real T, amrex::Real Y[NUM_SPECIES], amrex::Real& G)
   {
     amrex::Real bm, am, dAmdT, d2AmdT2;
@@ -818,8 +802,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RPY2Cs(amrex::Real R, amrex::Real P, amrex::Real Y[], amrex::Real& Cs)
+  void RPY2Cs(amrex::Real R, amrex::Real P, amrex::Real Y[], amrex::Real& Cs)
   {
     amrex::Real T, G;
     // RTY2Cs involves some redundant Am calcs but add cost is small relative
@@ -831,8 +814,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RTY2Cs(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cs)
+  void RTY2Cs(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cs)
   {
     amrex::Real P, G;
     // RTY2P involves one redundant MixingRuleAm
@@ -888,7 +870,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void RTY2dpde_dpdre(
+  void RTY2dpde_dpdre(
     amrex::Real R,
     amrex::Real T,
     amrex::Real Y[],
@@ -918,7 +900,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void RTY2transport(
+  void RTY2transport(
     amrex::Real R,
     amrex::Real T,
     amrex::Real Y[],

--- a/Eos/SRK.H
+++ b/Eos/SRK.H
@@ -20,7 +20,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void MixingRuleAmBm(
+  static void MixingRuleAmBm(
     amrex::Real T, const amrex::Real Y[], amrex::Real& am, amrex::Real& bm)
   {
     am = 0.0;
@@ -46,7 +46,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void MixingRuleAm(amrex::Real T, const amrex::Real Y[], amrex::Real& am)
+  static void
+  MixingRuleAm(amrex::Real T, const amrex::Real Y[], amrex::Real& am)
   {
     am = 0.0;
     AMREX_ASSERT(T > 0.0);
@@ -69,7 +70,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void MixingRuleBm(const amrex::Real Y[], amrex::Real& bm)
+  static void MixingRuleBm(const amrex::Real Y[], amrex::Real& bm)
   {
     bm = 0.0;
     for (int ii = 0; ii < NUM_SPECIES; ii++) {
@@ -79,7 +80,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void Calc_dAmdT(amrex::Real T, const amrex::Real Y[], amrex::Real& dAmdT)
+  static void
+  Calc_dAmdT(amrex::Real T, const amrex::Real Y[], amrex::Real& dAmdT)
   {
     dAmdT = 0.0;
     AMREX_ASSERT(T > 0.0);
@@ -105,7 +107,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void Calc_dAmdY(amrex::Real T, const amrex::Real Y[], amrex::Real dAmdY[])
+  static void
+  Calc_dAmdY(amrex::Real T, const amrex::Real Y[], amrex::Real dAmdY[])
   {
     AMREX_ASSERT(T > 0.0);
     const amrex::Real sqrtT = std::sqrt(T);
@@ -126,7 +129,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void Calc_d2AmdY2(
+  static void Calc_d2AmdY2(
     amrex::Real T, amrex::Real* /*Y[]*/, amrex::Real d2AmdY2[][NUM_SPECIES])
   {
     AMREX_ASSERT(T > 0.0);
@@ -147,7 +150,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void Calc_d2AmdTY(amrex::Real T, const amrex::Real Y[], amrex::Real d2AmdTY[])
+  static void
+  Calc_d2AmdTY(amrex::Real T, const amrex::Real Y[], amrex::Real d2AmdTY[])
   {
     AMREX_ASSERT(T > 0.0);
     const amrex::Real oneOverT = 1.0 / T;
@@ -172,7 +176,8 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void Calc_CompressFactor_Z(
+  AMREX_FORCE_INLINE
+  static void Calc_CompressFactor_Z(
     amrex::Real& Z,
     amrex::Real am,
     amrex::Real bm,
@@ -215,7 +220,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void Calc_d2AmdT2(amrex::Real T, const amrex::Real Y[], amrex::Real& d2AmdT2)
+  static void
+  Calc_d2AmdT2(amrex::Real T, const amrex::Real Y[], amrex::Real& d2AmdT2)
   {
     AMREX_ASSERT(T > 0.0);
     const amrex::Real oneOverT = 1.0 / T;
@@ -244,7 +250,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void Calc_Am_and_derivs(
+  static void Calc_Am_and_derivs(
     amrex::Real T,
     const amrex::Real Y[],
     amrex::Real& am,
@@ -301,19 +307,16 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void molecular_weight(amrex::Real mw[])
-  {
-    get_mw(mw);
-  }
+  AMREX_FORCE_INLINE
+  static void molecular_weight(amrex::Real mw[]) { get_mw(mw); }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void inv_molecular_weight(amrex::Real imw[])
-  {
-    get_imw(imw);
-  }
+  AMREX_FORCE_INLINE
+  static void inv_molecular_weight(amrex::Real imw[]) { get_imw(imw); }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   TY2Cp(amrex::Real /*T*/, amrex::Real* /*Y[]*/, amrex::Real& /*Cp*/)
   {
     amrex::Error("TY2Cp not physically possible for SRK EoS");
@@ -321,7 +324,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2Cp(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cp)
+  static void
+  RTY2Cp(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cp)
   {
     amrex::Real bm, am, dAmdT, d2AmdT2;
     amrex::Real K1, Cpig, wbar, tau, Rm;
@@ -352,7 +356,8 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   TY2Cv(amrex::Real /*T*/, amrex::Real* /*Y[]*/, amrex::Real& /*Cp*/)
   {
     amrex::Error("TY2Cv not physically possible for SRK EoS");
@@ -360,7 +365,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2Cv(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cv)
+  static void
+  RTY2Cv(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cv)
   {
     amrex::Real am, bm, d2AmdT2;
     // Alternative: MixingRuleBm then Calc_Am_and_derivs
@@ -371,15 +377,15 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  T2Cpi(amrex::Real /*T*/, amrex::Real* /*Cpi[]*/)
+  AMREX_FORCE_INLINE
+  static void T2Cpi(amrex::Real /*T*/, amrex::Real* /*Cpi[]*/)
   {
     amrex::Error("T2Cpi not physically possible for SRK EoS");
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  EY2T(amrex::Real /*E*/, amrex::Real* /*Y[]*/, amrex::Real& /*T*/)
+  AMREX_FORCE_INLINE
+  static void EY2T(amrex::Real /*E*/, amrex::Real* /*Y[]*/, amrex::Real& /*T*/)
   {
     // For Fuego this function is really just a wrapper for GET_T_GIVEN_EY
     // In SRK this will be different probably
@@ -388,7 +394,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void REY2T(amrex::Real R, amrex::Real E, amrex::Real Y[], amrex::Real& T)
+  static void
+  REY2T(amrex::Real R, amrex::Real E, amrex::Real Y[], amrex::Real& T)
   {
     // NOTE: for this function T is the output, but the input T serves as the
     // initial guess for Newton iteration, so it must be initialized to
@@ -430,15 +437,16 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  HY2T(amrex::Real /*H*/, amrex::Real* /*Y[]*/, amrex::Real& /*T*/)
+  AMREX_FORCE_INLINE
+  static void HY2T(amrex::Real /*H*/, amrex::Real* /*Y[]*/, amrex::Real& /*T*/)
   {
     // In SRK this  function is not possible
     amrex::Error("HY2T not physically possible for this EoS");
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RHY2T(
+  AMREX_FORCE_INLINE
+  static void RHY2T(
     amrex::Real /*R*/,
     amrex::Real /*H*/,
     amrex::Real* /*Y[]*/,
@@ -450,7 +458,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
+  static void
+  RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
   {
     amrex::Real wbar, tau, am, bm;
     tau = 1.0 / R;
@@ -461,7 +470,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RYET2P(
+  static void RYET2P(
     amrex::Real R,
     amrex::Real Y[],
     amrex::Real& E,
@@ -481,7 +490,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RYP2T(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& T)
+  static void
+  RYP2T(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& T)
   {
     amrex::Real am, bm, dAmdT;
     amrex::Real tau, wbar, Rm, Pnp1, dpdT;
@@ -520,7 +530,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2C(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real acti[])
+  static void
+  RTY2C(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real acti[])
   {
     amrex::Real am, bm, dAmdY[NUM_SPECIES];
     amrex::Real inv_mwt[NUM_SPECIES], mwt[NUM_SPECIES];
@@ -552,7 +563,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void
+  static void
   RTY2WDOT(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real WDOT[])
   {
     amrex::Real C[NUM_SPECIES];
@@ -567,7 +578,8 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RTY2JAC(
+  AMREX_FORCE_INLINE
+  static void RTY2JAC(
     amrex::Real /*R*/,
     amrex::Real /*T*/,
     amrex::Real* /*Y[]*/,
@@ -578,14 +590,16 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void T2Ei(amrex::Real /*T*/, amrex::Real* /*Ei[]*/)
+  AMREX_FORCE_INLINE
+  static void T2Ei(amrex::Real /*T*/, amrex::Real* /*Ei[]*/)
   {
     amrex::Error("T2Ei not physically possible for SRK EoS");
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2Ei(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real Ei[])
+  static void
+  RTY2Ei(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real Ei[])
   {
     amrex::Real am, bm, dAmdT, dAmdY[NUM_SPECIES], d2AmdTY[NUM_SPECIES];
     amrex::Real K1, inv_bm, InvEosT3Denom;
@@ -612,7 +626,8 @@ struct SRK
   // Function added for SRK
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2E(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& E)
+  static void
+  RTY2E(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& E)
   {
     amrex::Real Ei[NUM_SPECIES];
     amrex::Real am, bm, dAmdT, K1;
@@ -633,20 +648,16 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void Y2X(amrex::Real Y[], amrex::Real X[])
-  {
-    CKYTX(Y, X);
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void X2Y(amrex::Real X[], amrex::Real Y[])
-  {
-    CKXTY(X, Y);
-  }
+  AMREX_FORCE_INLINE
+  static void Y2X(amrex::Real Y[], amrex::Real X[]) { CKYTX(Y, X); }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void PYT2RE(
+  static void X2Y(amrex::Real X[], amrex::Real Y[]) { CKXTY(X, Y); }
+
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  static void PYT2RE(
     amrex::Real P,
     amrex::Real Y[],
     amrex::Real T,
@@ -674,7 +685,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void PYT2R(amrex::Real P, amrex::Real Y[], amrex::Real T, amrex::Real& R)
+  static void
+  PYT2R(amrex::Real P, amrex::Real Y[], amrex::Real T, amrex::Real& R)
   {
     amrex::Real am, bm, Z, wbar;
     MixingRuleAmBm(T, Y, am, bm);
@@ -685,7 +697,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RYP2E(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& E)
+  static void
+  RYP2E(amrex::Real R, amrex::Real Y[], amrex::Real P, amrex::Real& E)
   {
     amrex::Real T;
     // Note: could get away with one fewer MixingRuleAm by writing this
@@ -696,14 +709,16 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void T2Hi(amrex::Real /*T*/, amrex::Real* /*Hi[]*/)
+  AMREX_FORCE_INLINE
+  static void T2Hi(amrex::Real /*T*/, amrex::Real* /*Hi[]*/)
   {
     amrex::Error("T2Hi not physically possible for SRK EoS");
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2Hi(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real Hi[])
+  static void
+  RTY2Hi(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real Hi[])
   {
     amrex::Real am, bm, dAmdT, d2AmdT2;
     amrex::Real dAmdY[NUM_SPECIES], d2AmdTY[NUM_SPECIES], inv_mwt[NUM_SPECIES];
@@ -751,18 +766,19 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void S(amrex::Real& s) { s = 1.0; }
+  AMREX_FORCE_INLINE
+  static void S(amrex::Real& s) { s = 1.0; }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  TY2G(amrex::Real /*T*/, amrex::Real* /*Y[]*/, amrex::Real& /*G*/)
+  AMREX_FORCE_INLINE
+  static void TY2G(amrex::Real /*T*/, amrex::Real* /*Y[]*/, amrex::Real& /*G*/)
   {
     amrex::Error("TY2G not physically possible for SRK EoS");
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2G(
+  static void RTY2G(
     amrex::Real R, amrex::Real T, amrex::Real Y[NUM_SPECIES], amrex::Real& G)
   {
     amrex::Real bm, am, dAmdT, d2AmdT2;
@@ -802,7 +818,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RPY2Cs(amrex::Real R, amrex::Real P, amrex::Real Y[], amrex::Real& Cs)
+  static void
+  RPY2Cs(amrex::Real R, amrex::Real P, amrex::Real Y[], amrex::Real& Cs)
   {
     amrex::Real T, G;
     // RTY2Cs involves some redundant Am calcs but add cost is small relative
@@ -814,7 +831,8 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2Cs(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cs)
+  static void
+  RTY2Cs(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& Cs)
   {
     amrex::Real P, G;
     // RTY2P involves one redundant MixingRuleAm
@@ -824,7 +842,8 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   TY2H(amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
   {
     amrex::Real hi[NUM_SPECIES];
@@ -836,8 +855,8 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
-  Y2WBAR(const amrex::Real Y[], amrex::Real& WBAR)
+  AMREX_FORCE_INLINE
+  static void Y2WBAR(const amrex::Real Y[], amrex::Real& WBAR)
   {
     amrex::Real tmp[NUM_SPECIES];
     get_imw(tmp);
@@ -849,7 +868,8 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void RPE2dpdr_e(
+  AMREX_FORCE_INLINE
+  static void RPE2dpdr_e(
     amrex::Real /*R*/,
     amrex::Real /*P*/,
     amrex::Real /* E */,
@@ -859,7 +879,8 @@ struct SRK
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void
+  AMREX_FORCE_INLINE
+  static void
   RG2dpde(amrex::Real /*R*/, amrex::Real /*G*/, amrex::Real& /*dpde*/)
   {
     amrex::Error("RG2dpde not physically possible for SRK EoS");
@@ -867,7 +888,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2dpde_dpdre(
+  static void RTY2dpde_dpdre(
     amrex::Real R,
     amrex::Real T,
     amrex::Real Y[],
@@ -897,7 +918,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2transport(
+  static void RTY2transport(
     amrex::Real R,
     amrex::Real T,
     amrex::Real Y[],

--- a/Transport/Constant.H
+++ b/Transport/Constant.H
@@ -13,7 +13,7 @@ struct ConstTransport
   static std::string identifier() { return "ConstTransport"; }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void transport(
+  AMREX_FORCE_INLINE static void transport(
     const bool wtr_get_xi,
     const bool wtr_get_mu,
     const bool wtr_get_lam,
@@ -48,7 +48,7 @@ struct ConstTransport
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void get_transport_coeffs(
+  AMREX_FORCE_INLINE static void get_transport_coeffs(
     amrex::Box const& bx,
     amrex::Array4<const amrex::Real> const& /*Y_in*/,
     amrex::Array4<const amrex::Real> const& /*T_in*/,

--- a/Transport/Simple.H
+++ b/Transport/Simple.H
@@ -209,7 +209,7 @@ struct SimpleTransport
   static std::string identifier() { return "SimpleTransport"; }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void comp_pure_bulk(
+  AMREX_FORCE_INLINE static void comp_pure_bulk(
     amrex::Real Tloc,
     const amrex::Real* muloc,
     amrex::Real* xiloc,
@@ -266,7 +266,7 @@ struct SimpleTransport
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void transport(
+  AMREX_FORCE_INLINE static void transport(
     const bool wtr_get_xi,
     const bool wtr_get_mu,
     const bool wtr_get_lam,
@@ -366,7 +366,7 @@ struct SimpleTransport
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void get_transport_coeffs(
+  AMREX_FORCE_INLINE static void get_transport_coeffs(
     amrex::Box const& bx,
     amrex::Array4<const amrex::Real> const& Y_in,
     amrex::Array4<const amrex::Real> const& T_in,

--- a/Transport/Sutherland.H
+++ b/Transport/Sutherland.H
@@ -13,7 +13,7 @@ struct SutherlandTransport
   static std::string identifier() { return "Sutherland"; }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void transport(
+  AMREX_FORCE_INLINE static void transport(
     const bool wtr_get_xi,
     const bool wtr_get_mu,
     const bool wtr_get_lam,
@@ -58,7 +58,7 @@ struct SutherlandTransport
   }
 
   AMREX_GPU_HOST_DEVICE
-  static AMREX_FORCE_INLINE void get_transport_coeffs(
+  AMREX_FORCE_INLINE static void get_transport_coeffs(
     amrex::Box const& bx,
     amrex::Array4<const amrex::Real> const& Y_in,
     amrex::Array4<const amrex::Real> const& T_in,


### PR DESCRIPTION
Rather than using automated tools to fix this, I just made these functions more consistent.