### PR TITLE
Use gamma as member of EOS class

### DIFF
--- a/Eos/GammaLaw.H
+++ b/Eos/GammaLaw.H
@@ -392,6 +392,9 @@ struct GammaLaw
   AMREX_GPU_HOST_DEVICE GammaLaw(Args... /*unused*/)
   {
   }
+
+  amrex::Real gamma{Constants::gamma};
+
 };
 
 } // namespace eos

--- a/Eos/GammaLaw.H
+++ b/Eos/GammaLaw.H
@@ -394,7 +394,6 @@ struct GammaLaw
   }
 
   amrex::Real gamma{Constants::gamma};
-
 };
 
 } // namespace eos


### PR DESCRIPTION
I had problems directly using the constant in PeleC that I don't want to debug.