### PR TITLE
correct species init to stay bounded in Eos and Tran Eval utilities

### DIFF
--- a/Testing/Exec/EosEval/GPU_misc.H
+++ b/Testing/Exec/EosEval/GPU_misc.H
@@ -51,11 +51,11 @@ initialize_data(
   temp(i, j, k) = 500.0;
   rho(i, j, k) = 0.01;
 #else
-  temp(i, j, k) = 500.0 + dTemp * std::sin(2.0 * pi * y / P[1]);
-  rho(i, j, k) = 0.01 + dRho * std::sin(2.0 * pi * y / P[1]);
+  temp(i, j, k) = 500.0 + dTemp * std::sin(2.0 * pi * (y - plo[1]) / P[1]);
+  rho(i, j, k) = 0.01 + dRho * std::sin(2.0 * pi * (y - plo[1]) / P[1]);
 #endif
   for (int n = 0; n < NUM_SPECIES; n++) {
-    mf(i, j, k, n) = Y_lo[n] + (Y_hi[n] - Y_lo[n]) * x / L[0];
+    mf(i, j, k, n) = Y_lo[n] + (Y_hi[n] - Y_lo[n]) * (x - plo[0]) / L[0];
   }
   // corr Yk
   amrex::Real dummy = 0.0;
@@ -73,7 +73,7 @@ initialize_data(
 #if (AMREX_SPACEDIM == 1)
   energy(i, j, k) = energy(i, j, k);
 #else
-  energy(i, j, k) = energy(i, j, k) + denergy * std::sin(2.0 * pi * y / P[1]);
+  energy(i, j, k) = energy(i, j, k) + denergy * std::sin(2.0 * pi * (y - plo[1]) / P[1]);
 #endif
 }
 

--- a/Testing/Exec/EosEval/GPU_misc.H
+++ b/Testing/Exec/EosEval/GPU_misc.H
@@ -73,7 +73,8 @@ initialize_data(
 #if (AMREX_SPACEDIM == 1)
   energy(i, j, k) = energy(i, j, k);
 #else
-  energy(i, j, k) = energy(i, j, k) + denergy * std::sin(2.0 * pi * (y - plo[1]) / P[1]);
+  energy(i, j, k) =
+    energy(i, j, k) + denergy * std::sin(2.0 * pi * (y - plo[1]) / P[1]);
 #endif
 }
 

--- a/Testing/Exec/TranEval/GPU_misc.H
+++ b/Testing/Exec/TranEval/GPU_misc.H
@@ -48,11 +48,11 @@ initialize_data(
   temp(i, j, k) = 500.0;
   rho(i, j, k) = 0.01;
 #else
-  temp(i, j, k) = 500.0 + dTemp * std::sin(2.0 * pi * y / P[1]);
-  rho(i, j, k) = 0.01 + dRho * std::sin(2.0 * pi * y / P[1]);
+  temp(i, j, k) = 500.0 + dTemp * std::sin(2.0 * pi * (y - plo[1]) / P[1]);
+  rho(i, j, k) = 0.01 + dRho * std::sin(2.0 * pi * (y - plo[1]) / P[1]);
 #endif
   for (int n = 0; n < NUM_SPECIES; n++) {
-    spec(i, j, k, n) = Y_lo[n] + (Y_hi[n] - Y_lo[n]) * x / L[0];
+    spec(i, j, k, n) = Y_lo[n] + (Y_hi[n] - Y_lo[n]) * (x - plo[0]) / L[0];
   }
   // corr Yk
   amrex::Real dummy = 0.0;


### PR DESCRIPTION
Previous init causes out of bounds species.