### PR TITLE
ensure RK64 reactor doesn't integrate beyond the desired time

### DIFF
--- a/Reactions/ReactorRK64.cpp
+++ b/Reactions/ReactorRK64.cpp
@@ -134,6 +134,8 @@ ReactorRK64::react(
         dt_rk = amrex::max<amrex::Real>(dt_rk_min, dt_rk * change_factor);
       }
     }
+    // Don't overstep the integration time
+    dt_rk = amrex::min<amrex::Real>(dt_rk, time_out - current_time);
     d_nsteps[icell] = nsteps;
     // copy data back
     for (int sp = 0; sp < neq; sp++) {
@@ -283,6 +285,8 @@ ReactorRK64::react(
           rkp.betaerr_rk64 * pow((captured_abstol / max_err), rkp.exp2_rk64);
         dt_rk = amrex::max<amrex::Real>(dt_rk_min, dt_rk * change_factor);
       }
+      // Don't overstep the integration time
+      dt_rk = amrex::min<amrex::Real>(dt_rk, time_out - current_time);
     }
 
     // copy data back


### PR DESCRIPTION
The RK64 integrator just goes until the desired time is reached or exceeded and the timesteps are generally not even fractions of the integration time, so the last timestep will often go past the desired time by a small amount.

This PR fixes that by ensuring that the last timestep gets you exactly to the desired integration time.