### PR TITLE
Format common expressions

### DIFF
--- a/Support/ceptr/ceptr/ceptr.py
+++ b/Support/ceptr/ceptr/ceptr.py
@@ -10,7 +10,9 @@ import ceptr.converter as converter
 def convert(fname, hformat, remove_1, remove_pow2, min_op_count):
     """Convert a mechanism file."""
     mechanism = ct.Solution(fname)
-    conv = converter.Converter(mechanism, hformat, remove_1, remove_pow2, min_op_count)
+    conv = converter.Converter(
+        mechanism, hformat, remove_1, remove_pow2, min_op_count
+    )
     conv.writer()
     conv.formatter()
 
@@ -67,14 +69,25 @@ def main():
         help="Min number of operation count per expression",
         default=0,
     )
-    
 
     args = parser.parse_args()
 
     if args.fname:
-        convert(args.fname, args.hformat, args.remove_1, args.remove_pow2, args.min_op_count)
+        convert(
+            args.fname,
+            args.hformat,
+            args.remove_1,
+            args.remove_pow2,
+            args.min_op_count,
+        )
     elif args.lst:
-        convert_lst(args.lst, args.hformat, args.remove_1, args.remove_pow2, args.min_op_count)
+        convert_lst(
+            args.lst,
+            args.hformat,
+            args.remove_1,
+            args.remove_pow2,
+            args.min_op_count,
+        )
 
 
 if __name__ == "__main__":

--- a/Support/ceptr/ceptr/ceptr.py
+++ b/Support/ceptr/ceptr/ceptr.py
@@ -7,10 +7,10 @@ import cantera as ct
 import ceptr.converter as converter
 
 
-def convert(fname, hformat):
+def convert(fname, hformat, remove_1, remove_pow2, min_op_count):
     """Convert a mechanism file."""
     mechanism = ct.Solution(fname)
-    conv = converter.Converter(mechanism, hformat)
+    conv = converter.Converter(mechanism, hformat, remove_1, remove_pow2, min_op_count)
     conv.writer()
     conv.formatter()
 
@@ -44,12 +44,37 @@ def main():
         required=False,
     )
 
+    parser.add_argument(
+        "-r1",
+        "--remove_1",
+        action="store_true",
+        help="Remove factor 1.0 in printed expressions",
+    )
+
+    parser.add_argument(
+        "-rp2",
+        "--remove_pow2",
+        action="store_true",
+        help="Remove pow(...,2) in printed expressions",
+    )
+
+    parser.add_argument(
+        "-moc",
+        "--min_op_count",
+        type=int,
+        metavar="",
+        required=False,
+        help="Min number of operation count per expression",
+        default=0,
+    )
+    
+
     args = parser.parse_args()
 
     if args.fname:
-        convert(args.fname, args.hformat)
+        convert(args.fname, args.hformat, args.remove_1, args.remove_pow2, args.min_op_count)
     elif args.lst:
-        convert_lst(args.lst, args.hformat)
+        convert_lst(args.lst, args.hformat, args.remove_1, args.remove_pow2, args.min_op_count)
 
 
 if __name__ == "__main__":

--- a/Support/ceptr/ceptr/converter.py
+++ b/Support/ceptr/ceptr/converter.py
@@ -26,9 +26,12 @@ import ceptr.writer as cw
 class Converter:
     """Convert Cantera mechanism to C++ files for Pele."""
 
-    def __init__(self, mechanism, hformat):
+    def __init__(self, mechanism, hformat, remove_1, remove_pow2, min_op_count):
         self.mechanism = mechanism
         self.hformat = hformat
+        self.remove_1 = remove_1
+        self.remove_pow2 = remove_pow2
+        self.min_op_count = min_op_count
         self.mechpath = pathlib.Path(self.mechanism.source)
         self.rootname = "mechanism"
         self.hdrname = self.mechpath.parents[0] / f"{self.rootname}.H"
@@ -76,6 +79,9 @@ class Converter:
             self.reaction_info,
             self.mechanism,
             self.hformat,
+            self.remove_1,
+            self.remove_pow2,
+            self.min_op_count,
         )
 
     def set_species(self):
@@ -379,14 +385,14 @@ class Converter:
             )
             print(f"Time to do production_rate = {time.time()-times}")
 
-            # print("Symbolic wdot print for debug")
-            # cp.production_rate_debug(
-            #    hdr,
-            #    self.mechanism,
-            #    self.species_info,
-            #    self.reaction_info,
-            #    self.syms,
-            # )
+            print("Symbolic wdot print for debug")
+            cp.production_rate_debug(
+               hdr,
+               self.mechanism,
+               self.species_info,
+               self.reaction_info,
+               self.syms,
+            )
 
             times = time.time()
             self.species_info.identify_wdot_dependencies(self.syms)
@@ -476,13 +482,13 @@ class Converter:
                 precond=True,
             )
             # # Analytical jacobian on GPU -- not used on CPU, define in mechanism.cpp
-            cj.ajac(
-                hdr,
-                self.mechanism,
-                self.species_info,
-                self.reaction_info,
-                syms=self.syms,
-            )
+            # cj.ajac(
+            #     hdr,
+            #     self.mechanism,
+            #     self.species_info,
+            #     self.reaction_info,
+            #     syms=self.syms,
+            # )
             cj.dproduction_rate(
                 hdr, self.mechanism, self.species_info, self.reaction_info
             )

--- a/Support/ceptr/ceptr/converter.py
+++ b/Support/ceptr/ceptr/converter.py
@@ -26,7 +26,9 @@ import ceptr.writer as cw
 class Converter:
     """Convert Cantera mechanism to C++ files for Pele."""
 
-    def __init__(self, mechanism, hformat, remove_1, remove_pow2, min_op_count):
+    def __init__(
+        self, mechanism, hformat, remove_1, remove_pow2, min_op_count
+    ):
         self.mechanism = mechanism
         self.hformat = hformat
         self.remove_1 = remove_1

--- a/Support/ceptr/ceptr/converter.py
+++ b/Support/ceptr/ceptr/converter.py
@@ -385,14 +385,14 @@ class Converter:
             )
             print(f"Time to do production_rate = {time.time()-times}")
 
-            print("Symbolic wdot print for debug")
-            cp.production_rate_debug(
-               hdr,
-               self.mechanism,
-               self.species_info,
-               self.reaction_info,
-               self.syms,
-            )
+            # print("Symbolic wdot print for debug")
+            # cp.production_rate_debug(
+            #    hdr,
+            #    self.mechanism,
+            #    self.species_info,
+            #    self.reaction_info,
+            #    self.syms,
+            # )
 
             times = time.time()
             self.species_info.identify_wdot_dependencies(self.syms)

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -31,7 +31,7 @@ def ajac(
     else:
         cw.writer(
             fstream,
-            "void aJacobian_old(amrex::Real * J, amrex::Real * sc, amrex::Real T,"
+            "void aJacobian(amrex::Real * J, amrex::Real * sc, amrex::Real T,"
             " const int consP)",
         )
     cw.writer(fstream, "{")

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -1643,7 +1643,7 @@ def dscqss_dsc_fast_debug(
             cw.writer(fstream)
 
             # Write the dscqss terms
-            syms.write_dscqss_to_cpp(syms, species_info, cw, fstream)
+            syms.write_dscqss_to_cpp(species_info, cw, fstream)
 
             cw.writer(fstream)
 
@@ -1775,10 +1775,10 @@ def ajac_term_fast_debug(
             cw.writer(fstream, cw.comment("Species terms"))
             if syms.hformat == "readable":
                 syms.write_symjac_readable_to_cpp(
-                    syms, species_info, cw, fstream
+                    species_info, cw, fstream
                 )
             else:
-                syms.write_symjac_to_cpp(syms, species_info, cw, fstream)
+                syms.write_symjac_to_cpp(species_info, cw, fstream)
 
             cw.writer(fstream)
 

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -1774,9 +1774,7 @@ def ajac_term_fast_debug(
             # Now write out the species jacobian terms
             cw.writer(fstream, cw.comment("Species terms"))
             if syms.hformat == "readable":
-                syms.write_symjac_readable_to_cpp(
-                    species_info, cw, fstream
-                )
+                syms.write_symjac_readable_to_cpp(species_info, cw, fstream)
             else:
                 syms.write_symjac_to_cpp(species_info, cw, fstream)
 

--- a/Support/ceptr/ceptr/production.py
+++ b/Support/ceptr/ceptr/production.py
@@ -714,8 +714,12 @@ def production_rate(
                                 "    %.15g * exp(-tc[1] * %.15g)"
                                 % (1.0 - troe[0], (1 / troe[1])),
                             )
-                            first_factor = syms.convert_number_to_int(1.0 - troe[0])
-                            second_factor = syms.convert_number_to_int(-1 / troe[1])
+                            first_factor = syms.convert_number_to_int(
+                                1.0 - troe[0]
+                            )
+                            second_factor = syms.convert_number_to_int(
+                                -1 / troe[1]
+                            )
                             int_smp += first_factor * sme.exp(
                                 syms.tc_smp[1] * second_factor
                             )
@@ -729,7 +733,9 @@ def production_rate(
                                 % (troe[0], (1 / troe[2])),
                             )
                             first_factor = syms.convert_number_to_int(troe[0])
-                            second_factor = syms.convert_number_to_int(-1 / troe[2])
+                            second_factor = syms.convert_number_to_int(
+                                -1 / troe[2]
+                            )
                             int_smp += first_factor * sme.exp(
                                 syms.tc_smp[1] * second_factor
                             )
@@ -945,7 +951,9 @@ def production_rate(
                                     coefficient,
                                 ),
                             )
-                            coefficient = syms.convert_number_to_int(coefficient)
+                            coefficient = syms.convert_number_to_int(
+                                coefficient
+                            )
                             syms.wdot_smp[
                                 species_info.ordered_idx_map[symbol]
                             ] -= (coefficient * qdot_smp)
@@ -969,7 +977,9 @@ def production_rate(
                                     coefficient,
                                 ),
                             )
-                            coefficient = syms.convert_number_to_int(coefficient)
+                            coefficient = syms.convert_number_to_int(
+                                coefficient
+                            )
                             syms.wdot_smp[
                                 species_info.ordered_idx_map[symbol]
                             ] += (coefficient * qdot_smp)

--- a/Support/ceptr/ceptr/production.py
+++ b/Support/ceptr/ceptr/production.py
@@ -703,7 +703,7 @@ def production_rate(
                     )
                     logPred_smp = sme.log(redP_smp, 10)
                     cw.writer(fstream, "const amrex::Real logFcent = log10(")
-                    intLog_smp = 0.0
+                    int_smp = 0.0
                     if abs(troe[1]) > 1.0e-100:
                         if 1.0 - troe[0] != 0:
                             cw.writer(
@@ -711,7 +711,7 @@ def production_rate(
                                 "    %.15g * exp(-tc[1] * %.15g)"
                                 % (1.0 - troe[0], (1 / troe[1])),
                             )
-                            intLog_smp += (1.0 - troe[0]) * sme.exp(
+                            int_smp += (1.0 - troe[0]) * sme.exp(
                                 -syms.tc_smp[1] * (1 / troe[1])
                             )
                     else:
@@ -723,7 +723,7 @@ def production_rate(
                                 "    + %.15g * exp(-tc[1] * %.15g)"
                                 % (troe[0], (1 / troe[2])),
                             )
-                            intLog_smp += troe[0] * sme.exp(
+                            int_smp += troe[0] * sme.exp(
                                 -syms.tc_smp[1] * (1 / troe[2])
                             )
                     else:
@@ -733,15 +733,15 @@ def production_rate(
                             cw.writer(
                                 fstream, "    + exp(%.15g * invT));" % -troe[3]
                             )
-                            intLog_smp += sme.exp(-troe[3] * syms.invT_smp)
+                            int_smp += sme.exp(-troe[3] * syms.invT_smp)
                         else:
                             cw.writer(
                                 fstream, "    + exp(-%.15g * invT));" % troe[3]
                             )
-                            intLog_smp += sme.exp(-troe[3] * syms.invT_smp)
+                            int_smp += sme.exp(-troe[3] * syms.invT_smp)
                     else:
                         cw.writer(fstream, "    + 0.0);")
-                    logFcent_smp = sme.log(intLog_smp, 10)
+                    logFcent_smp = sme.log(int_smp, 10)
                     cw.writer(
                         fstream,
                         "const amrex::Real troe_c = -0.4 - 0.67 * logFcent;",

--- a/Support/ceptr/ceptr/production.py
+++ b/Support/ceptr/ceptr/production.py
@@ -711,8 +711,10 @@ def production_rate(
                                 "    %.15g * exp(-tc[1] * %.15g)"
                                 % (1.0 - troe[0], (1 / troe[1])),
                             )
-                            int_smp += (1.0 - troe[0]) * sme.exp(
-                                -syms.tc_smp[1] * (1 / troe[1])
+                            first_factor = syms.convert_number_to_int(1.0 - troe[0])
+                            second_factor = syms.convert_number_to_int(-1 / troe[1])
+                            int_smp += first_factor * sme.exp(
+                                syms.tc_smp[1] * second_factor
                             )
                     else:
                         cw.writer(fstream, "     0.0 ")
@@ -723,8 +725,10 @@ def production_rate(
                                 "    + %.15g * exp(-tc[1] * %.15g)"
                                 % (troe[0], (1 / troe[2])),
                             )
-                            int_smp += troe[0] * sme.exp(
-                                -syms.tc_smp[1] * (1 / troe[2])
+                            first_factor = syms.convert_number_to_int(troe[0])
+                            second_factor = syms.convert_number_to_int(-1 / troe[2])
+                            int_smp += first_factor * sme.exp(
+                                syms.tc_smp[1] * second_factor
                             )
                     else:
                         cw.writer(fstream, "    + 0.0 ")
@@ -733,12 +737,14 @@ def production_rate(
                             cw.writer(
                                 fstream, "    + exp(%.15g * invT));" % -troe[3]
                             )
-                            int_smp += sme.exp(-troe[3] * syms.invT_smp)
+                            first_factor = syms.convert_number_to_int(-troe[3])
+                            int_smp += sme.exp(first_factor * syms.invT_smp)
                         else:
                             cw.writer(
                                 fstream, "    + exp(-%.15g * invT));" % troe[3]
                             )
-                            int_smp += sme.exp(-troe[3] * syms.invT_smp)
+                            first_factor = syms.convert_number_to_int(-troe[3])
+                            int_smp += sme.exp(first_factor * syms.invT_smp)
                     else:
                         cw.writer(fstream, "    + 0.0);")
                     logFcent_smp = sme.log(int_smp, 10)

--- a/Support/ceptr/ceptr/production.py
+++ b/Support/ceptr/ceptr/production.py
@@ -609,6 +609,9 @@ def production_rate(
                     )
                     sys.exit(1)
 
+            beta = syms.convert_number_to_int(beta)
+            low_beta = syms.convert_number_to_int(low_beta)
+
             cw.writer(
                 fstream,
                 cw.comment("reaction %d:  %s" % (orig_idx, reaction.equation)),
@@ -942,6 +945,7 @@ def production_rate(
                                     coefficient,
                                 ),
                             )
+                            coefficient = syms.convert_number_to_int(coefficient)
                             syms.wdot_smp[
                                 species_info.ordered_idx_map[symbol]
                             ] -= (coefficient * qdot_smp)
@@ -965,6 +969,7 @@ def production_rate(
                                     coefficient,
                                 ),
                             )
+                            coefficient = syms.convert_number_to_int(coefficient)
                             syms.wdot_smp[
                                 species_info.ordered_idx_map[symbol]
                             ] += (coefficient * qdot_smp)

--- a/Support/ceptr/ceptr/progressBar.py
+++ b/Support/ceptr/ceptr/progressBar.py
@@ -1,0 +1,36 @@
+import sys
+
+# Print iterations progress
+def printProgressBar(
+    iteration,
+    total,
+    prefix="",
+    suffix="",
+    decimals=1,
+    length=100,
+    fill="█",
+    printEnd="\r",
+):
+    """
+    Call in a loop to create terminal progress bar
+    @params:
+        iteration   - Required  : current iteration (Int)
+        total       - Required  : total iterations (Int)
+        prefix      - Optional  : prefix string (Str)
+        suffix      - Optional  : suffix string (Str)
+        decimals    - Optional  : positive number of decimals in percent complete (Int)
+        length      - Optional  : character length of bar (Int)
+        fill        - Optional  : bar fill character (Str)
+        printEnd    - Optional  : end character (e.g. "\r", "\r\n") (Str)
+    """
+    percent = ("{0:." + str(decimals) + "f}").format(
+        100 * (iteration / float(total))
+    )
+    filledLength = int(length * iteration // total)
+    bar = fill * filledLength + "-" * (length - filledLength)
+    print(f"\x1b[2K\r{prefix} |{bar}| {percent}% {suffix}", end=printEnd)
+    sys.stdout.flush()
+    # Print New Line on Complete
+    if iteration == total:
+        print()
+        sys.stdout.flush()

--- a/Support/ceptr/ceptr/progressBar.py
+++ b/Support/ceptr/ceptr/progressBar.py
@@ -1,5 +1,6 @@
 import sys
 
+
 # Print iterations progress
 def printProgressBar(
     iteration,

--- a/Support/ceptr/ceptr/qssa_converter.py
+++ b/Support/ceptr/ceptr/qssa_converter.py
@@ -1565,9 +1565,9 @@ def qssa_coeff_functions(
         )
         coeff1 = cc.Patm_pa
         coeff2 = cc.R.to(cc.ureg.joule / (cc.ureg.mole / cc.ureg.kelvin)).m
-        syms.refC_smp = coeff1 / coeff2 * syms.invT_smp
+        #syms.refC_smp = coeff1 / coeff2 * syms.invT_smp
         cw.writer(fstream, "const amrex::Real refCinv = 1. / refC;")
-        syms.refCinv_smp = 1.0 / syms.refC_smp
+        #syms.refCinv_smp = 1.0 / syms.refC_smp
 
     cw.writer(fstream, cw.comment("compute the mixture concentration"))
     cw.writer(fstream, "amrex::Real mixture = 0.0;")

--- a/Support/ceptr/ceptr/qssa_converter.py
+++ b/Support/ceptr/ceptr/qssa_converter.py
@@ -1649,6 +1649,9 @@ def qssa_coeff_functions(
                 print(f"Unrecognized reaction rate type: {reaction.equation}")
                 sys.exit(1)
 
+        beta = syms.convert_number_to_int(beta)
+        low_beta = syms.convert_number_to_int(low_beta)
+ 
         cw.writer(fstream, "{")
         cw.writer(
             fstream,
@@ -3492,10 +3495,17 @@ def qssa_return_coeff(mechanism, species_info, reaction, reagents, syms):
             phi_smp += [conc_smp]
         if len(phi) < 1:
             phi = ["1.0"]
-            phi_smp = [1.0]
+            if syms.remove_1:
+                phi_smp = [1]
+            else:
+                phi_smp = [1.0]
 
-    qssa_coeff_smp = 1.0
+    if syms.remove_1:
+        qssa_coeff_smp = 1
+    else:
+        qssa_coeff_smp = 1.0
     for phival in phi_smp:
         qssa_coeff_smp *= phival
 
+    qssa_coeff_smp = syms.convert_symb_to_int(qssa_coeff_smp)
     return "*".join(phi), qssa_coeff_smp

--- a/Support/ceptr/ceptr/qssa_converter.py
+++ b/Support/ceptr/ceptr/qssa_converter.py
@@ -1117,7 +1117,9 @@ def sort_qssa_solution_elements(mechanism, species_info, reaction_info, syms):
                             + str(reaction_info.qfqr_co_idx_map.index(r))
                             + "]"
                         )
-                        species_appearances = syms.convert_number_to_int(species_appearances)
+                        species_appearances = syms.convert_number_to_int(
+                            species_appearances
+                        )
                         rhs_hold_smp.append(
                             species_appearances
                             * syms.qr_qss_smp[
@@ -1145,7 +1147,9 @@ def sort_qssa_solution_elements(mechanism, species_info, reaction_info, syms):
                         + str(reaction_info.qfqr_co_idx_map.index(r))
                         + "]"
                     )
-                    species_appearances = syms.convert_number_to_int(species_appearances)
+                    species_appearances = syms.convert_number_to_int(
+                        species_appearances
+                    )
                     rhs_hold_smp.append(
                         species_appearances
                         * syms.qf_qss_smp[
@@ -1181,7 +1185,9 @@ def sort_qssa_solution_elements(mechanism, species_info, reaction_info, syms):
                         + str(reaction_info.qfqr_co_idx_map.index(r))
                         + "]"
                     )
-                    species_appearances = syms.convert_number_to_int(species_appearances)
+                    species_appearances = syms.convert_number_to_int(
+                        species_appearances
+                    )
                     rhs_hold_smp.append(
                         species_appearances
                         * syms.qr_qss_smp[
@@ -1284,7 +1290,9 @@ def sort_qssa_solution_elements(mechanism, species_info, reaction_info, syms):
                             )
                             if len(group_coeff_hold_smp[other_qssa]) == 0:
                                 group_coeff_hold_smp[other_qssa] = [0]
-                            species_appearances = syms.convert_number_to_int(species_appearances)
+                            species_appearances = syms.convert_number_to_int(
+                                species_appearances
+                            )
                             group_coeff_hold_smp[other_qssa][0] += (
                                 species_appearances
                                 * syms.qr_qss_smp[
@@ -1321,7 +1329,9 @@ def sort_qssa_solution_elements(mechanism, species_info, reaction_info, syms):
                         + str(reaction_info.qfqr_co_idx_map.index(r))
                         + "]"
                     )
-                    species_appearances = syms.convert_number_to_int(species_appearances)
+                    species_appearances = syms.convert_number_to_int(
+                        species_appearances
+                    )
                     group_coeff_hold_smp[other_qssa][0] += (
                         species_appearances
                         * syms.qf_qss_smp[
@@ -1651,7 +1661,7 @@ def qssa_coeff_functions(
 
         beta = syms.convert_number_to_int(beta)
         low_beta = syms.convert_number_to_int(low_beta)
- 
+
         cw.writer(fstream, "{")
         cw.writer(
             fstream,
@@ -1783,8 +1793,12 @@ def qssa_coeff_functions(
                                 (1 / troe[1]),
                             ),
                         )
-                        first_factor = syms.convert_number_to_int(1.0 - troe[0])
-                        second_factor = syms.convert_number_to_int(-1 / troe[1])
+                        first_factor = syms.convert_number_to_int(
+                            1.0 - troe[0]
+                        )
+                        second_factor = syms.convert_number_to_int(
+                            -1 / troe[1]
+                        )
                         int_smp += first_factor * sme.exp(
                             syms.tc_smp[1] * second_factor
                         )
@@ -1802,7 +1816,9 @@ def qssa_coeff_functions(
                             ),
                         )
                         first_factor = syms.convert_number_to_int(troe[0])
-                        second_factor = syms.convert_number_to_int(-1 / troe[2])
+                        second_factor = syms.convert_number_to_int(
+                            -1 / troe[2]
+                        )
                         int_smp += first_factor * sme.exp(
                             syms.tc_smp[1] * second_factor
                         )

--- a/Support/ceptr/ceptr/qssa_converter.py
+++ b/Support/ceptr/ceptr/qssa_converter.py
@@ -1565,9 +1565,9 @@ def qssa_coeff_functions(
         )
         coeff1 = cc.Patm_pa
         coeff2 = cc.R.to(cc.ureg.joule / (cc.ureg.mole / cc.ureg.kelvin)).m
-        #syms.refC_smp = coeff1 / coeff2 * syms.invT_smp
+        # syms.refC_smp = coeff1 / coeff2 * syms.invT_smp
         cw.writer(fstream, "const amrex::Real refCinv = 1. / refC;")
-        #syms.refCinv_smp = 1.0 / syms.refC_smp
+        # syms.refCinv_smp = 1.0 / syms.refC_smp
 
     cw.writer(fstream, cw.comment("compute the mixture concentration"))
     cw.writer(fstream, "amrex::Real mixture = 0.0;")

--- a/Support/ceptr/ceptr/qssa_converter.py
+++ b/Support/ceptr/ceptr/qssa_converter.py
@@ -1117,8 +1117,9 @@ def sort_qssa_solution_elements(mechanism, species_info, reaction_info, syms):
                             + str(reaction_info.qfqr_co_idx_map.index(r))
                             + "]"
                         )
+                        species_appearances = syms.convert_number_to_int(species_appearances)
                         rhs_hold_smp.append(
-                            float(species_appearances)
+                            species_appearances
                             * syms.qr_qss_smp[
                                 reaction_info.qfqr_co_idx_map.index(r)
                             ]
@@ -1144,8 +1145,9 @@ def sort_qssa_solution_elements(mechanism, species_info, reaction_info, syms):
                         + str(reaction_info.qfqr_co_idx_map.index(r))
                         + "]"
                     )
+                    species_appearances = syms.convert_number_to_int(species_appearances)
                     rhs_hold_smp.append(
-                        float(species_appearances)
+                        species_appearances
                         * syms.qf_qss_smp[
                             reaction_info.qfqr_co_idx_map.index(r)
                         ]
@@ -1179,8 +1181,9 @@ def sort_qssa_solution_elements(mechanism, species_info, reaction_info, syms):
                         + str(reaction_info.qfqr_co_idx_map.index(r))
                         + "]"
                     )
+                    species_appearances = syms.convert_number_to_int(species_appearances)
                     rhs_hold_smp.append(
-                        float(species_appearances)
+                        species_appearances
                         * syms.qr_qss_smp[
                             reaction_info.qfqr_co_idx_map.index(r)
                         ]
@@ -1281,8 +1284,9 @@ def sort_qssa_solution_elements(mechanism, species_info, reaction_info, syms):
                             )
                             if len(group_coeff_hold_smp[other_qssa]) == 0:
                                 group_coeff_hold_smp[other_qssa] = [0]
+                            species_appearances = syms.convert_number_to_int(species_appearances)
                             group_coeff_hold_smp[other_qssa][0] += (
-                                float(species_appearances)
+                                species_appearances
                                 * syms.qr_qss_smp[
                                     reaction_info.qfqr_co_idx_map.index(r)
                                 ]
@@ -1317,8 +1321,9 @@ def sort_qssa_solution_elements(mechanism, species_info, reaction_info, syms):
                         + str(reaction_info.qfqr_co_idx_map.index(r))
                         + "]"
                     )
+                    species_appearances = syms.convert_number_to_int(species_appearances)
                     group_coeff_hold_smp[other_qssa][0] += (
-                        float(species_appearances)
+                        species_appearances
                         * syms.qf_qss_smp[
                             reaction_info.qfqr_co_idx_map.index(r)
                         ]
@@ -1775,8 +1780,10 @@ def qssa_coeff_functions(
                                 (1 / troe[1]),
                             ),
                         )
-                        int_smp += (1.0 - troe[0]) * sme.exp(
-                            -syms.tc_smp[1] * (1 / troe[1])
+                        first_factor = syms.convert_number_to_int(1.0 - troe[0])
+                        second_factor = syms.convert_number_to_int(-1 / troe[1])
+                        int_smp += first_factor * sme.exp(
+                            syms.tc_smp[1] * second_factor
                         )
                 else:
                     cw.writer(fstream, "     0.0 ")
@@ -1791,8 +1798,10 @@ def qssa_coeff_functions(
                                 (1 / troe[2]),
                             ),
                         )
-                        int_smp += (troe[0]) * sme.exp(
-                            -syms.tc_smp[1] * (1 / troe[2])
+                        first_factor = syms.convert_number_to_int(troe[0])
+                        second_factor = syms.convert_number_to_int(-1 / troe[2])
+                        int_smp += first_factor * sme.exp(
+                            syms.tc_smp[1] * second_factor
                         )
                 else:
                     cw.writer(fstream, "     0.0 ")
@@ -1803,13 +1812,15 @@ def qssa_coeff_functions(
                             fstream,
                             "    + exp(%.15g * invT));" % -troe[3],
                         )
-                        int_smp += sme.exp(-troe[3] * syms.invT_smp)
+                        first_factor = syms.convert_number_to_int(-troe[3])
+                        int_smp += sme.exp(first_factor * syms.invT_smp)
                     else:
                         cw.writer(
                             fstream,
                             "    + exp(-%.15g * invT));" % troe[3],
                         )
-                        int_smp += sme.exp(-troe[3] * syms.invT_smp)
+                        first_factor = syms.convert_number_to_int(-troe[3])
+                        int_smp += sme.exp(first_factor * syms.invT_smp)
                 else:
                     cw.writer(fstream, "    + 0.0);")
                     int_smp += 0.0

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -17,9 +17,13 @@ import ceptr.thermo as cth
 class SymbolicMath:
     """Symbols to carry throughout operations."""
 
-    def __init__(self, species_info, reaction_info, mechanism, hformat):
+    def __init__(self, species_info, reaction_info, mechanism, hformat, remove_1, remove_pow2, min_op_count):
 
+        # Formatting options
         self.hformat = hformat
+        self.remove_1 = remove_1
+        self.remove_pow2 = remove_pow2
+        self.min_op_count = min_op_count
 
         n_species = species_info.n_species
         n_qssa_species = species_info.n_qssa_species

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -11,14 +11,24 @@ import pandas as pd
 import symengine as sme
 import sympy as smp
 
-import ceptr.thermo as cth
 import ceptr.constants as cc
-from   ceptr.progressBar import printProgressBar
+import ceptr.thermo as cth
+from ceptr.progressBar import printProgressBar
+
 
 class SymbolicMath:
     """Symbols to carry throughout operations."""
 
-    def __init__(self, species_info, reaction_info, mechanism, hformat, remove_1, remove_pow2, min_op_count):
+    def __init__(
+        self,
+        species_info,
+        reaction_info,
+        mechanism,
+        hformat,
+        remove_1,
+        remove_pow2,
+        min_op_count,
+    ):
 
         # Formatting options
         self.hformat = hformat
@@ -220,16 +230,16 @@ class SymbolicMath:
         cpp_str = str(cppcode)
 
         if self.remove_1:
-            cpp_str = cpp_str.replace('1.0*', '')
+            cpp_str = cpp_str.replace("1.0*", "")
 
         return cpp_str
 
     # @profile
     def reduce_expr(self, orig):
-        ''' 
-            Loop over common and final expressions and remove the ones that have
-            a number of operation < self.min_op_count
-        '''
+        """
+        Loop over common and final expressions and remove the ones that have
+        a number of operation < self.min_op_count
+        """
 
         # Make a dict
         replacements = []
@@ -251,7 +261,7 @@ class SymbolicMath:
             suffix="Complete",
             length=20,
         )
-        for i, (lhs, rhs) in enumerate(zip(common_expr_lhs,common_expr_rhs)):
+        for i, (lhs, rhs) in enumerate(zip(common_expr_lhs, common_expr_rhs)):
             op_count = sme.count_ops(rhs)
             isFloat = True
             try:
@@ -260,36 +270,38 @@ class SymbolicMath:
             except RuntimeError:
                 isFloat = False
             if op_count < self.min_op_count or isFloat:
-               replacements.append(i)
-               ind = [j+i for j, s in enumerate(common_expr_symbols[i:]) if lhs in s]
-               for j in ind:
-                   common_expr_rhs[j] = common_expr_rhs[j].subs(lhs,rhs)
-                   common_expr_symbols[j].remove(lhs)
-               ind = [j for j, s in enumerate(final_expr_symbols) if lhs in s]
-               for j in ind:
-                   final_expr[j] = final_expr[j].subs(lhs,rhs)
-                   final_expr_symbols[j].remove(lhs)
-            
+                replacements.append(i)
+                ind = [
+                    j + i
+                    for j, s in enumerate(common_expr_symbols[i:])
+                    if lhs in s
+                ]
+                for j in ind:
+                    common_expr_rhs[j] = common_expr_rhs[j].subs(lhs, rhs)
+                    common_expr_symbols[j].remove(lhs)
+                ind = [j for j, s in enumerate(final_expr_symbols) if lhs in s]
+                for j in ind:
+                    final_expr[j] = final_expr[j].subs(lhs, rhs)
+                    final_expr_symbols[j].remove(lhs)
+
             printProgressBar(
-                        i+1,
-                        n_cse,
-                        prefix="Expr = %d / %d, removed Exp = %d "
-                        % (
-                            i+1,
-                            n_cse,
-                            len(replacements),
-                        ),
-                        suffix="Complete",
-                        length=20,
-                    )
+                i + 1,
+                n_cse,
+                prefix="Expr = %d / %d, removed Exp = %d "
+                % (
+                    i + 1,
+                    n_cse,
+                    len(replacements),
+                ),
+                suffix="Complete",
+                length=20,
+            )
         replacements.reverse()
         for rep in replacements:
             del common_expr_lhs[rep]
             del common_expr_rhs[rep]
 
-
         return common_expr_lhs, common_expr_rhs, final_expr
-
 
     # @profile
     def write_array_to_cpp(
@@ -490,8 +502,13 @@ class SymbolicMath:
 
         if self.min_op_count > 0:
             times = time.time()
-            common_expr_lhs, common_expr_rhs, final_expr = self.reduce_expr(array_cse)
-            print("reduced expressions in (time = %.3g s)" % (time.time() - times))
+            common_expr_lhs, common_expr_rhs, final_expr = self.reduce_expr(
+                array_cse
+            )
+            print(
+                "reduced expressions in (time = %.3g s)"
+                % (time.time() - times)
+            )
             times = time.time()
             for cse_idx in range(len(common_expr_lhs)):
                 left_cse = self.convert_to_cpp(common_expr_lhs[cse_idx])
@@ -535,7 +552,7 @@ class SymbolicMath:
                 cpp_str = self.convert_to_cpp(final_expr[i])
             else:
                 cpp_str = self.convert_to_cpp(array_cse[1][i])
-     
+
             num_idx = tuple_list[i][0]
             den_idx = tuple_list[i][1]
 

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -218,7 +218,9 @@ class SymbolicMath:
                     "Pow": [
                         (
                             lambda b, e: e.is_Integer and e == 2,
-                            lambda b, e: "(" + "*".join(["("+b+")"] * int(e)) + ")",
+                            lambda b, e: "("
+                            + "*".join(["(" + b + ")"] * int(e))
+                            + ")",
                         ),
                         (lambda b, e: not e.is_Integer, "pow"),
                     ]
@@ -244,10 +246,14 @@ class SymbolicMath:
     def convert_number_to_int(self, number):
         """Convert number to int if possible"""
         factor = float(number)
-        if self.remove_1 and abs(factor) < 1.1 and abs(factor - int(factor)) < 1e-16:
+        if (
+            self.remove_1
+            and abs(factor) < 1.1
+            and abs(factor - int(factor)) < 1e-16
+        ):
             factor = int(factor)
         return factor
- 
+
     # @profile
     def convert_symb_to_int(self, symb):
         """Convert symbol to int if possible"""
@@ -545,14 +551,14 @@ class SymbolicMath:
                         right_cse,
                     ),
                 )
-                #cw.writer(
+                # cw.writer(
                 #    fstream,
                 #    'std::cout << "%s = " << %s << "\\n";'
                 #    % (
                 #        left_cse,
                 #        left_cse
                 #    ),
-                #)
+                # )
         else:
             times = time.time()
             for cse_idx in range(len(array_cse[0])):

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -255,19 +255,19 @@ class SymbolicMath:
             )
 
     # @profile
-    def write_dscqss_to_cpp(self, syms, species_info, cw, fstream):
+    def write_dscqss_to_cpp(self, species_info, cw, fstream):
         """Write dscqss terms as functions of common subexpressions."""
 
-        n_dscqssdscqss = len(syms.dscqssdscqss)
-        n_dscqssdsc = len(syms.dscqssdsc)
+        n_dscqssdscqss = len(self.dscqssdscqss)
+        n_dscqssdsc = len(self.dscqssdsc)
 
-        list_smp = list(syms.dscqssdscqss.values()) + list(
-            syms.dscqssdsc.values()
+        list_smp = list(self.dscqssdscqss.values()) + list(
+            self.dscqssdsc.values()
         )
         n_total = len(list_smp)
 
-        dscqssdscqss_tuples = list(syms.dscqssdscqss.keys())
-        dscqssdsc_tuples = list(syms.dscqssdsc.keys())
+        dscqssdscqss_tuples = list(self.dscqssdscqss.keys())
+        dscqssdsc_tuples = list(self.dscqssdsc.keys())
         tuple_list = dscqssdscqss_tuples + dscqssdsc_tuples
 
         # Write common expressions
@@ -331,7 +331,7 @@ class SymbolicMath:
                 start_string = f"""dscqss{item["number"]}dsc{scnum}"""
                 chain_string = []
                 for scqss_dep in item["scqss_dep"]:
-                    scqssdepnum = syms.syms_to_specnum(scqss_dep)
+                    scqssdepnum = self.syms_to_specnum(scqss_dep)
                     chain_string.append(
                         f"""dscqss{item["number"]}dscqss{scqssdepnum} * dscqss_dsc[{species_info.n_species*scqssdepnum + scnum}]"""
                     )
@@ -353,26 +353,26 @@ class SymbolicMath:
                 )
 
     # @profile
-    def write_symjac_readable_to_cpp(self, syms, species_info, cw, fstream):
+    def write_symjac_readable_to_cpp(self, species_info, cw, fstream):
         """Write species jacobian terms as functions of common subexpressions."""
 
-        n_dscqssdscqss = len(syms.dscqssdscqss)
-        n_dscqssdsc = len(syms.dscqssdsc)
-        n_dwdotdscqss = len(syms.dwdotdscqss)
-        n_dwdotdsc = len(syms.dwdotdsc)
+        n_dscqssdscqss = len(self.dscqssdscqss)
+        n_dscqssdsc = len(self.dscqssdsc)
+        n_dwdotdscqss = len(self.dwdotdscqss)
+        n_dwdotdsc = len(self.dwdotdsc)
 
         list_smp = (
-            list(syms.dscqssdscqss.values())
-            + list(syms.dscqssdsc.values())
-            + list(syms.dwdotdscqss.values())
-            + list(syms.dwdotdsc.values())
+            list(self.dscqssdscqss.values())
+            + list(self.dscqssdsc.values())
+            + list(self.dwdotdscqss.values())
+            + list(self.dwdotdsc.values())
         )
         n_total = len(list_smp)
 
-        dscqssdscqss_tuples = list(syms.dscqssdscqss.keys())
-        dscqssdsc_tuples = list(syms.dscqssdsc.keys())
-        dwdotdscqss_tuples = list(syms.dwdotdscqss.keys())
-        dwdotdsc_tuples = list(syms.dwdotdsc.keys())
+        dscqssdscqss_tuples = list(self.dscqssdscqss.keys())
+        dscqssdsc_tuples = list(self.dscqssdsc.keys())
+        dwdotdscqss_tuples = list(self.dwdotdscqss.keys())
+        dwdotdsc_tuples = list(self.dwdotdsc.keys())
         tuple_list = (
             dscqssdscqss_tuples
             + dscqssdsc_tuples
@@ -458,7 +458,7 @@ class SymbolicMath:
                 start_string = f"""dscqss{item["number"]}dsc{scnum}"""
                 chain_string = []
                 for scqss_dep in item["scqss_dep"]:
-                    scqssdepnum = syms.syms_to_specnum(scqss_dep)
+                    scqssdepnum = self.syms_to_specnum(scqss_dep)
                     chain_string.append(
                         f"""dscqss{item["number"]}dscqss{scqssdepnum} * dscqss_dsc[{species_info.n_species*scqssdepnum + scnum}]"""
                     )
@@ -505,26 +505,26 @@ class SymbolicMath:
                 )
 
     # @profile
-    def write_symjac_to_cpp(self, syms, species_info, cw, fstream):
+    def write_symjac_to_cpp(self, species_info, cw, fstream):
         """Write species jacobian terms as functions of common subexpressions."""
 
-        n_dscqssdscqss = len(syms.dscqssdscqss)
-        n_dscqssdsc = len(syms.dscqssdsc)
-        n_dwdotdscqss = len(syms.dwdotdscqss)
-        n_dwdotdsc = len(syms.dwdotdsc)
+        n_dscqssdscqss = len(self.dscqssdscqss)
+        n_dscqssdsc = len(self.dscqssdsc)
+        n_dwdotdscqss = len(self.dwdotdscqss)
+        n_dwdotdsc = len(self.dwdotdsc)
 
         list_smp = (
-            list(syms.dscqssdscqss.values())
-            + list(syms.dscqssdsc.values())
-            + list(syms.dwdotdscqss.values())
-            + list(syms.dwdotdsc.values())
+            list(self.dscqssdscqss.values())
+            + list(self.dscqssdsc.values())
+            + list(self.dwdotdscqss.values())
+            + list(self.dwdotdsc.values())
         )
         n_total = len(list_smp)
 
-        dscqssdscqss_tuples = list(syms.dscqssdscqss.keys())
-        dscqssdsc_tuples = list(syms.dscqssdsc.keys())
-        dwdotdscqss_tuples = list(syms.dwdotdscqss.keys())
-        dwdotdsc_tuples = list(syms.dwdotdsc.keys())
+        dscqssdscqss_tuples = list(self.dscqssdscqss.keys())
+        dscqssdsc_tuples = list(self.dscqssdsc.keys())
+        dwdotdscqss_tuples = list(self.dwdotdscqss.keys())
+        dwdotdsc_tuples = list(self.dwdotdsc.keys())
         tuple_list = (
             dscqssdscqss_tuples
             + dscqssdsc_tuples

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -218,7 +218,7 @@ class SymbolicMath:
                     "Pow": [
                         (
                             lambda b, e: e.is_Integer and e == 2,
-                            lambda b, e: "(" + "*".join([b] * int(e)) + ")",
+                            lambda b, e: "(" + "*".join(["("+b+")"] * int(e)) + ")",
                         ),
                         (lambda b, e: not e.is_Integer, "pow"),
                     ]
@@ -521,6 +521,14 @@ class SymbolicMath:
                         right_cse,
                     ),
                 )
+                #cw.writer(
+                #    fstream,
+                #    'std::cout << "%s = " << %s << "\\n";'
+                #    % (
+                #        left_cse,
+                #        left_cse
+                #    ),
+                #)
         else:
             times = time.time()
             for cse_idx in range(len(array_cse[0])):

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -229,8 +229,8 @@ class SymbolicMath:
 
         cpp_str = str(cppcode)
 
-        #if self.remove_1:
-        #    cpp_str = cpp_str.replace("1.0*", "")
+        if self.remove_1:
+            cpp_str = cpp_str.replace("1.0*", "")
 
         return cpp_str
 
@@ -311,7 +311,7 @@ class SymbolicMath:
             printProgressBar(
                 i + 1,
                 n_cse,
-                prefix="Expr = %d / %d, removed Exp = %d "
+                prefix="Expr = %d / %d, removed expr = %d "
                 % (
                     i + 1,
                     n_cse,

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -229,10 +229,34 @@ class SymbolicMath:
 
         cpp_str = str(cppcode)
 
-        if self.remove_1:
-            cpp_str = cpp_str.replace("1.0*", "")
+        #if self.remove_1:
+        #    cpp_str = cpp_str.replace("1.0*", "")
 
         return cpp_str
+
+    # @profile
+    def syms_to_specnum(self, sym_smp):
+        """Extracts number from syms string"""
+        num = re.findall(r"\[(.*?)\]", str(sym_smp))
+        return int(num[0])
+
+    # @profile
+    def convert_number_to_int(self, number):
+        """Convert number to int if possible"""
+        factor = float(number)
+        if self.remove_1 and abs(factor) < 1.1 and abs(factor - int(factor)) < 1e-16:
+            factor = int(factor)
+        return factor
+ 
+    # @profile
+    def convert_symb_to_int(self, symb):
+        """Convert symbol to int if possible"""
+        try:
+            number = float(symb)
+            number = self.convert_number_to_int(number)
+            return number
+        except RuntimeError:
+            return symb
 
     # @profile
     def reduce_expr(self, orig):

--- a/Support/ceptr/ceptr/utilities.py
+++ b/Support/ceptr/ceptr/utilities.py
@@ -98,9 +98,13 @@ def qss_sorted_phase_space(
     if not record_symbolic_operations:
         return "*".join(phi)
     else:
-        out_smp = 1.0
+        if syms.remove_1:
+            out_smp = 1
+        else:
+            out_smp = 1.0
         for phi_val_smp in phi_smp:
             out_smp *= phi_val_smp
+        out_smp = syms.convert_symb_to_int(out_smp) 
         return "*".join(phi), out_smp
 
 
@@ -173,6 +177,7 @@ def fkc_conv_inv(self, mechanism, reaction, syms=None):
                 conversion_smp *= syms.refC_smp**dim
 
     if record_symbolic_operations:
+        conversion_smp = syms.convert_symb_to_int(conversion_smp)
         return conversion, conversion_smp
     else:
         return conversion
@@ -250,11 +255,13 @@ def sorted_kc_exp_arg(mechanism, species_info, reaction, syms=None):
             i = species_info.ordered_idx_map[symbol] - species_info.n_species
             terms_qss[i] += "%sg_RT_qss[%d]" % (factor, i)
             if record_symbolic_operations:
+                factor_smp = syms.convert_symb_to_int(factor_smp)
                 terms_qss_smp[i] += factor_smp * syms.g_RT_qss_smp[i]
         else:
             i = species_info.ordered_idx_map[symbol]
             terms[i] += "%sg_RT[%d]" % (factor, i)
             if record_symbolic_operations:
+                factor_smp = syms.convert_symb_to_int(factor_smp)
                 terms_smp[i] += factor_smp * syms.g_RT_smp[i]
 
     for symbol, coefficient in reaction.products.items():
@@ -271,11 +278,13 @@ def sorted_kc_exp_arg(mechanism, species_info, reaction, syms=None):
             i = species_info.ordered_idx_map[symbol] - species_info.n_species
             terms_qss[i] += "%sg_RT_qss[%d]" % (factor, i)
             if record_symbolic_operations:
+                factor_smp = syms.convert_symb_to_int(factor_smp)
                 terms_qss_smp[i] += factor_smp * syms.g_RT_qss_smp[i]
         else:
             i = species_info.ordered_idx_map[symbol]
             terms[i] += "%sg_RT[%d]" % (factor, i)
             if record_symbolic_operations:
+                factor_smp = syms.convert_symb_to_int(factor_smp)
                 terms_smp[i] += factor_smp * syms.g_RT_smp[i]
 
     dg = ""
@@ -296,6 +305,7 @@ def sorted_kc_exp_arg(mechanism, species_info, reaction, syms=None):
         # print("p dg = ", dg)
         # print("p dg_smp = ", dg_smp)
         if record_symbolic_operations:
+            dg_smp = syms.convert_symb_to_int(dg_smp)
             return dg[3:], dg_smp
         else:
             return dg[3:]
@@ -303,6 +313,7 @@ def sorted_kc_exp_arg(mechanism, species_info, reaction, syms=None):
         # print("m dg = ", dg)
         # print("m dg_smp = ", dg_smp)
         if record_symbolic_operations:
+            dg_smp = syms.convert_symb_to_int(dg_smp)
             return "-" + dg[3:], dg_smp
         else:
             return "-" + dg[3:]
@@ -364,6 +375,7 @@ def enhancement_d(mechanism, species_info, reaction, syms=None):
                 else:
                     alpha.append("%s*%s" % (factor, conc))
                     if record_symbolic_operations:
+                        factor_smp = syms.convert_symb_to_int(factor_smp)
                         alpha_smp.append(factor_smp * conc_smp)
 
     if record_symbolic_operations:
@@ -372,6 +384,7 @@ def enhancement_d(mechanism, species_info, reaction, syms=None):
             enhancement_smp += alpha_val
 
     if record_symbolic_operations:
+        enhancement_smp = syms.convert_symb_to_int(enhancement_smp)
         return " + ".join(alpha).replace("+ -", "- "), enhancement_smp
     else:
         return " + ".join(alpha).replace("+ -", "- ")

--- a/Support/ceptr/ceptr/utilities.py
+++ b/Support/ceptr/ceptr/utilities.py
@@ -104,7 +104,7 @@ def qss_sorted_phase_space(
             out_smp = 1.0
         for phi_val_smp in phi_smp:
             out_smp *= phi_val_smp
-        out_smp = syms.convert_symb_to_int(out_smp) 
+        out_smp = syms.convert_symb_to_int(out_smp)
         return "*".join(phi), out_smp
 
 
@@ -151,7 +151,7 @@ def fkc_conv_inv(self, mechanism, reaction, syms=None):
 
     conversion_smp = 1.0
     if record_symbolic_operations and syms.remove_1:
-        conversion_smp = 1 
+        conversion_smp = 1
     if dim == 0:
         conversion = ""
     elif dim > 0:

--- a/Support/ceptr/ceptr/utilities.py
+++ b/Support/ceptr/ceptr/utilities.py
@@ -150,6 +150,8 @@ def fkc_conv_inv(self, mechanism, reaction, syms=None):
             dim_smp += coefficient
 
     conversion_smp = 1.0
+    if record_symbolic_operations and syms.remove_1:
+        conversion_smp = 1 
     if dim == 0:
         conversion = ""
     elif dim > 0:

--- a/Support/ceptr/makeQss_gpu.sh
+++ b/Support/ceptr/makeQss_gpu.sh
@@ -1,0 +1,5 @@
+bash disableAllProfile.sh
+
+poetry run qssa -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/skeletal.yaml -n ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/non_qssa_list.yaml
+
+poetry run convert -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml --hformat gpu

--- a/Support/ceptr/makeQss_readable.sh
+++ b/Support/ceptr/makeQss_readable.sh
@@ -1,0 +1,5 @@
+bash disableAllProfile.sh
+
+poetry run qssa -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/skeletal.yaml -n ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/non_qssa_list.yaml
+
+poetry run convert -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml --hformat readable --remove_1 --remove_pow2 --min_op_count 3

--- a/Testing/Exec/debugJacDodecaneLuQss_all/main.cpp
+++ b/Testing/Exec/debugJacDodecaneLuQss_all/main.cpp
@@ -95,10 +95,7 @@ main(int argc, char* argv[])
     }
 
     // Compute analytically
-    ajac_term_fast_debug(J_sympy, sc, T, consP);
-    aJacobian(J_fuego_consP, sc, T, consP);
-    aJacobian(J_fuego_noconsP, sc, T, noconsP);
-
+    aJacobian(J_sympy, sc, T, consP);
 
     // Compute dscqss/dsc by finite difference
     for (int i=0; i < NUM_SPECIES; ++i){
@@ -124,7 +121,7 @@ main(int argc, char* argv[])
             index_wdot = j;
             index_J = index_sc * (NUM_SPECIES+1) + index_wdot;
             //if (error[index_J] > 1e-5 and (std::abs(J_sympy[index_J])>1e-15 or std::abs(J_sympy[index_J])>1e-15) and error[index_J]< 0.99){
-            if (error[index_J] > 1e-5 and (std::abs(J_sympy[index_J])>1e-15 or std::abs(J_sympy[index_J])>1e-15) ){
+            if (error[index_J] > 1e-3 and (std::abs(J_sympy[index_J])>1e-15 or std::abs(J_sympy[index_J])>1e-15) ){
                 std::cout << "\t wdot " << index_wdot << "\t sc " << index_sc  << " : " <<  error[index_J] << "\n";
                 std::cout << "\t \t FD : " << J_FD[index_J] << "\n";
                 std::cout << "\t \t SYMPY : " <<  J_sympy[index_J]  << "\n";


### PR DESCRIPTION
Common expressions are formatted to remove factors of type `1.0 *`, and `pow(...,2)`.
The number of common expressions is reduced by substitution. The criterion is the `min_op_count` the minimum number of operations for each variable created.
Currently validated (by comparing Jacobian to FD Jacobian) with `--hformat readable`. 
