### PR TITLE
Include future use of use of CSE in operation count

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ I tried to not modify functions that did not need be modified but we should prob
     - ~~Place `qf` and `qr` in `J`~~
     - ~~Round numbers when possible~~
     - ~~Recycle CSE~~
-    - Include subsequent use of expression in the cost estimate
+    - ~~Include subsequent use of expression in the cost estimate~~
   - Reduce number of intermediate values (Nick)
     - ~~Eliminate the allocation of array `dscqssdsc`~~
     - ~~Eliminate intermediate `dscqssdscxxx` reals~~

--- a/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml
+++ b/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml
@@ -2,15 +2,15 @@ description: QSSA of gas
 generator: YamlWriter
 cantera-version: 2.6.0
 git-commit: 9573e6b
-date: Fri Jul  8 15:36:18 2022
+date: Sun Jul 10 12:53:55 2022
 phases:
-  - qssa_species: [PXC8H17, PXC10H21, S3XC12H25, PXC7H15, CH2, PXC12H25, SXC12H25, HCO,
-    CH3O, C2H5, C2H3, nC3H7, CH2*, O2C12H24OOH, PXC6H13, pC4H9, C12OOH,
-    PXC5H11]
-    forward_to_remove_idx: [13, 66, 119, 120, 123, 146, 227, 229, 230, 231]
+  - forward_to_remove_idx: [13, 66, 119, 120, 123, 146, 227, 229, 230, 231]
     n_qssa_species: 18
     kinetics: gas
     transport: mixture-averaged
+    qssa_species: [pC4H9, PXC7H15, C2H3, CH2*, CH2, HCO, CH3O, C2H5, PXC12H25, PXC5H11,
+    PXC10H21, O2C12H24OOH, nC3H7, C12OOH, SXC12H25, PXC6H13, PXC8H17,
+    S3XC12H25]
     name: gas-qssa
     thermo: ideal-gas
     elements: [C, H, O, N]

--- a/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml
+++ b/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml
@@ -2,15 +2,15 @@ description: QSSA of gas
 generator: YamlWriter
 cantera-version: 2.6.0
 git-commit: 9573e6b
-date: Sun Jul 10 12:53:55 2022
+date: Sun Jul 10 14:37:53 2022
 phases:
   - forward_to_remove_idx: [13, 66, 119, 120, 123, 146, 227, 229, 230, 231]
     n_qssa_species: 18
     kinetics: gas
     transport: mixture-averaged
-    qssa_species: [pC4H9, PXC7H15, C2H3, CH2*, CH2, HCO, CH3O, C2H5, PXC12H25, PXC5H11,
-    PXC10H21, O2C12H24OOH, nC3H7, C12OOH, SXC12H25, PXC6H13, PXC8H17,
-    S3XC12H25]
+    qssa_species: [pC4H9, C12OOH, SXC12H25, nC3H7, CH2*, PXC6H13, CH3O, HCO, C2H3,
+    S3XC12H25, PXC10H21, O2C12H24OOH, PXC5H11, CH2, PXC8H17, PXC12H25,
+    PXC7H15, C2H5]
     name: gas-qssa
     thermo: ideal-gas
     elements: [C, H, O, N]

--- a/Support/ceptr/ceptr/ceptr.py
+++ b/Support/ceptr/ceptr/ceptr.py
@@ -19,6 +19,7 @@ def convert(
     round_decimals,
     recycle_cse,
     min_op_count_all,
+    remove_single_symbols_cse,
 ):
     """Convert a mechanism file."""
     mechanism = ct.Solution(fname)
@@ -34,6 +35,7 @@ def convert(
         round_decimals,
         recycle_cse,
         min_op_count_all,
+        remove_single_symbols_cse,
     )
     conv.writer()
     conv.formatter()
@@ -128,6 +130,13 @@ def main():
     )
 
     parser.add_argument(
+        "-rss",
+        "--remove_single_symbols_cse",
+        action="store_true",
+        help="Remove cse made of a single symbol",
+    )
+
+    parser.add_argument(
         "-moca",
         "--min_op_count_all",
         type=int,
@@ -152,6 +161,7 @@ def main():
             args.round_decimals,
             args.recycle_cse,
             args.min_op_count_all,
+            args.remove_single_symbols_cse,
         )
     elif args.lst:
         convert_lst(
@@ -166,6 +176,7 @@ def main():
             args.round_decimals,
             args.recycle_cse,
             args.min_op_count_all,
+            args.remove_single_symbols_cse,
         )
 
 

--- a/Support/ceptr/ceptr/ceptr.py
+++ b/Support/ceptr/ceptr/ceptr.py
@@ -14,7 +14,7 @@ def convert(
     remove_pow,
     remove_pow10,
     min_op_count,
-    recursive_op_count,
+    gradual_op_count,
     store_in_jacobian,
     round_decimals,
     recycle_cse,
@@ -29,7 +29,7 @@ def convert(
         remove_pow,
         remove_pow10,
         min_op_count,
-        recursive_op_count,
+        gradual_op_count,
         store_in_jacobian,
         round_decimals,
         recycle_cse,
@@ -101,9 +101,9 @@ def main():
 
     parser.add_argument(
         "-roc",
-        "--recursive_op_count",
+        "--gradual_op_count",
         action="store_true",
-        help="Recursive elimination of expression",
+        help="Gradual elimination of expression (ensure monotonicity)",
     )
 
     parser.add_argument(
@@ -147,7 +147,7 @@ def main():
             args.remove_pow,
             args.remove_pow10,
             args.min_op_count,
-            args.recursive_op_count,
+            args.gradual_op_count,
             args.store_in_jacobian,
             args.round_decimals,
             args.recycle_cse,
@@ -161,7 +161,7 @@ def main():
             args.remove_pow,
             args.remove_pow10,
             args.min_op_count,
-            args.recursive_op_count,
+            args.gradual_op_count,
             args.store_in_jacobian,
             args.round_decimals,
             args.recycle_cse,

--- a/Support/ceptr/ceptr/ceptr.py
+++ b/Support/ceptr/ceptr/ceptr.py
@@ -18,6 +18,7 @@ def convert(
     store_in_jacobian,
     round_decimals,
     recycle_cse,
+    min_op_count_all,
 ):
     """Convert a mechanism file."""
     mechanism = ct.Solution(fname)
@@ -32,6 +33,7 @@ def convert(
         store_in_jacobian,
         round_decimals,
         recycle_cse,
+        min_op_count_all,
     )
     conv.writer()
     conv.formatter()
@@ -125,6 +127,16 @@ def main():
         help="Recycle common expressions when possible",
     )
 
+    parser.add_argument(
+        "-moca",
+        "--min_op_count_all",
+        type=int,
+        metavar="",
+        required=False,
+        help="Min number of operation count saved per expression",
+        default=0,
+    )
+
     args = parser.parse_args()
 
     if args.fname:
@@ -139,6 +151,7 @@ def main():
             args.store_in_jacobian,
             args.round_decimals,
             args.recycle_cse,
+            args.min_op_count_all,
         )
     elif args.lst:
         convert_lst(
@@ -152,6 +165,7 @@ def main():
             args.store_in_jacobian,
             args.round_decimals,
             args.recycle_cse,
+            args.min_op_count_all,
         )
 
 

--- a/Support/ceptr/ceptr/converter.py
+++ b/Support/ceptr/ceptr/converter.py
@@ -38,6 +38,7 @@ class Converter:
         store_in_jacobian,
         round_decimals,
         recycle_cse,
+        min_op_count_all,
     ):
         self.mechanism = mechanism
 
@@ -51,6 +52,7 @@ class Converter:
         self.store_in_jacobian = store_in_jacobian
         self.round_decimals = round_decimals
         self.recycle_cse = recycle_cse
+        self.min_op_count_all = min_op_count_all
 
         self.mechpath = pathlib.Path(self.mechanism.source)
         self.rootname = "mechanism"
@@ -107,6 +109,7 @@ class Converter:
             self.store_in_jacobian,
             self.round_decimals,
             self.recycle_cse,
+            self.min_op_count_all,
         )
 
     def set_species(self):

--- a/Support/ceptr/ceptr/converter.py
+++ b/Support/ceptr/ceptr/converter.py
@@ -34,7 +34,7 @@ class Converter:
         remove_pow,
         remove_pow10,
         min_op_count,
-        recursive_op_count,
+        gradual_op_count,
         store_in_jacobian,
         round_decimals,
         recycle_cse,
@@ -48,7 +48,7 @@ class Converter:
         self.remove_pow = remove_pow
         self.remove_pow10 = remove_pow10
         self.min_op_count = min_op_count
-        self.recursive_op_count = recursive_op_count
+        self.gradual_op_count = gradual_op_count
         self.store_in_jacobian = store_in_jacobian
         self.round_decimals = round_decimals
         self.recycle_cse = recycle_cse
@@ -105,7 +105,7 @@ class Converter:
             self.remove_pow,
             self.remove_pow10,
             self.min_op_count,
-            self.recursive_op_count,
+            self.gradual_op_count,
             self.store_in_jacobian,
             self.round_decimals,
             self.recycle_cse,

--- a/Support/ceptr/ceptr/converter.py
+++ b/Support/ceptr/ceptr/converter.py
@@ -39,6 +39,7 @@ class Converter:
         round_decimals,
         recycle_cse,
         min_op_count_all,
+        remove_single_symbols_cse,
     ):
         self.mechanism = mechanism
 
@@ -53,7 +54,8 @@ class Converter:
         self.round_decimals = round_decimals
         self.recycle_cse = recycle_cse
         self.min_op_count_all = min_op_count_all
-
+        self.remove_single_symbols_cse = remove_single_symbols_cse
+ 
         self.mechpath = pathlib.Path(self.mechanism.source)
         self.rootname = "mechanism"
         self.hdrname = self.mechpath.parents[0] / f"{self.rootname}.H"
@@ -110,6 +112,7 @@ class Converter:
             self.round_decimals,
             self.recycle_cse,
             self.min_op_count_all,
+            self.remove_single_symbols_cse,
         )
 
     def set_species(self):

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -34,6 +34,7 @@ class SymbolicMath:
         round_decimals,
         recycle_cse,
         min_op_count_all,
+        remove_single_symbols_cse,
     ):
 
         # Formatting options
@@ -52,6 +53,7 @@ class SymbolicMath:
         self.round_decimals = round_decimals
         self.recycle_cse = recycle_cse
         self.min_op_count_all = min_op_count_all
+        self.remove_single_symbols_cse = remove_single_symbols_cse
         # Set to False to use bottom up approach
         self.top_bottom = True
 
@@ -400,6 +402,48 @@ class SymbolicMath:
         final_expr = [orig[1][i] for i in range(n_exp)]
         to_replace = []
         replace_with = []
+
+
+        if self.min_op_count_all>0:
+            if self.gradual_op_count:
+                for count_lim in range(1, self.min_op_count_all + 1):
+                    print(" Doing min op count ALL = ", count_lim)
+                    times = time.time()
+                    (
+                        common_expr_lhs,
+                        common_expr_rhs,
+                        final_expr,
+                    ) = self.reduce_expr_top_bottom_rec_count(
+                        orig,
+                        count_lim,
+                        common_expr_lhs,
+                        common_expr_rhs,
+                        final_expr,
+                    )
+                    print(
+                        "Reduced expressions in (time = %.3g s)"
+                        % (time.time() - times)
+                    )
+            else:
+                count_lim = self.min_op_count_all
+                print(" Doing min op count ALL = ", count_lim)
+                times = time.time()
+                (
+                    common_expr_lhs,
+                    common_expr_rhs,
+                    final_expr,
+                ) = self.reduce_expr_top_bottom_rec_count(
+                    orig,
+                    count_lim,
+                    common_expr_lhs,
+                    common_expr_rhs,
+                    final_expr,
+                )
+                print(
+                    "Reduced expressions in (time = %.3g s)"
+                    % (time.time() - times)
+                )
+
         if self.min_op_count>0:
             if self.gradual_op_count:
                 for count_lim in range(1, self.min_op_count + 1):
@@ -466,45 +510,23 @@ class SymbolicMath:
                     % (time.time() - times)
                 )
 
-        if self.min_op_count_all>0:
-            if self.gradual_op_count:
-                for count_lim in range(1, self.min_op_count_all + 1):
-                    print(" Doing min op count ALL = ", count_lim)
-                    times = time.time()
-                    (
-                        common_expr_lhs,
-                        common_expr_rhs,
-                        final_expr,
-                    ) = self.reduce_expr_top_bottom_rec_count(
-                        orig,
-                        count_lim,
-                        common_expr_lhs,
-                        common_expr_rhs,
-                        final_expr,
-                    )
-                    print(
-                        "Reduced expressions in (time = %.3g s)"
-                        % (time.time() - times)
-                    )
-            else:
-                count_lim = self.min_op_count_all
-                print(" Doing min op count ALL = ", count_lim)
-                times = time.time()
-                (
-                    common_expr_lhs,
-                    common_expr_rhs,
-                    final_expr,
-                ) = self.reduce_expr_top_bottom_rec_count(
-                    orig,
-                    count_lim,
-                    common_expr_lhs,
-                    common_expr_rhs,
-                    final_expr,
+        if self.remove_single_symbols_cse:
+           times = time.time()
+           (
+               common_expr_lhs,
+               common_expr_rhs,
+               final_expr,
+           ) = self.remove_single_symbol(
+               orig,
+               common_expr_lhs,
+               common_expr_rhs,
+               final_expr,
+           )
+           print(
+                  "Removed single symbols in (time = %.3g s)"
+                  % (time.time() - times)
                 )
-                print(
-                    "Reduced expressions in (time = %.3g s)"
-                    % (time.time() - times)
-                )
+
 
         if self.recycle_cse:
             common_expr_lhs, common_expr_rhs, final_expr, to_replace, replace_with = self.recycle_cse_post(
@@ -513,6 +535,79 @@ class SymbolicMath:
          
 
         return common_expr_lhs, common_expr_rhs, final_expr, to_replace, replace_with
+
+    # @profile
+    def remove_single_symbol(
+        self,
+        orig,
+        common_expr_lhs,
+        common_expr_rhs,
+        final_expr,
+    ):
+        """
+        Remove cses made of single symbols.
+        Those are typically of the for "-xi" where the operation may disappear after substitution
+        """
+    
+        replacements = []
+        n_cse = len(common_expr_lhs)
+        n_exp = len(final_expr)
+        common_expr_symbols = [rhs.free_symbols for rhs in common_expr_rhs]
+        final_expr_symbols = [expr.free_symbols for expr in final_expr]
+    
+        # Replacement loop
+        printProgressBar(
+            0,
+            n_cse,
+            prefix="Expr = %d / %d " % (0, n_cse),
+            suffix="Complete",
+            length=20,
+        )
+        for i, (lhs, rhs) in enumerate(zip(common_expr_lhs, common_expr_rhs)):
+            op_count = sme.count_ops(rhs)
+            is_float = True
+            is_single_symbol = True
+            try:
+                number = float(rhs)
+                rhs = number
+            except RuntimeError:
+                is_float = False
+            if not is_float:
+                if op_count > 1 or len(rhs.free_symbols) > 1:
+                    is_single_symbol = False
+            if is_float or is_single_symbol:
+                replacements.append(i)
+                ind = [
+                    j + i
+                    for j, s in enumerate(common_expr_symbols[i:])
+                    if lhs in s
+                ]
+                for j in ind:
+                    common_expr_rhs[j] = common_expr_rhs[j].subs(lhs, rhs)
+                    #common_expr_symbols[j].remove(lhs)
+                ind = [j for j, s in enumerate(final_expr_symbols) if lhs in s]
+                for j in ind:
+                    final_expr[j] = final_expr[j].subs(lhs, rhs)
+                    #final_expr_symbols[j].remove(lhs)
+    
+            printProgressBar(
+                i + 1,
+                n_cse,
+                prefix="Expr = %d / %d, removed single symb expr = %d "
+                % (
+                    i + 1,
+                    n_cse,
+                    len(replacements),
+                ),
+                suffix="Complete",
+                length=20,
+            )
+        replacements.reverse()
+        for rep in replacements:
+            del common_expr_lhs[rep]
+            del common_expr_rhs[rep]
+    
+        return common_expr_lhs, common_expr_rhs, final_expr
 
     # @profile
     def reduce_expr_top_bottom_rec_count(
@@ -563,13 +658,13 @@ class SymbolicMath:
                 rec_count += smp.sympify(final_expr[ind]).count(lhs)
     
             total_op = (rec_count-1)*op_count
-            isFloat = True
+            is_float = True
             try:
                 number = float(rhs)
                 rhs = number
             except RuntimeError:
-                isFloat = False
-            if total_op < count_lim or isFloat:
+                is_float = False
+            if total_op < count_lim or is_float:
                 replacements.append(i)
                 ind = [
                     j + i
@@ -633,13 +728,13 @@ class SymbolicMath:
         )
         for i, (lhs, rhs) in enumerate(zip(common_expr_lhs, common_expr_rhs)):
             op_count = sme.count_ops(rhs)
-            isFloat = True
+            is_float = True
             try:
                 number = float(rhs)
                 rhs = number
             except RuntimeError:
-                isFloat = False
-            if op_count < count_lim or isFloat:
+                is_float = False
+            if op_count < count_lim or is_float:
                 replacements.append(i)
                 ind = [
                     j + i
@@ -704,13 +799,13 @@ class SymbolicMath:
             list(enumerate(zip(common_expr_lhs, common_expr_rhs)))
         ):
             op_count = sme.count_ops(rhs)
-            isFloat = True
+            is_float = True
             try:
                 number = float(rhs)
                 rhs = number
             except RuntimeError:
-                isFloat = False
-            if op_count < count_lim or isFloat:
+                is_float = False
+            if op_count < count_lim or is_float:
                 replacements.append(i)
                 ind = [
                     j + i

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -29,7 +29,7 @@ class SymbolicMath:
         remove_pow,
         remove_pow10,
         min_op_count,
-        recursive_op_count,
+        gradual_op_count,
         store_in_jacobian,
         round_decimals,
         recycle_cse,
@@ -42,7 +42,7 @@ class SymbolicMath:
         self.remove_pow = remove_pow
         self.remove_pow10 = remove_pow10
         self.min_op_count = min_op_count
-        self.recursive_op_count = recursive_op_count
+        self.gradual_op_count = gradual_op_count
         self.store_in_jacobian = store_in_jacobian
         if (
             2 * reaction_info.n_qssa_reactions
@@ -401,7 +401,7 @@ class SymbolicMath:
         to_replace = []
         replace_with = []
         if self.min_op_count>0:
-            if self.recursive_op_count:
+            if self.gradual_op_count:
                 for count_lim in range(1, self.min_op_count + 1):
                     print(" Doing min op count = ", count_lim)
                     times = time.time()
@@ -467,7 +467,7 @@ class SymbolicMath:
                 )
 
         if self.min_op_count_all>0:
-            if self.recursive_op_count:
+            if self.gradual_op_count:
                 for count_lim in range(1, self.min_op_count_all + 1):
                     print(" Doing min op count ALL = ", count_lim)
                     times = time.time()

--- a/Support/ceptr/makeQss.sh
+++ b/Support/ceptr/makeQss.sh
@@ -2,4 +2,4 @@ bash disableAllProfile.sh
 
 poetry run qssa -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/skeletal.yaml -n ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/non_qssa_list.yaml
 
-poetry run convert -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml --hformat gpu --remove_1 --remove_pow --remove_pow10  --min_op_count 0  --min_op_count_all 10 --recursive_op_count --store_in_jacobian --round_decimals --recycle_cse
+poetry run convert -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml --hformat gpu --remove_1 --remove_pow --remove_pow10  --min_op_count 0  --min_op_count_all 10 --gradual_op_count --store_in_jacobian --round_decimals --recycle_cse

--- a/Support/ceptr/makeQss.sh
+++ b/Support/ceptr/makeQss.sh
@@ -2,4 +2,4 @@ bash disableAllProfile.sh
 
 poetry run qssa -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/skeletal.yaml -n ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/non_qssa_list.yaml
 
-poetry run convert -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml --hformat gpu --remove_1 --remove_pow --remove_pow10  --min_op_count 3 --recursive_op_count --store_in_jacobian --round_decimals --recycle_cse
+poetry run convert -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml --hformat gpu --remove_1 --remove_pow --remove_pow10  --min_op_count 0  --min_op_count_all 10 --recursive_op_count --store_in_jacobian --round_decimals --recycle_cse

--- a/Support/ceptr/makeQss.sh
+++ b/Support/ceptr/makeQss.sh
@@ -2,4 +2,4 @@ bash disableAllProfile.sh
 
 poetry run qssa -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/skeletal.yaml -n ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/non_qssa_list.yaml
 
-poetry run convert -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml --hformat gpu --remove_1 --remove_pow --remove_pow10  --min_op_count 0  --min_op_count_all 3 --gradual_op_count --store_in_jacobian --round_decimals --recycle_cse --remove_single_symbols_cse
+poetry run convert -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml --hformat gpu --remove_1 --remove_pow --remove_pow10  --min_op_count 0  --min_op_count_all 10 --gradual_op_count --store_in_jacobian --round_decimals --recycle_cse --remove_single_symbols_cse

--- a/Support/ceptr/makeQss.sh
+++ b/Support/ceptr/makeQss.sh
@@ -2,4 +2,4 @@ bash disableAllProfile.sh
 
 poetry run qssa -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/skeletal.yaml -n ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/non_qssa_list.yaml
 
-poetry run convert -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml --hformat gpu --remove_1 --remove_pow --remove_pow10  --min_op_count 0  --min_op_count_all 10 --gradual_op_count --store_in_jacobian --round_decimals --recycle_cse
+poetry run convert -f ${PELE_PHYSICS_HOME}/Support/Mechanism/Models/dodecane_lu_qss/qssa.yaml --hformat gpu --remove_1 --remove_pow --remove_pow10  --min_op_count 0  --min_op_count_all 3 --gradual_op_count --store_in_jacobian --round_decimals --recycle_cse --remove_single_symbols_cse


### PR DESCRIPTION
Count total number of operations saved by declaring a new variable.
This has the added benefit of significantly reducing the file size.
Remove single operations that involve single variables (typically of the type `x2=-x1`) which may appear everywhere and wrongly suggest that they reduce global operation count.