### PR TITLE
add RTY2H for SRK (and other EOS)

### DIFF
--- a/Eos/Fuego.H
+++ b/Eos/Fuego.H
@@ -329,7 +329,7 @@ struct Fuego
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void
-  TY2H(const amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
+  TY2H(amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
   {
     amrex::Real hi[NUM_SPECIES];
     CKHMS(&T, hi);
@@ -342,8 +342,8 @@ struct Fuego
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void RTY2H(
-    const amrex::Real /*rho*/,
-    const amrex::Real T,
+    const amrex::Real /*R*/,
+    amrex::Real T,
     const amrex::Real Y[NUM_SPECIES],
     amrex::Real& H)
   {

--- a/Eos/Fuego.H
+++ b/Eos/Fuego.H
@@ -329,7 +329,7 @@ struct Fuego
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void
-  TY2H(amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
+  TY2H(const amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
   {
     amrex::Real hi[NUM_SPECIES];
     CKHMS(&T, hi);
@@ -337,6 +337,14 @@ struct Fuego
     for (int n = 0; n < NUM_SPECIES; n++) {
       H += Y[n] * hi[n];
     }
+  }
+
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  static void
+  RTY2H(const amrex::Real /*rho*/, const amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
+  {
+    TY2H(T, Y, H);
   }
 
   AMREX_GPU_HOST_DEVICE

--- a/Eos/Fuego.H
+++ b/Eos/Fuego.H
@@ -341,8 +341,11 @@ struct Fuego
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RTY2H(const amrex::Real /*rho*/, const amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
+  static void RTY2H(
+    const amrex::Real /*rho*/,
+    const amrex::Real T,
+    const amrex::Real Y[NUM_SPECIES],
+    amrex::Real& H)
   {
     TY2H(T, Y, H);
   }

--- a/Eos/GammaLaw.H
+++ b/Eos/GammaLaw.H
@@ -358,7 +358,7 @@ struct GammaLaw
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void RTY2H(
-    const amrex::Real /*rho*/,
+    const amrex::Real /*R*/,
     const amrex::Real T,
     const amrex::Real Y[NUM_SPECIES],
     amrex::Real& H)

--- a/Eos/GammaLaw.H
+++ b/Eos/GammaLaw.H
@@ -357,8 +357,11 @@ struct GammaLaw
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  RTY2H(const amrex::Real /*rho*/, const amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
+  static void RTY2H(
+    const amrex::Real /*rho*/,
+    const amrex::Real T,
+    const amrex::Real Y[NUM_SPECIES],
+    amrex::Real& H)
   {
     TY2H(T, Y, H);
   }

--- a/Eos/GammaLaw.H
+++ b/Eos/GammaLaw.H
@@ -343,7 +343,7 @@ struct GammaLaw
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void
-  TY2H(amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
+  TY2H(const amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
   {
     amrex::Real Hi[NUM_SPECIES];
     amrex::Real wbar = Constants::AIRMW;
@@ -353,6 +353,14 @@ struct GammaLaw
       Hi[n] = Cv * T * Constants::gamma;
       H = H + Y[n] * Hi[n];
     }
+  }
+
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  static void
+  RTY2H(const amrex::Real /*rho*/, const amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
+  {
+    TY2H(T, Y, H);
   }
 
   AMREX_GPU_HOST_DEVICE

--- a/Eos/SRK.H
+++ b/Eos/SRK.H
@@ -448,7 +448,11 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2P(const amrex::Real R, const amrex::Real T, const amrex::Real Y[], amrex::Real& P)
+  void RTY2P(
+    const amrex::Real R,
+    const amrex::Real T,
+    const amrex::Real Y[],
+    amrex::Real& P)
   {
     amrex::Real wbar = 0.0, tau, am, bm;
     tau = 1.0 / R;
@@ -613,7 +617,11 @@ struct SRK
   // Function added for SRK
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2E(const amrex::Real R, const amrex::Real T, const amrex::Real Y[], amrex::Real& E)
+  void RTY2E(
+    const amrex::Real R,
+    const amrex::Real T,
+    const amrex::Real Y[],
+    amrex::Real& E)
   {
     amrex::Real Ei[NUM_SPECIES];
     amrex::Real am, bm, dAmdT, K1;
@@ -824,21 +832,26 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void
-  TY2H(amrex::Real /*T*/, const amrex::Real* /*Y[NUM_SPECIES]*/, amrex::Real& /*H*/)
+  static void TY2H(
+    amrex::Real /*T*/,
+    const amrex::Real* /*Y[NUM_SPECIES]*/,
+    amrex::Real& /*H*/)
   {
     amrex::Error("TY2H not physically possible for SRK EoS");
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void
-  RTY2H(const amrex::Real rho, const amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
+  void RTY2H(
+    const amrex::Real rho,
+    const amrex::Real T,
+    const amrex::Real Y[NUM_SPECIES],
+    amrex::Real& H)
   {
     amrex::Real E, P;
     RTY2E(rho, T, Y, E);
     RTY2P(rho, T, Y, P);
-    H = E + P/rho;
+    H = E + P / rho;
   }
 
   AMREX_GPU_HOST_DEVICE

--- a/Eos/SRK.H
+++ b/Eos/SRK.H
@@ -448,7 +448,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
+  void RTY2P(const amrex::Real R, const amrex::Real T, const amrex::Real Y[], amrex::Real& P)
   {
     amrex::Real wbar = 0.0, tau, am, bm;
     tau = 1.0 / R;
@@ -613,7 +613,7 @@ struct SRK
   // Function added for SRK
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2E(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& E)
+  void RTY2E(const amrex::Real R, const amrex::Real T, const amrex::Real Y[], amrex::Real& E)
   {
     amrex::Real Ei[NUM_SPECIES];
     amrex::Real am, bm, dAmdT, K1;
@@ -825,14 +825,20 @@ struct SRK
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void
-  TY2H(amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
+  TY2H(amrex::Real /*T*/, const amrex::Real* /*Y[NUM_SPECIES]*/, amrex::Real& /*H*/)
   {
-    amrex::Real hi[NUM_SPECIES];
-    CKHMS(&T, hi);
-    H = 0.0;
-    for (int n = 0; n < NUM_SPECIES; n++) {
-      H += Y[n] * hi[n];
-    }
+    amrex::Error("TY2H not physically possible for SRK EoS");
+  }
+
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  void
+  RTY2H(const amrex::Real rho, const amrex::Real T, const amrex::Real Y[NUM_SPECIES], amrex::Real& H)
+  {
+    amrex::Real E, P;
+    RTY2E(rho, T, Y, E);
+    RTY2P(rho, T, Y, P);
+    H = E + P/rho;
   }
 
   AMREX_GPU_HOST_DEVICE

--- a/Eos/SRK.H
+++ b/Eos/SRK.H
@@ -448,11 +448,7 @@ struct SRK
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2P(
-    const amrex::Real R,
-    const amrex::Real T,
-    const amrex::Real Y[],
-    amrex::Real& P)
+  void RTY2P(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& P)
   {
     amrex::Real wbar = 0.0, tau, am, bm;
     tau = 1.0 / R;
@@ -617,11 +613,7 @@ struct SRK
   // Function added for SRK
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void RTY2E(
-    const amrex::Real R,
-    const amrex::Real T,
-    const amrex::Real Y[],
-    amrex::Real& E)
+  void RTY2E(amrex::Real R, amrex::Real T, amrex::Real Y[], amrex::Real& E)
   {
     amrex::Real Ei[NUM_SPECIES];
     amrex::Real am, bm, dAmdT, K1;
@@ -833,7 +825,7 @@ struct SRK
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void TY2H(
-    amrex::Real /*T*/,
+    const amrex::Real /*T*/,
     const amrex::Real* /*Y[NUM_SPECIES]*/,
     amrex::Real& /*H*/)
   {
@@ -843,15 +835,12 @@ struct SRK
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   void RTY2H(
-    const amrex::Real rho,
-    const amrex::Real T,
-    const amrex::Real Y[NUM_SPECIES],
-    amrex::Real& H)
+    amrex::Real R, amrex::Real T, amrex::Real Y[NUM_SPECIES], amrex::Real& H)
   {
     amrex::Real E, P;
-    RTY2E(rho, T, Y, E);
-    RTY2P(rho, T, Y, P);
-    H = E + P / rho;
+    RTY2E(R, T, Y, E);
+    RTY2P(R, T, Y, P);
+    H = E + P / R;
   }
 
   AMREX_GPU_HOST_DEVICE


### PR DESCRIPTION
We previously did not support RTY2H EOS calls, only TY2H which is only applicable for ideal EOSs. This PR add an RTY2H function for SRK, corrects the SRK TY2H to throw an error, and adds RTY2H wrappers around TY2H for the other EOSs.

It turns out that RTY2H is easy to implement through the definition h = e + p/rho because we already have functions to compute e and p (@shashankNREL please verify I'm not missing anything).