### PR TITLE
Hari/bdfscheme

### DIFF
--- a/Reactions/Make.package
+++ b/Reactions/Make.package
@@ -1,2 +1,2 @@
-CEXE_headers += ReactorUtils.H ReactorTypes.H ReactorBase.H ReactorRK64.H ReactorArkode.H ReactorNull.H ReactorCvode.H ReactorCvodeUtils.H ReactorCvodePreconditioner.H ReactorCvodeJacobian.H ReactorCvodeCustomLinSolver.H
-CEXE_sources += ReactorUtils.cpp ReactorBase.cpp ReactorRK64.cpp ReactorArkode.cpp ReactorNull.cpp ReactorCvode.cpp ReactorCvodeUtils.cpp ReactorCvodePreconditioner.cpp ReactorCvodeJacobian.cpp ReactorCvodeCustomLinSolver.cpp
+CEXE_headers += ReactorUtils.H ReactorTypes.H ReactorBase.H ReactorBDF.H ReactorBDFsolver.H ReactorRK64.H ReactorArkode.H ReactorNull.H ReactorCvode.H ReactorCvodeUtils.H ReactorCvodePreconditioner.H ReactorCvodeJacobian.H ReactorCvodeCustomLinSolver.H
+CEXE_sources += ReactorUtils.cpp ReactorBase.cpp ReactorBDF.cpp ReactorRK64.cpp ReactorArkode.cpp ReactorNull.cpp ReactorCvode.cpp ReactorCvodeUtils.cpp ReactorCvodePreconditioner.cpp ReactorCvodeJacobian.cpp ReactorCvodeCustomLinSolver.cpp

--- a/Reactions/ReactorBDF.H
+++ b/Reactions/ReactorBDF.H
@@ -115,7 +115,7 @@ public:
 
 private:
   amrex::Real m_nonlin_tol{1e-6};
-  int m_nsubsteps{10};
+  int m_nsubsteps{1};
   int m_nonlinear_iters{1};
   int m_gmres_restarts{10};
   amrex::Real m_gmres_tol{1e-10};
@@ -123,7 +123,7 @@ private:
   bool m_clean_init_massfrac{false};
   utils::FlattenOps<Ordering> flatten_ops;
   int m_gmres_precond{2};
-  int m_tstepscheme{BDF2SCHEME};
+  int m_tstepscheme{BDF1SCHEME};
 };
 } // namespace pele::physics::reactions
 #endif

--- a/Reactions/ReactorBDF.H
+++ b/Reactions/ReactorBDF.H
@@ -4,32 +4,29 @@
 #define BDF1SCHEME 0
 #define TRPZSCHEME 1
 #define BDF2SCHEME 2
-#define BDF3SCHEME 3
 
-#define NBDFSCHEMES 4
-#define NBDFSTENCIL 4
+#define NBDFSCHEMES 3
+#define NBDFSTENCIL 3
 
 #include "ReactorBase.H"
 // stages and coefficients for rk64
 struct BDFParams
 {
-   //4 schemes are implemented
-   //BDF1, TRPZ, BDF2, BDF3
+   //3 schemes are implemented
+   //BDF1, TRPZ, BDF2
    
    //mass matrix multipliers
    const amrex::Real TCOEFFMAT[NBDFSCHEMES][NBDFSTENCIL]
-    = { {1.0000,-1.0000, 0.0000, 0.0000},
-        {1.0000,-1.0000, 0.0000, 0.0000},
-        {1.0000,-1.3333, 0.3333, 0.0000},
-        {1.0000,-1.6363, 0.8181,-0.1818}
+    = { {1.0000,-1.0000, 0.0000},
+        {1.0000,-1.0000, 0.0000},
+        {1.0000,-1.3333, 0.3333}
       };
 
     //forcing multipliers
     const amrex::Real FCOEFFMAT[NBDFSCHEMES][NBDFSTENCIL]
-     = { {1.0000, 0.0000,0.0000,0.0000},
-         {0.5000, 0.5000,0.0000,0.0000},
-         {0.6666, 0.0000,0.0000,0.0000},
-         {0.5454, 0.0000,0.0000,0.0000}
+     = { {1.0000, 0.0000,0.0000},
+         {0.5000, 0.5000,0.0000},
+         {0.6666, 0.0000,0.0000}
        };
 };
 
@@ -117,7 +114,7 @@ public:
   }
 
 private:
-  amrex::Real absTol{1e-10};
+  amrex::Real bdf_nonlin_tol{1e-6};
   int bdf_nsubsteps{10};
   int bdf_nonlinear_iters{1};
   int bdf_gmres_restarts{10};

--- a/Reactions/ReactorBDF.H
+++ b/Reactions/ReactorBDF.H
@@ -4,9 +4,10 @@
 #define BDF1SCHEME 0
 #define TRPZSCHEME 1
 #define BDF2SCHEME 2
+#define BDF3SCHEME 3
 
-#define NBDFSCHEMES 3
-#define NBDFSTENCIL 3
+#define NBDFSCHEMES 4
+#define NBDFSTENCIL 4
 
 #include "ReactorBase.H"
 // stages and coefficients for rk64
@@ -17,16 +18,18 @@ struct BDFParams
    
    //mass matrix multipliers
    const amrex::Real TCOEFFMAT[NBDFSCHEMES][NBDFSTENCIL]
-    = { {1.0000,-1.0000, 0.0000},
-        {1.0000,-1.0000, 0.0000},
-        {1.0000,-1.3333, 0.3333}
+    = { {1.0000,-1.0000, 0.0000,  0.0000},
+        {1.0000,-1.0000, 0.0000,  0.0000},
+        {1.0000,-1.3333, 0.3333,  0.0000},
+        {1.0000,-1.6363, 0.8181, -0.1818}
       };
 
     //forcing multipliers
     const amrex::Real FCOEFFMAT[NBDFSCHEMES][NBDFSTENCIL]
-     = { {1.0000, 0.0000,0.0000},
-         {0.5000, 0.5000,0.0000},
-         {0.6666, 0.0000,0.0000}
+     = { {1.0000, 0.0000, 0.0000, 0.0000},
+         {0.5000, 0.5000, 0.0000, 0.0000},
+         {0.6666, 0.0000, 0.0000, 0.0000},
+         {0.5454, 0.0000, 0.0000, 0.0000}
        };
 };
 
@@ -123,7 +126,7 @@ private:
   bool m_clean_init_massfrac{false};
   utils::FlattenOps<Ordering> flatten_ops;
   int m_gmres_precond{2};
-  int m_tstepscheme{BDF1SCHEME};
+  int m_tstepscheme{BDF3SCHEME};
 };
 } // namespace pele::physics::reactions
 #endif

--- a/Reactions/ReactorBDF.H
+++ b/Reactions/ReactorBDF.H
@@ -114,16 +114,16 @@ public:
   }
 
 private:
-  amrex::Real bdf_nonlin_tol{1e-6};
-  int bdf_nsubsteps{10};
-  int bdf_nonlinear_iters{1};
-  int bdf_gmres_restarts{10};
-  amrex::Real bdf_gmres_tol{1e-10};
+  amrex::Real m_nonlin_tol{1e-6};
+  int m_nsubsteps{10};
+  int m_nonlinear_iters{1};
+  int m_gmres_restarts{10};
+  amrex::Real m_gmres_tol{1e-10};
   int m_reactor_type{0};
   bool m_clean_init_massfrac{false};
   utils::FlattenOps<Ordering> flatten_ops;
-  int bdf_gmres_precond{2};
-  int bdf_scheme{BDF1SCHEME};
+  int m_gmres_precond{2};
+  int m_tstepscheme{BDF2SCHEME};
 };
 } // namespace pele::physics::reactions
 #endif

--- a/Reactions/ReactorBDF.H
+++ b/Reactions/ReactorBDF.H
@@ -1,7 +1,37 @@
 #ifndef REACTORBDF_H
 #define REACTORBDF_H
 
+#define BDF1SCHEME 0
+#define TRPZSCHEME 1
+#define BDF2SCHEME 2
+#define BDF3SCHEME 3
+
+#define NBDFSCHEMES 4
+#define NBDFSTENCIL 4
+
 #include "ReactorBase.H"
+// stages and coefficients for rk64
+struct BDFParams
+{
+   //4 schemes are implemented
+   //BDF1, TRPZ, BDF2, BDF3
+   
+   //mass matrix multipliers
+   const amrex::Real TCOEFFMAT[NBDFSCHEMES][NBDFSTENCIL]
+    = { {1.0000,-1.0000, 0.0000, 0.0000},
+        {1.0000,-1.0000, 0.0000, 0.0000},
+        {1.0000,-1.3333, 0.3333, 0.0000},
+        {1.0000,-1.6363, 0.8181,-0.1818}
+      };
+
+    //forcing multipliers
+    const amrex::Real FCOEFFMAT[NBDFSCHEMES][NBDFSTENCIL]
+     = { {1.0000, 0.0000,0.0000,0.0000},
+         {0.5000, 0.5000,0.0000,0.0000},
+         {0.6666, 0.0000,0.0000,0.0000},
+         {0.5454, 0.0000,0.0000,0.0000}
+       };
+};
 
 namespace pele::physics::reactions {
 
@@ -96,6 +126,7 @@ private:
   bool m_clean_init_massfrac{false};
   utils::FlattenOps<Ordering> flatten_ops;
   int bdf_gmres_precond{2};
+  int bdf_scheme{BDF1SCHEME};
 };
 } // namespace pele::physics::reactions
 #endif

--- a/Reactions/ReactorBDF.H
+++ b/Reactions/ReactorBDF.H
@@ -95,7 +95,7 @@ private:
   int m_reactor_type{0};
   bool m_clean_init_massfrac{false};
   utils::FlattenOps<Ordering> flatten_ops;
-  int bdf_gmres_precond{0};
+  int bdf_gmres_precond{2};
 };
 } // namespace pele::physics::reactions
 #endif

--- a/Reactions/ReactorBDF.H
+++ b/Reactions/ReactorBDF.H
@@ -1,0 +1,101 @@
+#ifndef REACTORBDF_H
+#define REACTORBDF_H
+
+#include "ReactorBase.H"
+
+namespace pele::physics::reactions {
+
+class ReactorBDF : public ReactorBase::Register<ReactorBDF>
+{
+public:
+  static std::string identifier() { return "ReactorBDF"; }
+
+  using Ordering = utils::YCOrder;
+
+  int init(int reactor_type, int ncells) override;
+
+  void close() override {}
+
+  void print_final_stats(void* /*mem*/) override {}
+
+  int react(
+    const amrex::Box& box,
+    amrex::Array4<amrex::Real> const& rY_in,
+    amrex::Array4<amrex::Real> const& rYsrc_in,
+    amrex::Array4<amrex::Real> const& T_in,
+    amrex::Array4<amrex::Real> const& rEner_in,
+    amrex::Array4<amrex::Real> const& rEner_src_in,
+    amrex::Array4<amrex::Real> const& FC_in,
+    amrex::Array4<int> const& mask,
+    amrex::Real& dt_react,
+    amrex::Real& time
+#ifdef AMREX_USE_GPU
+    ,
+    amrex::gpuStream_t stream
+#endif
+    ) override;
+
+  int react(
+    amrex::Real* rY_in,
+    amrex::Real* rYsrc_in,
+    amrex::Real* rX_in,
+    amrex::Real* rX_src_in,
+    amrex::Real& dt_react,
+    amrex::Real& time,
+    int ncells
+#ifdef AMREX_USE_GPU
+    ,
+    amrex::gpuStream_t stream
+#endif
+    ) override;
+
+  void flatten(
+    const amrex::Box& box,
+    const int ncells,
+    amrex::Array4<const amrex::Real> const& rhoY,
+    amrex::Array4<const amrex::Real> const& frcExt,
+    amrex::Array4<const amrex::Real> const& temperature,
+    amrex::Array4<const amrex::Real> const& rhoE,
+    amrex::Array4<const amrex::Real> const& frcEExt,
+    amrex::Real* y_vect,
+    amrex::Real* src_vect,
+    amrex::Real* vect_energy,
+    amrex::Real* src_vect_energy) override
+  {
+    flatten_ops.flatten(
+      box, ncells, m_reactor_type, m_clean_init_massfrac, rhoY, frcExt,
+      temperature, rhoE, frcEExt, y_vect, src_vect, vect_energy,
+      src_vect_energy);
+  }
+
+  void unflatten(
+    const amrex::Box& box,
+    const int ncells,
+    amrex::Array4<amrex::Real> const& rhoY,
+    amrex::Array4<amrex::Real> const& temperature,
+    amrex::Array4<amrex::Real> const& rhoE,
+    amrex::Array4<amrex::Real> const& frcEExt,
+    amrex::Array4<amrex::Real> const& FC_in,
+    amrex::Real* y_vect,
+    amrex::Real* vect_energy,
+    long int* FCunt,
+    amrex::Real dt) override
+  {
+    flatten_ops.unflatten(
+      box, ncells, m_reactor_type, m_clean_init_massfrac, rhoY, temperature,
+      rhoE, frcEExt, FC_in, y_vect, vect_energy, FCunt, dt);
+  }
+
+private:
+  amrex::Real absTol{1e-10};
+  int bdf_nsubsteps{10};
+  int bdf_nonlinear_iters{1};
+  int bdf_gmres_restarts{10};
+  amrex::Real bdf_gmres_tol{1e-10};
+  int m_reactor_type{0};
+  bool m_clean_init_massfrac{false};
+  utils::FlattenOps<Ordering> flatten_ops;
+  int bdf_gmres_precond{0};
+};
+} // namespace pele::physics::reactions
+#endif

--- a/Reactions/ReactorBDF.H
+++ b/Reactions/ReactorBDF.H
@@ -13,24 +13,22 @@
 // stages and coefficients for rk64
 struct BDFParams
 {
-   //3 schemes are implemented
-   //BDF1, TRPZ, BDF2
-   
-   //mass matrix multipliers
-   const amrex::Real TCOEFFMAT[NBDFSCHEMES][NBDFSTENCIL]
-    = { {1.0000,-1.0000, 0.0000,  0.0000},
-        {1.0000,-1.0000, 0.0000,  0.0000},
-        {1.0000,-1.3333, 0.3333,  0.0000},
-        {1.0000,-1.6363, 0.8181, -0.1818}
-      };
+  // 3 schemes are implemented
+  // BDF1, TRPZ, BDF2
 
-    //forcing multipliers
-    const amrex::Real FCOEFFMAT[NBDFSCHEMES][NBDFSTENCIL]
-     = { {1.0000, 0.0000, 0.0000, 0.0000},
-         {0.5000, 0.5000, 0.0000, 0.0000},
-         {0.6666, 0.0000, 0.0000, 0.0000},
-         {0.5454, 0.0000, 0.0000, 0.0000}
-       };
+  // mass matrix multipliers
+  const amrex::Real TCOEFFMAT[NBDFSCHEMES][NBDFSTENCIL] = {
+    {1.0000, -1.0000, 0.0000, 0.0000},
+    {1.0000, -1.0000, 0.0000, 0.0000},
+    {1.0000, -1.3333, 0.3333, 0.0000},
+    {1.0000, -1.6363, 0.8181, -0.1818}};
+
+  // forcing multipliers
+  const amrex::Real FCOEFFMAT[NBDFSCHEMES][NBDFSTENCIL] = {
+    {1.0000, 0.0000, 0.0000, 0.0000},
+    {0.5000, 0.5000, 0.0000, 0.0000},
+    {0.6666, 0.0000, 0.0000, 0.0000},
+    {0.5454, 0.0000, 0.0000, 0.0000}};
 };
 
 namespace pele::physics::reactions {
@@ -126,7 +124,7 @@ private:
   bool m_clean_init_massfrac{false};
   utils::FlattenOps<Ordering> flatten_ops;
   int m_gmres_precond{2};
-  int m_gmres_kspiters{NUM_SPECIES+1};
+  int m_gmres_kspiters{NUM_SPECIES + 1};
   int m_tstepscheme{BDF3SCHEME};
 };
 } // namespace pele::physics::reactions

--- a/Reactions/ReactorBDF.H
+++ b/Reactions/ReactorBDF.H
@@ -126,6 +126,7 @@ private:
   bool m_clean_init_massfrac{false};
   utils::FlattenOps<Ordering> flatten_ops;
   int m_gmres_precond{2};
+  int m_gmres_kspiters{NUM_SPECIES+1};
   int m_tstepscheme{BDF3SCHEME};
 };
 } // namespace pele::physics::reactions

--- a/Reactions/ReactorBDF.cpp
+++ b/Reactions/ReactorBDF.cpp
@@ -3,501 +3,486 @@
 #include "ReactorBDFsolver.H"
 
 namespace pele::physics::reactions {
-    
-    //The linear system for first order backward Euler 
-    //is of the form
-    //[I/dt - df/du] du = -(uk-un)/dt + f(uk)
 
-    //The linear system for trapezoidal scheme
-    //is of the form
-    //[I/dt - 0.5*df/du] du = -(uk-un)/dt + 0.5*f(uk) + 0.5*f(un)
-    //
-    //The linear system for BDF2
-    //(u - 4/3 u{n-1} + 1/3 u{n-2})/dt=2/3 f(u)
-    //[I/dt- 2/3 df/du] du = -(uk-4/3 un + 1/3u{n-1})/dt + 2/3 f(u)
+// The linear system for first order backward Euler
+// is of the form
+//[I/dt - df/du] du = -(uk-un)/dt + f(uk)
 
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
-    get_rho_and_massfracs(amrex::Real soln[NUM_SPECIES+1],
-                          amrex::Real &rho, 
-                          amrex::Real massfrac[NUM_SPECIES])
-    {
-        rho = 0.0;
-        for (int sp = 0; sp < NUM_SPECIES; sp++) 
-        {
-            rho += soln[sp];
-        }
-        amrex::Real rho_inv = 1.0 / rho;
-        for (int sp = 0; sp < NUM_SPECIES; sp++) 
-        {
-            massfrac[sp] = soln[sp] * rho_inv;
-        }
-    
+// The linear system for trapezoidal scheme
+// is of the form
+//[I/dt - 0.5*df/du] du = -(uk-un)/dt + 0.5*f(uk) + 0.5*f(un)
+//
+// The linear system for BDF2
+//(u - 4/3 u{n-1} + 1/3 u{n-2})/dt=2/3 f(u)
+//[I/dt- 2/3 df/du] du = -(uk-4/3 un + 1/3u{n-1})/dt + 2/3 f(u)
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+get_rho_and_massfracs(
+  amrex::Real soln[NUM_SPECIES + 1],
+  amrex::Real& rho,
+  amrex::Real massfrac[NUM_SPECIES])
+{
+  rho = 0.0;
+  for (int sp = 0; sp < NUM_SPECIES; sp++) {
+    rho += soln[sp];
+  }
+  amrex::Real rho_inv = 1.0 / rho;
+  for (int sp = 0; sp < NUM_SPECIES; sp++) {
+    massfrac[sp] = soln[sp] * rho_inv;
+  }
+}
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+get_bdf_matrix_and_rhs(
+  amrex::Real soln[NUM_SPECIES + 1],
+  amrex::Real soln_n[NUM_SPECIES + 1],
+  amrex::Real soln_nm1[NUM_SPECIES + 1],
+  amrex::Real soln_nm2[NUM_SPECIES + 1],
+  amrex::Real mw[NUM_SPECIES],
+  int reactor_type,
+  int tstepscheme,
+  amrex::Real dt,
+  amrex::Real rhoe_init[1],
+  amrex::Real rhoesrc_ext[1],
+  amrex::Real rYsrc_ext[NUM_SPECIES],
+  amrex::Real current_time,
+  amrex::Real time_init,
+  amrex::Real Jmat2d[NUM_SPECIES + 1][NUM_SPECIES + 1],
+  amrex::Real rhs[NUM_SPECIES + 1])
+{
+
+  BDFParams bdfp;
+
+  const int consP = (reactor_type == ReactorTypes::h_reactor_type);
+
+  amrex::Real rho;
+  amrex::Real massfrac[NUM_SPECIES] = {0.0};
+  amrex::Real dt_inv = 1.0 / dt;
+  amrex::Real ydot[NUM_SPECIES + 1] = {0.0};
+  amrex::Real ydot_n[NUM_SPECIES + 1] = {0.0};
+  amrex::Real Jmat1d[(NUM_SPECIES + 1) * (NUM_SPECIES + 1)] = {0.0};
+  auto eos = pele::physics::PhysicsType::eos();
+
+  get_rho_and_massfracs(soln, rho, massfrac);
+
+  eos.RTY2JAC(rho, soln[NUM_SPECIES], massfrac, Jmat1d, consP);
+  for (int ii = 0; ii < NUM_SPECIES; ii++) {
+    for (int jj = 0; jj < NUM_SPECIES; jj++) {
+      Jmat2d[ii][jj] = -bdfp.FCOEFFMAT[tstepscheme][0] *
+                       Jmat1d[jj * (NUM_SPECIES + 1) + ii] * mw[ii] / mw[jj];
     }
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
-    get_bdf_matrix_and_rhs(amrex::Real soln[NUM_SPECIES+1],
-                           amrex::Real soln_n[NUM_SPECIES+1],
-                           amrex::Real soln_nm1[NUM_SPECIES+1],
-                           amrex::Real soln_nm2[NUM_SPECIES+1],
-                           amrex::Real mw[NUM_SPECIES],
-                           int reactor_type,int tstepscheme,amrex::Real dt,
-                           amrex::Real rhoe_init[1],amrex::Real rhoesrc_ext[1],
-                           amrex::Real rYsrc_ext[NUM_SPECIES],
-                           amrex::Real current_time, amrex::Real time_init,
-                           amrex::Real Jmat2d[NUM_SPECIES+1][NUM_SPECIES+1],
-                           amrex::Real rhs[NUM_SPECIES+1])
-    {
-  
-        BDFParams bdfp;
+    Jmat2d[ii][NUM_SPECIES] = -bdfp.FCOEFFMAT[tstepscheme][0] *
+                              Jmat1d[NUM_SPECIES * (NUM_SPECIES + 1) + ii] *
+                              mw[ii];
+    Jmat2d[NUM_SPECIES][ii] = -bdfp.FCOEFFMAT[tstepscheme][0] *
+                              Jmat1d[ii * (NUM_SPECIES + 1) + NUM_SPECIES] /
+                              mw[ii];
+  }
+  Jmat2d[NUM_SPECIES][NUM_SPECIES] =
+    -bdfp.FCOEFFMAT[tstepscheme][0] *
+    Jmat1d[(NUM_SPECIES + 1) * (NUM_SPECIES + 1) - 1];
 
-        const int consP = (reactor_type 
-                           == ReactorTypes::h_reactor_type);
+  // FIXME: need to change this to Ordering
+  utils::fKernelSpec<utils::YCOrder>(
+    0, 1, current_time - time_init, reactor_type, soln, ydot, rhoe_init,
+    rhoesrc_ext, rYsrc_ext);
 
-        amrex::Real rho;
-        amrex::Real massfrac[NUM_SPECIES]={0.0};
-        amrex::Real dt_inv=1.0/dt;
-        amrex::Real ydot[NUM_SPECIES+1]={0.0};
-        amrex::Real ydot_n[NUM_SPECIES+1]={0.0};
-        amrex::Real Jmat1d[(NUM_SPECIES + 1) * (NUM_SPECIES + 1)] = {0.0};
-        auto eos = pele::physics::PhysicsType::eos();
+  if (tstepscheme == TRPZSCHEME) {
+    utils::fKernelSpec<utils::YCOrder>(
+      0, 1, current_time - time_init, reactor_type, soln_n, ydot_n, rhoe_init,
+      rhoesrc_ext, rYsrc_ext);
+  }
 
-        get_rho_and_massfracs(soln,rho,massfrac);
+  for (int ii = 0; ii < (NUM_SPECIES + 1); ii++) {
+    Jmat2d[ii][ii] += bdfp.TCOEFFMAT[tstepscheme][0] * dt_inv;
 
-        eos.RTY2JAC(rho, soln[NUM_SPECIES], massfrac, Jmat1d, consP);
-        for (int ii = 0; ii < NUM_SPECIES; ii++) 
-        {
-            for (int jj = 0; jj < NUM_SPECIES; jj++) 
-            {
-                Jmat2d[ii][jj] = -bdfp.FCOEFFMAT[tstepscheme][0]*Jmat1d[jj*(NUM_SPECIES+1) + ii] * mw[ii] / mw[jj];
-            }
-            Jmat2d[ii][NUM_SPECIES] = -bdfp.FCOEFFMAT[tstepscheme][0]*Jmat1d[NUM_SPECIES*(NUM_SPECIES+1)+ii]*mw[ii];
-            Jmat2d[NUM_SPECIES][ii] = -bdfp.FCOEFFMAT[tstepscheme][0]*Jmat1d[ii*(NUM_SPECIES+1)+NUM_SPECIES]/mw[ii];
-        }
-        Jmat2d[NUM_SPECIES][NUM_SPECIES] = -bdfp.FCOEFFMAT[tstepscheme][0]*Jmat1d[(NUM_SPECIES+1)*(NUM_SPECIES+1)-1];
+    rhs[ii] = -bdfp.TCOEFFMAT[tstepscheme][0] * soln[ii] * dt_inv;
+    rhs[ii] += -bdfp.TCOEFFMAT[tstepscheme][1] * soln_n[ii] * dt_inv;
+    rhs[ii] += -bdfp.TCOEFFMAT[tstepscheme][2] * soln_nm1[ii] * dt_inv;
+    rhs[ii] += -bdfp.TCOEFFMAT[tstepscheme][3] * soln_nm2[ii] * dt_inv;
 
-        
-        //FIXME: need to change this to Ordering
-        utils::fKernelSpec<utils::YCOrder>(
-            0, 1, current_time - time_init, reactor_type, soln, ydot,
-            rhoe_init, rhoesrc_ext, rYsrc_ext);
-        
-        if(tstepscheme==TRPZSCHEME)
-        {
-            utils::fKernelSpec<utils::YCOrder>(
-                0, 1, current_time - time_init, reactor_type, soln_n, ydot_n,
-                rhoe_init, rhoesrc_ext, rYsrc_ext);
-        }
+    rhs[ii] += bdfp.FCOEFFMAT[tstepscheme][0] * ydot[ii];
+    rhs[ii] += bdfp.FCOEFFMAT[tstepscheme][1] * ydot_n[ii];
+  }
+}
 
-        for (int ii = 0; ii < (NUM_SPECIES+1); ii++) 
-        {
-            Jmat2d[ii][ii] += bdfp.TCOEFFMAT[tstepscheme][0]*dt_inv;
+int
+ReactorBDF::init(int reactor_type, int /*ncells*/)
+{
+  BL_PROFILE("Pele::ReactorBDF::init()");
+  m_reactor_type = reactor_type;
+  ReactorTypes::check_reactor_type(m_reactor_type);
+  amrex::ParmParse pp("ode");
+  pp.query("verbose", verbose);
+  pp.query("bdf_nonlinear_iters", m_nonlinear_iters);
+  pp.query("bdf_nonlinear_tol", m_nonlin_tol);
+  pp.query("bdf_nsubsteps", m_nsubsteps);
+  pp.query("bdf_gmres_restarts", m_gmres_restarts);
+  pp.query("bdf_gmres_kspiters", m_gmres_kspiters);
+  pp.query("bdf_gmres_tol", m_gmres_tol);
+  pp.query("bdf_gmres_precond", m_gmres_precond);
+  pp.query("clean_init_massfrac", m_clean_init_massfrac);
+  pp.query("bdf_scheme", m_tstepscheme);
+  return (0);
+}
 
-            rhs[ii] =  -bdfp.TCOEFFMAT[tstepscheme][0]*soln[ii]*dt_inv;
-            rhs[ii] += -bdfp.TCOEFFMAT[tstepscheme][1]*soln_n[ii]*dt_inv;
-            rhs[ii] += -bdfp.TCOEFFMAT[tstepscheme][2]*soln_nm1[ii]*dt_inv;
-            rhs[ii] += -bdfp.TCOEFFMAT[tstepscheme][3]*soln_nm2[ii]*dt_inv;
-
-            rhs[ii] += bdfp.FCOEFFMAT[tstepscheme][0]*ydot[ii];
-            rhs[ii] += bdfp.FCOEFFMAT[tstepscheme][1]*ydot_n[ii];
-        }
-
-    }
-
-
-    int ReactorBDF::init(int reactor_type, int /*ncells*/)
-    {
-        BL_PROFILE("Pele::ReactorBDF::init()");
-        m_reactor_type = reactor_type;
-        ReactorTypes::check_reactor_type(m_reactor_type);
-        amrex::ParmParse pp("ode");
-        pp.query("verbose", verbose);
-        pp.query("bdf_nonlinear_iters",m_nonlinear_iters);
-        pp.query("bdf_nonlinear_tol",m_nonlin_tol);
-        pp.query("bdf_nsubsteps", m_nsubsteps);
-        pp.query("bdf_gmres_restarts",m_gmres_restarts);
-        pp.query("bdf_gmres_kspiters",m_gmres_kspiters);
-        pp.query("bdf_gmres_tol",m_gmres_tol);
-        pp.query("bdf_gmres_precond",m_gmres_precond);
-        pp.query("clean_init_massfrac", m_clean_init_massfrac);
-        pp.query("bdf_scheme",m_tstepscheme);
-        return (0);
-    }
-
-    int
-    ReactorBDF::react(
-        amrex::Real* rY_in,
-        amrex::Real* rYsrc_in,
-        amrex::Real* rX_in,
-        amrex::Real* rX_src_in,
-        amrex::Real& dt_react,
-        amrex::Real& time,
-        int ncells
+int
+ReactorBDF::react(
+  amrex::Real* rY_in,
+  amrex::Real* rYsrc_in,
+  amrex::Real* rX_in,
+  amrex::Real* rX_src_in,
+  amrex::Real& dt_react,
+  amrex::Real& time,
+  int ncells
 #ifdef AMREX_USE_GPU
-        ,
-        amrex::gpuStream_t /*stream*/
+  ,
+  amrex::gpuStream_t /*stream*/
 #endif
-        )
-    {
-        BL_PROFILE("Pele::ReactorBDF::react()");
+)
+{
+  BL_PROFILE("Pele::ReactorBDF::react()");
 
-        amrex::Real time_init = time;
-        amrex::Real time_out = time + dt_react;
+  amrex::Real time_init = time;
+  amrex::Real time_out = time + dt_react;
 
-        // Copy to device
-        amrex::Gpu::DeviceVector<amrex::Real> rY(ncells * (NUM_SPECIES + 1), 0);
-        amrex::Gpu::DeviceVector<amrex::Real> rYsrc(ncells * NUM_SPECIES, 0);
-        amrex::Gpu::DeviceVector<amrex::Real> rX(ncells, 0);
-        amrex::Gpu::DeviceVector<amrex::Real> rX_src(ncells, 0);
-        amrex::Real* d_rY = rY.data();
-        amrex::Real* d_rYsrc = rYsrc.data();
-        amrex::Real* d_rX = rX.data();
-        amrex::Real* d_rX_src = rX_src.data();
-        amrex::Gpu::copy(
-            amrex::Gpu::hostToDevice, rY_in, rY_in + ncells * (NUM_SPECIES + 1), d_rY);
-        amrex::Gpu::copy(
-            amrex::Gpu::hostToDevice, rYsrc_in, rYsrc_in + ncells * NUM_SPECIES,
-            d_rYsrc);
-        amrex::Gpu::copy(amrex::Gpu::hostToDevice, rX_in, rX_in + ncells, d_rX);
-        amrex::Gpu::copy(
-            amrex::Gpu::hostToDevice, rX_src_in, rX_src_in + ncells, d_rX_src);
+  // Copy to device
+  amrex::Gpu::DeviceVector<amrex::Real> rY(ncells * (NUM_SPECIES + 1), 0);
+  amrex::Gpu::DeviceVector<amrex::Real> rYsrc(ncells * NUM_SPECIES, 0);
+  amrex::Gpu::DeviceVector<amrex::Real> rX(ncells, 0);
+  amrex::Gpu::DeviceVector<amrex::Real> rX_src(ncells, 0);
+  amrex::Real* d_rY = rY.data();
+  amrex::Real* d_rYsrc = rYsrc.data();
+  amrex::Real* d_rX = rX.data();
+  amrex::Real* d_rX_src = rX_src.data();
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, rY_in, rY_in + ncells * (NUM_SPECIES + 1), d_rY);
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, rYsrc_in, rYsrc_in + ncells * NUM_SPECIES,
+    d_rYsrc);
+  amrex::Gpu::copy(amrex::Gpu::hostToDevice, rX_in, rX_in + ncells, d_rX);
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, rX_src_in, rX_src_in + ncells, d_rX_src);
 
-        // capture variables
-        const int captured_tstepscheme=m_tstepscheme;
-        const int captured_reactor_type = m_reactor_type;
-        const int captured_nsubsteps = m_nsubsteps;
-        const amrex::Real captured_nonlin_tol = m_nonlin_tol;
-        const amrex::Real captured_gmres_tol = m_gmres_tol;
-        const int captured_gmres_restarts=m_gmres_restarts;
-        const int captured_gmres_kspiters=m_gmres_kspiters;
-        const int captured_nonlinear_iters=m_nonlinear_iters;
-        const int captured_gmres_precond=m_gmres_precond;
+  // capture variables
+  const int captured_tstepscheme = m_tstepscheme;
+  const int captured_reactor_type = m_reactor_type;
+  const int captured_nsubsteps = m_nsubsteps;
+  const amrex::Real captured_nonlin_tol = m_nonlin_tol;
+  const amrex::Real captured_gmres_tol = m_gmres_tol;
+  const int captured_gmres_restarts = m_gmres_restarts;
+  const int captured_gmres_kspiters = m_gmres_kspiters;
+  const int captured_nonlinear_iters = m_nonlinear_iters;
+  const int captured_gmres_precond = m_gmres_precond;
 
-        amrex::Gpu::DeviceVector<int> v_nsteps(ncells, 0);
-        int* d_nsteps = v_nsteps.data();
+  amrex::Gpu::DeviceVector<int> v_nsteps(ncells, 0);
+  int* d_nsteps = v_nsteps.data();
 
-        amrex::ParallelFor(ncells, [=] AMREX_GPU_DEVICE(int icell) noexcept {
-            amrex::Real soln_n[NUM_SPECIES + 1] = {0.0}; //at time level n
-            amrex::Real soln_nm1[NUM_SPECIES + 1] = {0.0}; //at time level n-1
-            amrex::Real soln_nm2[NUM_SPECIES + 1] = {0.0}; //at time level n-2
-            amrex::Real soln[NUM_SPECIES + 1] = {0.0};
-            amrex::Real dsoln[NUM_SPECIES + 1] = {0.0};  //newton_soln_k+1 - newton_soln_k
-            amrex::Real dsoln0[NUM_SPECIES + 1] = {0.0}; //initial newton_soln_k+1 -newton_soln_k
-            amrex::Real ydot[NUM_SPECIES + 1] = {0.0};
-            amrex::Real rYsrc_ext[NUM_SPECIES] = {0.0};
-            amrex::Real mw[NUM_SPECIES]        = {0.0};
-            const int neq = (NUM_SPECIES + 1);
-            get_mw(mw);
+  amrex::ParallelFor(ncells, [=] AMREX_GPU_DEVICE(int icell) noexcept {
+    amrex::Real soln_n[NUM_SPECIES + 1] = {0.0};   // at time level n
+    amrex::Real soln_nm1[NUM_SPECIES + 1] = {0.0}; // at time level n-1
+    amrex::Real soln_nm2[NUM_SPECIES + 1] = {0.0}; // at time level n-2
+    amrex::Real soln[NUM_SPECIES + 1] = {0.0};
+    amrex::Real dsoln[NUM_SPECIES + 1] = {
+      0.0}; // newton_soln_k+1 - newton_soln_k
+    amrex::Real dsoln0[NUM_SPECIES + 1] = {
+      0.0}; // initial newton_soln_k+1 -newton_soln_k
+    amrex::Real ydot[NUM_SPECIES + 1] = {0.0};
+    amrex::Real rYsrc_ext[NUM_SPECIES] = {0.0};
+    amrex::Real mw[NUM_SPECIES] = {0.0};
+    const int neq = (NUM_SPECIES + 1);
+    get_mw(mw);
 
-            //initialization of variables before timestepping=====================
-            amrex::Real current_time = time_init;
-            amrex::Real dt = dt_react / amrex::Real(captured_nsubsteps);
-            
-            amrex::Real rho = 0.0;
-            amrex::Real massfrac[NUM_SPECIES] = {0.0};
-            for (int i = 0; i < neq; i++) {
-                soln_n[i] = d_rY[icell * neq + i];
-            }
-            get_rho_and_massfracs(soln_n,rho,massfrac);
-            amrex::Real temp = soln[NUM_SPECIES];
-    
-            amrex::Real rhoe_init[] = {d_rX[icell]};
-            amrex::Real rhoesrc_ext[] = {d_rX_src[icell]};
+    // initialization of variables before timestepping=====================
+    amrex::Real current_time = time_init;
+    amrex::Real dt = dt_react / amrex::Real(captured_nsubsteps);
 
-            for (int sp = 0; sp < NUM_SPECIES; sp++) {
-                rYsrc_ext[sp] = d_rYsrc[icell * NUM_SPECIES + sp];
-            }
+    amrex::Real rho = 0.0;
+    amrex::Real massfrac[NUM_SPECIES] = {0.0};
+    for (int i = 0; i < neq; i++) {
+      soln_n[i] = d_rY[icell * neq + i];
+    }
+    get_rho_and_massfracs(soln_n, rho, massfrac);
+    amrex::Real temp = soln[NUM_SPECIES];
 
-            const int consP = (captured_reactor_type 
-                               == ReactorTypes::h_reactor_type);
-            for (int ii = 0; ii < neq; ii++) 
-            {
-                soln[ii] = soln_n[ii];
-                soln_nm1[ii] = soln_n[ii];
-                soln_nm2[ii] = soln_n[ii];
-            }
-            //==================================================================
-            
-            int nsteps = 0;
-            int printflag=0;
-            //if BDF2 use trapz or BDF1 for first step
-            int first_tstepscheme=(captured_tstepscheme>=BDF2SCHEME)
-            ?TRPZSCHEME:captured_tstepscheme;
-            int schemechangestep=captured_tstepscheme-2; //0 for BDF2 and 1 for BDF3 
-            amrex::Real rhs[(NUM_SPECIES+1)]={0.0};
-            amrex::Real Jmat2d[NUM_SPECIES+1][NUM_SPECIES+1]={0.0};
-            for(int nsteps=0;nsteps<captured_nsubsteps;nsteps++) 
-            {
-                //shift to BDF2 after first step
-                int tstepscheme=(nsteps > schemechangestep)?captured_tstepscheme:first_tstepscheme;
-                
-                for (int ii = 0; ii < neq; ii++) 
-                {
-                    dsoln0[ii] = 0.0;
-                }
-                //non-linear iterations for each timestep=======================
-                for(int nlit=0;nlit<captured_nonlinear_iters;nlit++)
-                {
-                    for (int ii = 0; ii < neq; ii++) 
-                    {
-                        dsoln0[ii] = dsoln[ii];
-                    }
-                    get_bdf_matrix_and_rhs(soln,soln_n,soln_nm1,soln_nm2,
-                                           mw,captured_reactor_type,
-                                           tstepscheme,dt,
-                                           rhoe_init,rhoesrc_ext,rYsrc_ext,
-                                           current_time,time_init,
-                                           Jmat2d,rhs);
+    amrex::Real rhoe_init[] = {d_rX[icell]};
+    amrex::Real rhoesrc_ext[] = {d_rX_src[icell]};
 
-                    performgmres(Jmat2d,rhs,dsoln0,dsoln,captured_gmres_precond,
-                                 captured_gmres_restarts,captured_gmres_kspiters,
-                                 captured_gmres_tol,printflag);
+    for (int sp = 0; sp < NUM_SPECIES; sp++) {
+      rYsrc_ext[sp] = d_rYsrc[icell * NUM_SPECIES + sp];
+    }
 
+    const int consP = (captured_reactor_type == ReactorTypes::h_reactor_type);
+    for (int ii = 0; ii < neq; ii++) {
+      soln[ii] = soln_n[ii];
+      soln_nm1[ii] = soln_n[ii];
+      soln_nm2[ii] = soln_n[ii];
+    }
+    //==================================================================
 
-                    for (int ii = 0; ii < neq; ii++) 
-                    {
-                        soln[ii] += dsoln[ii];
-                    }
-                    amrex::Real norm=0.0;
-                    for(int ii=0;ii<neq;ii++)
-                    {
-                        norm += rhs[ii]*rhs[ii];
-                    }
-                    norm=std::sqrt(norm);
-                    if(norm <= captured_nonlin_tol)
-                    {
-                        break;
-                    }
-                }
+    int nsteps = 0;
+    int printflag = 0;
+    // if BDF2 use trapz or BDF1 for first step
+    int first_tstepscheme =
+      (captured_tstepscheme >= BDF2SCHEME) ? TRPZSCHEME : captured_tstepscheme;
+    int schemechangestep = captured_tstepscheme - 2; // 0 for BDF2 and 1 for
+                                                     // BDF3
+    amrex::Real rhs[(NUM_SPECIES + 1)] = {0.0};
+    amrex::Real Jmat2d[NUM_SPECIES + 1][NUM_SPECIES + 1] = {0.0};
+    for (int nsteps = 0; nsteps < captured_nsubsteps; nsteps++) {
+      // shift to BDF2 after first step
+      int tstepscheme =
+        (nsteps > schemechangestep) ? captured_tstepscheme : first_tstepscheme;
 
-                //copy non-linear solution onto soln_n, 
-                //soln_n to soln_nm1
-                for (int ii = 0; ii < neq; ii++) 
-                {
-                    soln_nm2[ii] = soln_nm1[ii];
-                    soln_nm1[ii] = soln_n[ii];
-                    soln_n[ii] = soln[ii];
-                }
-                current_time += dt;
-            }
+      for (int ii = 0; ii < neq; ii++) {
+        dsoln0[ii] = 0.0;
+      }
+      // non-linear iterations for each timestep=======================
+      for (int nlit = 0; nlit < captured_nonlinear_iters; nlit++) {
+        for (int ii = 0; ii < neq; ii++) {
+          dsoln0[ii] = dsoln[ii];
+        }
+        get_bdf_matrix_and_rhs(
+          soln, soln_n, soln_nm1, soln_nm2, mw, captured_reactor_type,
+          tstepscheme, dt, rhoe_init, rhoesrc_ext, rYsrc_ext, current_time,
+          time_init, Jmat2d, rhs);
 
-            //ideally should be cost
-            d_nsteps[icell] = captured_nsubsteps;
+        performgmres(
+          Jmat2d, rhs, dsoln0, dsoln, captured_gmres_precond,
+          captured_gmres_restarts, captured_gmres_kspiters, captured_gmres_tol,
+          printflag);
 
-            // copy data back
-            for (int sp = 0; sp < neq; sp++) {
-                d_rY[icell * neq + sp] = soln_n[sp];
-            }
-            d_rX[icell] = rhoe_init[0] + dt_react * rhoesrc_ext[0];
-        });
+        for (int ii = 0; ii < neq; ii++) {
+          soln[ii] += dsoln[ii];
+        }
+        amrex::Real norm = 0.0;
+        for (int ii = 0; ii < neq; ii++) {
+          norm += rhs[ii] * rhs[ii];
+        }
+        norm = std::sqrt(norm);
+        if (norm <= captured_nonlin_tol) {
+          break;
+        }
+      }
+
+      // copy non-linear solution onto soln_n,
+      // soln_n to soln_nm1
+      for (int ii = 0; ii < neq; ii++) {
+        soln_nm2[ii] = soln_nm1[ii];
+        soln_nm1[ii] = soln_n[ii];
+        soln_n[ii] = soln[ii];
+      }
+      current_time += dt;
+    }
+
+    // ideally should be cost
+    d_nsteps[icell] = captured_nsubsteps;
+
+    // copy data back
+    for (int sp = 0; sp < neq; sp++) {
+      d_rY[icell * neq + sp] = soln_n[sp];
+    }
+    d_rX[icell] = rhoe_init[0] + dt_react * rhoesrc_ext[0];
+  });
 
 #ifdef MOD_REACTOR
-        time = time_out;
+  time = time_out;
 #endif
 
-        const int avgsteps = amrex::Reduce::Sum<int>(
-            ncells, [=] AMREX_GPU_DEVICE(int i) noexcept -> int { return d_nsteps[i]; },
-            0);
+  const int avgsteps = amrex::Reduce::Sum<int>(
+    ncells, [=] AMREX_GPU_DEVICE(int i) noexcept -> int { return d_nsteps[i]; },
+    0);
 
-        amrex::Gpu::copy(
-            amrex::Gpu::deviceToHost, d_rY, d_rY + ncells * (NUM_SPECIES + 1), rY_in);
-        amrex::Gpu::copy(
-            amrex::Gpu::deviceToHost, d_rYsrc, d_rYsrc + ncells * NUM_SPECIES,
-            rYsrc_in);
-        amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_rX, d_rX + ncells, rX_in);
-        amrex::Gpu::copy(
-            amrex::Gpu::deviceToHost, d_rX_src, d_rX_src + ncells, rX_src_in);
+  amrex::Gpu::copy(
+    amrex::Gpu::deviceToHost, d_rY, d_rY + ncells * (NUM_SPECIES + 1), rY_in);
+  amrex::Gpu::copy(
+    amrex::Gpu::deviceToHost, d_rYsrc, d_rYsrc + ncells * NUM_SPECIES,
+    rYsrc_in);
+  amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_rX, d_rX + ncells, rX_in);
+  amrex::Gpu::copy(
+    amrex::Gpu::deviceToHost, d_rX_src, d_rX_src + ncells, rX_src_in);
 
-        //return cost here
-        return (int(avgsteps / amrex::Real(ncells)));
+  // return cost here
+  return (int(avgsteps / amrex::Real(ncells)));
+}
+
+int
+ReactorBDF::react(
+  const amrex::Box& box,
+  amrex::Array4<amrex::Real> const& rY_in,
+  amrex::Array4<amrex::Real> const& rYsrc_in,
+  amrex::Array4<amrex::Real> const& T_in,
+  amrex::Array4<amrex::Real> const& rEner_in,
+  amrex::Array4<amrex::Real> const& rEner_src_in,
+  amrex::Array4<amrex::Real> const& FC_in,
+  amrex::Array4<int> const& /*mask*/,
+  amrex::Real& dt_react,
+  amrex::Real& time
+#ifdef AMREX_USE_GPU
+  ,
+  amrex::gpuStream_t /*stream*/
+#endif
+)
+{
+  BL_PROFILE("Pele::ReactorBDF::react()");
+
+  amrex::Real time_init = time;
+  amrex::Real time_out = time + dt_react;
+
+  // capture variables
+  const int captured_tstepscheme = m_tstepscheme;
+  const int captured_reactor_type = m_reactor_type;
+  const int captured_nsubsteps = m_nsubsteps;
+  const amrex::Real captured_nonlin_tol = m_nonlin_tol;
+  const amrex::Real captured_gmres_tol = m_gmres_tol;
+  const int captured_gmres_restarts = m_gmres_restarts;
+  const int captured_gmres_kspiters = m_gmres_kspiters;
+  const int captured_nonlinear_iters = m_nonlinear_iters;
+  const int captured_gmres_precond = m_gmres_precond;
+
+  int ncells = static_cast<int>(box.numPts());
+  const auto len = amrex::length(box);
+  const auto lo = amrex::lbound(box);
+
+  amrex::Gpu::DeviceVector<int> v_nsteps(ncells, 0);
+  int* d_nsteps = v_nsteps.data();
+
+  amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+    amrex::Real soln[NUM_SPECIES + 1] = {0.0};
+    amrex::Real soln_n[NUM_SPECIES + 1] = {0.0};   // at time level n
+    amrex::Real soln_nm1[NUM_SPECIES + 1] = {0.0}; // at time level n-1
+    amrex::Real soln_nm2[NUM_SPECIES + 1] = {0.0}; // at time level n-2
+    amrex::Real dsoln[NUM_SPECIES + 1] = {
+      0.0}; // newton_soln_k+1 - newton_soln_k
+    amrex::Real dsoln0[NUM_SPECIES + 1] = {
+      0.0}; // initial newton_soln_k+1 -newton_soln_k
+    amrex::Real ydot[NUM_SPECIES + 1] = {0.0};
+    amrex::Real rYsrc_ext[NUM_SPECIES] = {0.0};
+    amrex::Real mw[NUM_SPECIES] = {0.0};
+    const int neq = (NUM_SPECIES + 1);
+    get_mw(mw);
+
+    // initialization of variables before timestepping=====================
+    amrex::Real current_time = time_init;
+    amrex::Real dt = dt_react / amrex::Real(captured_nsubsteps);
+    amrex::Real rho = 0.0;
+    amrex::Real massfrac[NUM_SPECIES] = {0.0};
+    for (int sp = 0; sp < NUM_SPECIES; sp++) {
+      soln_n[sp] = rY_in(i, j, k, sp);
+    }
+    get_rho_and_massfracs(soln_n, rho, massfrac);
+
+    amrex::Real temp = T_in(i, j, k, 0);
+    amrex::Real Enrg_loc = rEner_in(i, j, k, 0) / rho;
+    auto eos = pele::physics::PhysicsType::eos();
+    if (captured_reactor_type == ReactorTypes::e_reactor_type) {
+      eos.REY2T(rho, Enrg_loc, massfrac, temp);
+    } else if (captured_reactor_type == ReactorTypes::h_reactor_type) {
+      eos.RHY2T(rho, Enrg_loc, massfrac, temp);
+    } else {
+      amrex::Abort("Wrong reactor type. Choose between 1 (e) or 2 (h).");
+    }
+    soln_n[NUM_SPECIES] = temp;
+    amrex::Real rhoe_init[] = {rEner_in(i, j, k, 0)};
+    amrex::Real rhoesrc_ext[] = {rEner_src_in(i, j, k, 0)};
+    for (int sp = 0; sp < NUM_SPECIES; sp++) {
+      rYsrc_ext[sp] = rYsrc_in(i, j, k, sp);
+    }
+    const int consP = (captured_reactor_type == ReactorTypes::h_reactor_type);
+    for (int ii = 0; ii < neq; ii++) {
+      soln[ii] = soln_n[ii];
+      soln_nm1[ii] = soln_n[ii];
+      soln_nm2[ii] = soln_n[ii];
+    }
+    //==================================================================
+
+    // begin timestepping================================================
+    int printflag = 0;
+    // if BDF2 use trapz or BDF1 for first step
+    int first_tstepscheme =
+      (captured_tstepscheme >= BDF2SCHEME) ? TRPZSCHEME : captured_tstepscheme;
+    int schemechangestep = captured_tstepscheme - 2; // 0 for BDF2 and 1 for
+                                                     // BDF3
+    amrex::Real rhs[(NUM_SPECIES + 1)] = {0.0};
+    amrex::Real Jmat2d[NUM_SPECIES + 1][NUM_SPECIES + 1] = {0.0};
+    for (int nsteps = 0; nsteps < captured_nsubsteps; nsteps++) {
+      // shift to BDF2 after first step
+      int tstepscheme =
+        (nsteps > schemechangestep) ? captured_tstepscheme : first_tstepscheme;
+
+      for (int ii = 0; ii < neq; ii++) {
+        dsoln0[ii] = 0.0;
+      }
+      // non-linear iterations for each timestep=======================
+      for (int nlit = 0; nlit < captured_nonlinear_iters; nlit++) {
+        for (int ii = 0; ii < neq; ii++) {
+          dsoln0[ii] = dsoln[ii];
+        }
+        get_bdf_matrix_and_rhs(
+          soln, soln_n, soln_nm1, soln_nm2, mw, captured_reactor_type,
+          tstepscheme, dt, rhoe_init, rhoesrc_ext, rYsrc_ext, current_time,
+          time_init, Jmat2d, rhs);
+
+        performgmres(
+          Jmat2d, rhs, dsoln0, dsoln, captured_gmres_precond,
+          captured_gmres_restarts, captured_gmres_kspiters, captured_gmres_tol,
+          printflag);
+
+        for (int ii = 0; ii < neq; ii++) {
+          soln[ii] += dsoln[ii];
+        }
+
+        amrex::Real norm = 0.0;
+        for (int ii = 0; ii < neq; ii++) {
+          norm += rhs[ii] * rhs[ii];
+        }
+        norm = std::sqrt(norm);
+        if (norm <= captured_nonlin_tol) {
+          break;
+        }
+      }
+
+      // copy non-linear solution onto soln_n,
+      // soln_n to soln_nm1
+      for (int ii = 0; ii < neq; ii++) {
+        soln_nm2[ii] = soln_nm1[ii];
+        soln_nm1[ii] = soln_n[ii];
+        soln_n[ii] = soln[ii];
+      }
+      current_time += dt;
     }
 
-    int
-    ReactorBDF::react(
-        const amrex::Box& box,
-        amrex::Array4<amrex::Real> const& rY_in,
-        amrex::Array4<amrex::Real> const& rYsrc_in,
-        amrex::Array4<amrex::Real> const& T_in,
-        amrex::Array4<amrex::Real> const& rEner_in,
-        amrex::Array4<amrex::Real> const& rEner_src_in,
-        amrex::Array4<amrex::Real> const& FC_in,
-        amrex::Array4<int> const& /*mask*/,
-        amrex::Real& dt_react,
-        amrex::Real& time
-#ifdef AMREX_USE_GPU
-        ,
-        amrex::gpuStream_t /*stream*/
-#endif
-        )
-    {
-        BL_PROFILE("Pele::ReactorBDF::react()");
+    // copy data back
+    int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
+    d_nsteps[icell] = captured_nsubsteps;
 
-        amrex::Real time_init = time;
-        amrex::Real time_out = time + dt_react;
+    get_rho_and_massfracs(soln_n, rho, massfrac);
+    for (int sp = 0; sp < NUM_SPECIES; sp++) {
+      rY_in(i, j, k, sp) = soln_n[sp];
+    }
 
-        // capture variables
-        const int captured_tstepscheme=m_tstepscheme;
-        const int captured_reactor_type = m_reactor_type;
-        const int captured_nsubsteps = m_nsubsteps;
-        const amrex::Real captured_nonlin_tol = m_nonlin_tol;
-        const amrex::Real captured_gmres_tol = m_gmres_tol;
-        const int captured_gmres_restarts=m_gmres_restarts;
-        const int captured_gmres_kspiters=m_gmres_kspiters;
-        const int captured_nonlinear_iters=m_nonlinear_iters;
-        const int captured_gmres_precond=m_gmres_precond;
+    temp = soln_n[NUM_SPECIES];
+    rEner_in(i, j, k, 0) = rhoe_init[0] + dt_react * rhoesrc_ext[0];
+    Enrg_loc = rEner_in(i, j, k, 0) / rho;
 
-        int ncells = static_cast<int>(box.numPts());
-        const auto len = amrex::length(box);
-        const auto lo = amrex::lbound(box);
-
-        amrex::Gpu::DeviceVector<int> v_nsteps(ncells, 0);
-        int* d_nsteps = v_nsteps.data();
-
-        amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-
-            amrex::Real soln[NUM_SPECIES + 1] = {0.0};
-            amrex::Real soln_n[NUM_SPECIES + 1] = {0.0}; //at time level n
-            amrex::Real soln_nm1[NUM_SPECIES + 1] = {0.0}; //at time level n-1
-            amrex::Real soln_nm2[NUM_SPECIES + 1] = {0.0}; //at time level n-2
-            amrex::Real dsoln[NUM_SPECIES + 1] = {0.0};  //newton_soln_k+1 - newton_soln_k
-            amrex::Real dsoln0[NUM_SPECIES + 1] = {0.0}; //initial newton_soln_k+1 -newton_soln_k
-            amrex::Real ydot[NUM_SPECIES + 1] = {0.0};
-            amrex::Real rYsrc_ext[NUM_SPECIES] = {0.0};
-            amrex::Real mw[NUM_SPECIES]        = {0.0};
-            const int neq = (NUM_SPECIES + 1);
-            get_mw(mw);
-
-            //initialization of variables before timestepping=====================
-            amrex::Real current_time = time_init;
-            amrex::Real dt = dt_react / amrex::Real(captured_nsubsteps);
-            amrex::Real rho = 0.0;
-            amrex::Real massfrac[NUM_SPECIES] = {0.0};
-            for (int sp = 0; sp < NUM_SPECIES; sp++) {
-                soln_n[sp] = rY_in(i, j, k, sp);
-            }
-            get_rho_and_massfracs(soln_n,rho,massfrac);
-            
-            amrex::Real temp = T_in(i, j, k, 0);
-            amrex::Real Enrg_loc = rEner_in(i, j, k, 0)/rho;
-            auto eos = pele::physics::PhysicsType::eos();
-            if (captured_reactor_type == ReactorTypes::e_reactor_type) {
-                eos.REY2T(rho, Enrg_loc, massfrac, temp);
-            } else if (captured_reactor_type == ReactorTypes::h_reactor_type) {
-                eos.RHY2T(rho, Enrg_loc, massfrac, temp);
-            } else {
-                amrex::Abort("Wrong reactor type. Choose between 1 (e) or 2 (h).");
-            }
-            soln_n[NUM_SPECIES] = temp;
-            amrex::Real rhoe_init[] = {rEner_in(i, j, k, 0)};
-            amrex::Real rhoesrc_ext[] = {rEner_src_in(i, j, k, 0)};
-            for (int sp = 0; sp < NUM_SPECIES; sp++) 
-            {
-                rYsrc_ext[sp] = rYsrc_in(i, j, k, sp);
-            }
-            const int consP = (captured_reactor_type 
-                               == ReactorTypes::h_reactor_type);
-            for (int ii = 0; ii < neq; ii++) 
-            {
-                soln[ii] = soln_n[ii];
-                soln_nm1[ii] = soln_n[ii];
-                soln_nm2[ii] = soln_n[ii];
-            }
-            //==================================================================
-
-            //begin timestepping================================================
-            int printflag=0;
-            //if BDF2 use trapz or BDF1 for first step
-            int first_tstepscheme=(captured_tstepscheme>=BDF2SCHEME)
-            ?TRPZSCHEME:captured_tstepscheme;
-            int schemechangestep=captured_tstepscheme-2; //0 for BDF2 and 1 for BDF3 
-            amrex::Real rhs[(NUM_SPECIES+1)]={0.0};
-            amrex::Real Jmat2d[NUM_SPECIES+1][NUM_SPECIES+1]={0.0};
-            for(int nsteps=0;nsteps<captured_nsubsteps;nsteps++)
-            {
-                //shift to BDF2 after first step
-                int tstepscheme=(nsteps > schemechangestep)?captured_tstepscheme:first_tstepscheme;
-
-                for (int ii = 0; ii < neq; ii++) 
-                {
-                    dsoln0[ii] = 0.0;
-                }
-                //non-linear iterations for each timestep=======================
-                for(int nlit=0;nlit<captured_nonlinear_iters;nlit++)
-                {
-                    for (int ii = 0; ii < neq; ii++) 
-                    {
-                        dsoln0[ii] = dsoln[ii];
-                    }
-                    get_bdf_matrix_and_rhs(soln,soln_n,soln_nm1,soln_nm2,
-                                           mw,captured_reactor_type,
-                                           tstepscheme,dt,
-                                           rhoe_init,rhoesrc_ext,rYsrc_ext,
-                                           current_time, time_init,
-                                           Jmat2d,rhs);
-
-                    performgmres(Jmat2d,rhs,dsoln0,dsoln,captured_gmres_precond,
-                                 captured_gmres_restarts,captured_gmres_kspiters,
-                                 captured_gmres_tol,printflag);
-
-                    for (int ii = 0; ii < neq; ii++) 
-                    {
-                        soln[ii] += dsoln[ii];
-                    }
-
-                    amrex::Real norm=0.0;
-                    for(int ii=0;ii<neq;ii++)
-                    {
-                        norm += rhs[ii]*rhs[ii];
-                    }
-                    norm=std::sqrt(norm);
-                    if(norm <= captured_nonlin_tol)
-                    {
-                        break;
-                    }
-                }
-
-                //copy non-linear solution onto soln_n, 
-                //soln_n to soln_nm1
-                for (int ii = 0; ii < neq; ii++) 
-                {
-                    soln_nm2[ii] = soln_nm1[ii];
-                    soln_nm1[ii] = soln_n[ii];
-                    soln_n[ii] = soln[ii];
-                }
-                current_time += dt;
-
-            }
-
-            // copy data back
-            int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
-            d_nsteps[icell] = captured_nsubsteps;
-
-            get_rho_and_massfracs(soln_n,rho,massfrac);
-            for (int sp = 0; sp < NUM_SPECIES; sp++) {
-                rY_in(i, j, k, sp) = soln_n[sp];
-            }
-
-            temp = soln_n[NUM_SPECIES];
-            rEner_in(i, j, k, 0) = rhoe_init[0] + dt_react * rhoesrc_ext[0];
-            Enrg_loc = rEner_in(i, j, k, 0)/rho;
-
-            if (captured_reactor_type == ReactorTypes::e_reactor_type) {
-                eos.REY2T(rho, Enrg_loc, massfrac, temp);
-            } else if (captured_reactor_type == ReactorTypes::h_reactor_type) {
-                eos.RHY2T(rho, Enrg_loc, massfrac, temp);
-            } else {
-                amrex::Abort("Wrong reactor type. Choose between 1 (e) or 2 (h).");
-            }
-            T_in(i, j, k, 0) = temp;
-            FC_in(i, j, k, 0) = captured_nsubsteps;
-        });
+    if (captured_reactor_type == ReactorTypes::e_reactor_type) {
+      eos.REY2T(rho, Enrg_loc, massfrac, temp);
+    } else if (captured_reactor_type == ReactorTypes::h_reactor_type) {
+      eos.RHY2T(rho, Enrg_loc, massfrac, temp);
+    } else {
+      amrex::Abort("Wrong reactor type. Choose between 1 (e) or 2 (h).");
+    }
+    T_in(i, j, k, 0) = temp;
+    FC_in(i, j, k, 0) = captured_nsubsteps;
+  });
 
 #ifdef MOD_REACTOR
-        time = time_out;
+  time = time_out;
 #endif
 
-        const int avgsteps = amrex::Reduce::Sum<int>(
-            ncells, [=] AMREX_GPU_DEVICE(int i) noexcept -> int { return d_nsteps[i]; },
-            0);
-        return (int(avgsteps / amrex::Real(ncells)));
-    }
+  const int avgsteps = amrex::Reduce::Sum<int>(
+    ncells, [=] AMREX_GPU_DEVICE(int i) noexcept -> int { return d_nsteps[i]; },
+    0);
+  return (int(avgsteps / amrex::Real(ncells)));
+}
 
 } // namespace pele::physics::reactions

--- a/Reactions/ReactorBDF.cpp
+++ b/Reactions/ReactorBDF.cpp
@@ -114,6 +114,7 @@ namespace pele::physics::reactions {
         pp.query("bdf_nonlinear_tol",m_nonlin_tol);
         pp.query("bdf_nsubsteps", m_nsubsteps);
         pp.query("bdf_gmres_restarts",m_gmres_restarts);
+        pp.query("bdf_gmres_kspiters",m_gmres_kspiters);
         pp.query("bdf_gmres_tol",m_gmres_tol);
         pp.query("bdf_gmres_precond",m_gmres_precond);
         pp.query("clean_init_massfrac", m_clean_init_massfrac);
@@ -166,6 +167,7 @@ namespace pele::physics::reactions {
         const amrex::Real captured_nonlin_tol = m_nonlin_tol;
         const amrex::Real captured_gmres_tol = m_gmres_tol;
         const int captured_gmres_restarts=m_gmres_restarts;
+        const int captured_gmres_kspiters=m_gmres_kspiters;
         const int captured_nonlinear_iters=m_nonlinear_iters;
         const int captured_gmres_precond=m_gmres_precond;
 
@@ -248,7 +250,8 @@ namespace pele::physics::reactions {
                                            Jmat2d,rhs);
 
                     performgmres(Jmat2d,rhs,dsoln0,dsoln,captured_gmres_precond,
-                                 captured_gmres_restarts,captured_gmres_tol,printflag);
+                                 captured_gmres_restarts,captured_gmres_kspiters,
+                                 captured_gmres_tol,printflag);
 
 
                     for (int ii = 0; ii < neq; ii++) 
@@ -340,6 +343,7 @@ namespace pele::physics::reactions {
         const amrex::Real captured_nonlin_tol = m_nonlin_tol;
         const amrex::Real captured_gmres_tol = m_gmres_tol;
         const int captured_gmres_restarts=m_gmres_restarts;
+        const int captured_gmres_kspiters=m_gmres_kspiters;
         const int captured_nonlinear_iters=m_nonlinear_iters;
         const int captured_gmres_precond=m_gmres_precond;
 
@@ -435,7 +439,8 @@ namespace pele::physics::reactions {
                                            Jmat2d,rhs);
 
                     performgmres(Jmat2d,rhs,dsoln0,dsoln,captured_gmres_precond,
-                                 captured_gmres_restarts,captured_gmres_tol,printflag);
+                                 captured_gmres_restarts,captured_gmres_kspiters,
+                                 captured_gmres_tol,printflag);
 
                     for (int ii = 0; ii < neq; ii++) 
                     {

--- a/Reactions/ReactorBDF.cpp
+++ b/Reactions/ReactorBDF.cpp
@@ -1,0 +1,311 @@
+#include "AMReX_Reduce.H"
+#include "ReactorBDF.H"
+#include "ReactorBDFsolver.H"
+
+namespace pele::physics::reactions {
+
+    int
+    ReactorBDF::init(int reactor_type, int /*ncells*/)
+    {
+        BL_PROFILE("Pele::ReactorBDF::init()");
+        m_reactor_type = reactor_type;
+        ReactorTypes::check_reactor_type(m_reactor_type);
+        amrex::ParmParse pp("ode");
+        pp.query("verbose", verbose);
+        pp.query("atol", absTol);
+        pp.query("nonlinear_iters",bdf_nonlinear_iters);
+        pp.query("bdf_nsubsteps", bdf_nsubsteps);
+        pp.query("bdf_gmres_restarts",bdf_gmres_restarts);
+        pp.query("bdf_gmres_tol",bdf_gmres_tol);
+        pp.query("bdf_gmres_precond",bdf_gmres_precond);
+        pp.query("clean_init_massfrac", m_clean_init_massfrac);
+        return (0);
+    }
+
+    int
+    ReactorBDF::react(
+        amrex::Real* rY_in,
+        amrex::Real* rYsrc_in,
+        amrex::Real* rX_in,
+        amrex::Real* rX_src_in,
+        amrex::Real& dt_react,
+        amrex::Real& time,
+        int ncells
+#ifdef AMREX_USE_GPU
+        ,
+        amrex::gpuStream_t /*stream*/
+#endif
+        )
+    {
+        BL_PROFILE("Pele::ReactorBDF::react()");
+
+        amrex::Real time_init = time;
+        amrex::Real time_out = time + dt_react;
+
+        // Copy to device
+        amrex::Gpu::DeviceVector<amrex::Real> rY(ncells * (NUM_SPECIES + 1), 0);
+        amrex::Gpu::DeviceVector<amrex::Real> rYsrc(ncells * NUM_SPECIES, 0);
+        amrex::Gpu::DeviceVector<amrex::Real> rX(ncells, 0);
+        amrex::Gpu::DeviceVector<amrex::Real> rX_src(ncells, 0);
+        amrex::Real* d_rY = rY.data();
+        amrex::Real* d_rYsrc = rYsrc.data();
+        amrex::Real* d_rX = rX.data();
+        amrex::Real* d_rX_src = rX_src.data();
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, rY_in, rY_in + ncells * (NUM_SPECIES + 1), d_rY);
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, rYsrc_in, rYsrc_in + ncells * NUM_SPECIES,
+            d_rYsrc);
+        amrex::Gpu::copy(amrex::Gpu::hostToDevice, rX_in, rX_in + ncells, d_rX);
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, rX_src_in, rX_src_in + ncells, d_rX_src);
+
+        // capture variables
+        const int captured_reactor_type = m_reactor_type;
+        const int captured_nsubsteps = bdf_nsubsteps;
+        const amrex::Real captured_abstol = absTol;
+        const amrex::Real captured_gmres_tol = bdf_gmres_tol;
+        const int captured_gmres_restarts=bdf_gmres_restarts;
+        const int captured_nonlinear_iters=bdf_nonlinear_iters;
+        const int captured_gmres_precond=bdf_gmres_precond;
+
+        amrex::Gpu::DeviceVector<int> v_nsteps(ncells, 0);
+        int* d_nsteps = v_nsteps.data();
+
+        amrex::ParallelFor(ncells, [=] AMREX_GPU_DEVICE(int icell) noexcept {
+            amrex::Real soln_reg_n[NUM_SPECIES + 1] = {0.0}; //at time level n
+            amrex::Real soln_reg0[NUM_SPECIES + 1] = {0.0}; //at time level n
+            amrex::Real soln_reg[NUM_SPECIES + 1] = {0.0};
+            amrex::Real rYsrc_ext[NUM_SPECIES] = {0.0};
+            amrex::Real ydot[NUM_SPECIES + 1] = {0.0};
+            amrex::Real current_time = time_init;
+            const int neq = (NUM_SPECIES + 1);
+
+            for (int sp = 0; sp < neq; sp++) {
+                soln_reg_n[sp] = d_rY[icell * neq + sp];
+                soln_reg[sp] = soln_reg_n[sp];
+            }
+    
+            amrex::Real rho = 0.0;
+            for (int sp = 0; sp < NUM_SPECIES; sp++) {
+                 rho = rho + soln_reg[sp];
+            }
+            amrex::Real temp = soln_reg[NUM_SPECIES];
+    
+            amrex::Real massfrac[NUM_SPECIES] = {0.0};
+            amrex::Real rhoinv = 1.0 / rho;
+            for (int sp = 0; sp < NUM_SPECIES; sp++) {
+                massfrac[sp] = soln_reg[sp] * rhoinv;
+            }   
+
+            amrex::Real dt_bdf = dt_react / amrex::Real(captured_nsubsteps);
+
+            amrex::Real rhoe_init[] = {d_rX[icell]};
+            amrex::Real rhoesrc_ext[] = {d_rX_src[icell]};
+
+            for (int sp = 0; sp < NUM_SPECIES; sp++) {
+                rYsrc_ext[sp] = d_rYsrc[icell * NUM_SPECIES + sp];
+            }
+
+            int nsteps = 0;
+            int printflag=0;
+            const int consP = (captured_reactor_type 
+                               == ReactorTypes::h_reactor_type);
+            auto eos = pele::physics::PhysicsType::eos();
+            while (current_time < time_out) 
+            {
+                for(int nlit=0;nlit<bdf_nonlinear_iters;nlit++)
+                {
+                    for (int sp = 0; sp < neq; sp++) {
+                        soln_reg0[sp] = soln_reg[sp];
+                    }
+                    amrex::Real Jmat[(NUM_SPECIES + 1) * (NUM_SPECIES + 1)] = {0.0};
+                    eos.RTY2JAC(rho, temp, massfrac, Jmat, consP);
+                    utils::fKernelSpec<Ordering>(
+                        0, 1, current_time - time_init, 
+                        captured_reactor_type, soln_reg, ydot,
+                        rhoe_init, rhoesrc_ext, rYsrc_ext);
+                    performgmres(Jmat,ydot,soln_reg0,soln_reg,soln_reg_n,
+                                 dt_bdf,captured_gmres_precond,
+                                 captured_gmres_restarts,captured_gmres_tol,printflag);
+                }
+                current_time += dt_bdf;
+                nsteps++;
+
+            }
+
+            //ideally should be cost
+            d_nsteps[icell] = nsteps;
+
+            // copy data back
+            for (int sp = 0; sp < neq; sp++) {
+                d_rY[icell * neq + sp] = soln_reg[sp];
+            }
+            d_rX[icell] = rhoe_init[0] + dt_react * rhoesrc_ext[0];
+        });
+
+#ifdef MOD_REACTOR
+        time = time_out;
+#endif
+
+        const int avgsteps = amrex::Reduce::Sum<int>(
+            ncells, [=] AMREX_GPU_DEVICE(int i) noexcept -> int { return d_nsteps[i]; },
+            0);
+
+        amrex::Gpu::copy(
+            amrex::Gpu::deviceToHost, d_rY, d_rY + ncells * (NUM_SPECIES + 1), rY_in);
+        amrex::Gpu::copy(
+            amrex::Gpu::deviceToHost, d_rYsrc, d_rYsrc + ncells * NUM_SPECIES,
+            rYsrc_in);
+        amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_rX, d_rX + ncells, rX_in);
+        amrex::Gpu::copy(
+            amrex::Gpu::deviceToHost, d_rX_src, d_rX_src + ncells, rX_src_in);
+
+        //return cost here
+        return (int(avgsteps / amrex::Real(ncells)));
+    }
+
+    int
+    ReactorBDF::react(
+        const amrex::Box& box,
+        amrex::Array4<amrex::Real> const& rY_in,
+        amrex::Array4<amrex::Real> const& rYsrc_in,
+        amrex::Array4<amrex::Real> const& T_in,
+        amrex::Array4<amrex::Real> const& rEner_in,
+        amrex::Array4<amrex::Real> const& rEner_src_in,
+        amrex::Array4<amrex::Real> const& FC_in,
+        amrex::Array4<int> const& /*mask*/,
+        amrex::Real& dt_react,
+        amrex::Real& time
+#ifdef AMREX_USE_GPU
+        ,
+        amrex::gpuStream_t /*stream*/
+#endif
+        )
+    {
+        BL_PROFILE("Pele::ReactorBDF::react()");
+
+        amrex::Real time_init = time;
+        amrex::Real time_out = time + dt_react;
+
+        // capture variables
+        const int captured_reactor_type = m_reactor_type;
+        const int captured_nsubsteps = bdf_nsubsteps;
+        const amrex::Real captured_abstol = absTol;
+        const amrex::Real captured_gmres_tol = bdf_gmres_tol;
+        const int captured_gmres_restarts=bdf_gmres_restarts;
+        const int captured_nonlinear_iters=bdf_nonlinear_iters;
+        const int captured_gmres_precond=bdf_gmres_precond;
+
+        int ncells = static_cast<int>(box.numPts());
+        const auto len = amrex::length(box);
+        const auto lo = amrex::lbound(box);
+
+        amrex::Gpu::DeviceVector<int> v_nsteps(ncells, 0);
+        int* d_nsteps = v_nsteps.data();
+
+        amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            amrex::Real soln_reg_n[NUM_SPECIES + 1] = {0.0}; //at time level n
+            amrex::Real soln_reg[NUM_SPECIES + 1] = {0.0};
+            amrex::Real soln_reg0[NUM_SPECIES + 1] = {0.0};
+            amrex::Real ydot[NUM_SPECIES + 1] = {0.0};
+            amrex::Real rYsrc_ext[NUM_SPECIES] = {0.0};
+            amrex::Real current_time = time_init;
+            const int neq = (NUM_SPECIES + 1);
+
+            amrex::Real rho = 0.0;
+            for (int sp = 0; sp < NUM_SPECIES; sp++) {
+                soln_reg_n[sp] = rY_in(i, j, k, sp);
+                soln_reg[sp] = soln_reg_n[sp];
+                rho += rY_in(i, j, k, sp);
+            }
+            amrex::Real rho_inv = 1.0 / rho;
+            amrex::Real massfrac[NUM_SPECIES] = {0.0};
+            for (int sp = 0; sp < NUM_SPECIES; sp++) {
+                massfrac[sp] = rY_in(i, j, k, sp) * rho_inv;
+            }
+            amrex::Real temp = T_in(i, j, k, 0);
+
+            amrex::Real Enrg_loc = rEner_in(i, j, k, 0) * rho_inv;
+            auto eos = pele::physics::PhysicsType::eos();
+            if (captured_reactor_type == ReactorTypes::e_reactor_type) {
+                eos.REY2T(rho, Enrg_loc, massfrac, temp);
+            } else if (captured_reactor_type == ReactorTypes::h_reactor_type) {
+                eos.RHY2T(rho, Enrg_loc, massfrac, temp);
+            } else {
+                amrex::Abort("Wrong reactor type. Choose between 1 (e) or 2 (h).");
+            }
+            soln_reg_n[NUM_SPECIES] = temp;
+            soln_reg[NUM_SPECIES] = temp;
+
+            amrex::Real dt_bdf = dt_react / amrex::Real(captured_nsubsteps);
+
+            amrex::Real rhoe_init[] = {rEner_in(i, j, k, 0)};
+            amrex::Real rhoesrc_ext[] = {rEner_src_in(i, j, k, 0)};
+
+            for (int sp = 0; sp < NUM_SPECIES; sp++) {
+                rYsrc_ext[sp] = rYsrc_in(i, j, k, sp);
+            }
+
+            int nsteps = 0;
+            int printflag=0;
+            const int consP = (captured_reactor_type 
+                               == ReactorTypes::h_reactor_type);
+            while (current_time < time_out) 
+            {
+                for(int nlit=0;nlit<bdf_nonlinear_iters;nlit++)
+                {
+                    for (int sp = 0; sp < neq; sp++) {
+                        soln_reg0[sp] = soln_reg[sp];
+                    }
+                    amrex::Real Jmat[(NUM_SPECIES + 1) * (NUM_SPECIES + 1)] = {0.0};
+                    eos.RTY2JAC(rho, temp, massfrac, Jmat, consP);
+                    utils::fKernelSpec<Ordering>(
+                        0, 1, current_time - time_init, captured_reactor_type, soln_reg, ydot,
+                        rhoe_init, rhoesrc_ext, rYsrc_ext);
+                    performgmres(Jmat,ydot,soln_reg0,soln_reg,soln_reg_n,
+                                 dt_bdf,captured_gmres_precond,
+                                 captured_gmres_restarts,captured_gmres_tol,printflag);
+                }
+                current_time += dt_bdf;
+                nsteps++;
+            }
+
+            // copy data back
+            int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
+            d_nsteps[icell] = nsteps;
+            rho = 0.0;
+            for (int sp = 0; sp < NUM_SPECIES; sp++) {
+                rY_in(i, j, k, sp) = soln_reg[sp];
+                rho += rY_in(i, j, k, sp);
+            }
+            rho_inv = 1.0 / rho;
+            for (int sp = 0; sp < NUM_SPECIES; sp++) {
+                massfrac[sp] = rY_in(i, j, k, sp) * rho_inv;
+            }
+            temp = soln_reg[NUM_SPECIES];
+            rEner_in(i, j, k, 0) = rhoe_init[0] + dt_react * rhoesrc_ext[0];
+            Enrg_loc = rEner_in(i, j, k, 0) * rho_inv;
+
+            if (captured_reactor_type == ReactorTypes::e_reactor_type) {
+                eos.REY2T(rho, Enrg_loc, massfrac, temp);
+            } else if (captured_reactor_type == ReactorTypes::h_reactor_type) {
+                eos.RHY2T(rho, Enrg_loc, massfrac, temp);
+            } else {
+                amrex::Abort("Wrong reactor type. Choose between 1 (e) or 2 (h).");
+            }
+            T_in(i, j, k, 0) = temp;
+            FC_in(i, j, k, 0) = nsteps;
+        });
+
+#ifdef MOD_REACTOR
+        time = time_out;
+#endif
+
+        const int avgsteps = amrex::Reduce::Sum<int>(
+            ncells, [=] AMREX_GPU_DEVICE(int i) noexcept -> int { return d_nsteps[i]; },
+            0);
+        return (int(avgsteps / amrex::Real(ncells)));
+    }
+
+} // namespace pele::physics::reactions

--- a/Reactions/ReactorBDF.cpp
+++ b/Reactions/ReactorBDF.cpp
@@ -217,7 +217,7 @@ namespace pele::physics::reactions {
             ?TRPZSCHEME:captured_tstepscheme;
             amrex::Real rhs[(NUM_SPECIES+1)]={0.0};
             amrex::Real Jmat2d[NUM_SPECIES+1][NUM_SPECIES+1]={0.0};
-            while (current_time < time_out) 
+            for(int nsteps=0;nsteps<captured_nsubsteps;nsteps++) 
             {
                 //shift to BDF2 after first step
                 int tstepscheme=(nsteps > 0)?captured_tstepscheme:first_tstepscheme;
@@ -237,7 +237,7 @@ namespace pele::physics::reactions {
                     }
                     get_bdf_matrix_and_rhs(soln,soln_n,soln_nm1,
                                            mw,captured_reactor_type,
-                                           captured_tstepscheme,dt,
+                                           tstepscheme,dt,
                                            rhoe_init,rhoesrc_ext,rYsrc_ext,
                                            current_time, time_init,
                                            Jmat2d,rhs);
@@ -271,11 +271,10 @@ namespace pele::physics::reactions {
                     soln_n[ii] = soln[ii];
                 }
                 current_time += dt;
-                nsteps++;
             }
 
             //ideally should be cost
-            d_nsteps[icell] = nsteps;
+            d_nsteps[icell] = captured_nsubsteps;
 
             // copy data back
             for (int sp = 0; sp < neq; sp++) {
@@ -395,14 +394,13 @@ namespace pele::physics::reactions {
             //==================================================================
 
             //begin timestepping================================================
-            int nsteps = 0;
             int printflag=0;
             //if BDF2 use trapz or BDF1 for first step
             int first_tstepscheme=(captured_tstepscheme==BDF2SCHEME)
             ?TRPZSCHEME:captured_tstepscheme;
             amrex::Real rhs[(NUM_SPECIES+1)]={0.0};
             amrex::Real Jmat2d[NUM_SPECIES+1][NUM_SPECIES+1]={0.0};
-            while (current_time < time_out) 
+            for(int nsteps=0;nsteps<captured_nsubsteps;nsteps++)
             {
                 //shift to BDF2 after first step
                 int tstepscheme=(nsteps > 0)?captured_tstepscheme:first_tstepscheme;
@@ -422,7 +420,7 @@ namespace pele::physics::reactions {
                     }
                     get_bdf_matrix_and_rhs(soln,soln_n,soln_nm1,
                                            mw,captured_reactor_type,
-                                           captured_tstepscheme,dt,
+                                           tstepscheme,dt,
                                            rhoe_init,rhoesrc_ext,rYsrc_ext,
                                            current_time, time_init,
                                            Jmat2d,rhs);
@@ -456,12 +454,11 @@ namespace pele::physics::reactions {
                     soln_n[ii] = soln[ii];
                 }
                 current_time += dt;
-                nsteps++;
             }
 
             // copy data back
             int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
-            d_nsteps[icell] = nsteps;
+            d_nsteps[icell] = captured_nsubsteps;
 
             get_rho_and_massfracs(soln_n,rho,massfrac);
             for (int sp = 0; sp < NUM_SPECIES; sp++) {
@@ -480,7 +477,7 @@ namespace pele::physics::reactions {
                 amrex::Abort("Wrong reactor type. Choose between 1 (e) or 2 (h).");
             }
             T_in(i, j, k, 0) = temp;
-            FC_in(i, j, k, 0) = nsteps;
+            FC_in(i, j, k, 0) = captured_nsubsteps;
         });
 
 #ifdef MOD_REACTOR

--- a/Reactions/ReactorBDF.cpp
+++ b/Reactions/ReactorBDF.cpp
@@ -229,7 +229,6 @@ namespace pele::physics::reactions {
                 //shift to BDF2 after first step
                 int tstepscheme=(nsteps > schemechangestep)?captured_tstepscheme:first_tstepscheme;
                 
-                //amrex::Print()<<"step,time:"<<nsteps<<"\t"<<current_time<<"\n";
                 for (int ii = 0; ii < neq; ii++) 
                 {
                     dsoln0[ii] = 0.0;
@@ -237,7 +236,6 @@ namespace pele::physics::reactions {
                 //non-linear iterations for each timestep=======================
                 for(int nlit=0;nlit<captured_nonlinear_iters;nlit++)
                 {
-                    //amrex::Print()<<"non-lin iter:"<<nlit<<"\n";
                     for (int ii = 0; ii < neq; ii++) 
                     {
                         dsoln0[ii] = dsoln[ii];
@@ -264,7 +262,6 @@ namespace pele::physics::reactions {
                         norm += rhs[ii]*rhs[ii];
                     }
                     norm=std::sqrt(norm);
-                    //amrex::Print()<<"Non linear residual:"<<norm<<"\t"<<captured_nonlin_tol<<"\n";
                     if(norm <= captured_nonlin_tol)
                     {
                         break;
@@ -418,7 +415,6 @@ namespace pele::physics::reactions {
                 //shift to BDF2 after first step
                 int tstepscheme=(nsteps > schemechangestep)?captured_tstepscheme:first_tstepscheme;
 
-                //amrex::Print()<<"step,time:"<<nsteps<<"\t"<<current_time<<"\n";
                 for (int ii = 0; ii < neq; ii++) 
                 {
                     dsoln0[ii] = 0.0;
@@ -426,7 +422,6 @@ namespace pele::physics::reactions {
                 //non-linear iterations for each timestep=======================
                 for(int nlit=0;nlit<captured_nonlinear_iters;nlit++)
                 {
-                    //amrex::Print()<<"non-lin iter:"<<nlit<<"\n";
                     for (int ii = 0; ii < neq; ii++) 
                     {
                         dsoln0[ii] = dsoln[ii];
@@ -453,7 +448,6 @@ namespace pele::physics::reactions {
                         norm += rhs[ii]*rhs[ii];
                     }
                     norm=std::sqrt(norm);
-                    //amrex::Print()<<"Non linear residual:"<<norm<<"\t"<<captured_nonlin_tol<<"\n";
                     if(norm <= captured_nonlin_tol)
                     {
                         break;
@@ -468,7 +462,6 @@ namespace pele::physics::reactions {
                     soln_nm1[ii] = soln_n[ii];
                     soln_n[ii] = soln[ii];
                 }
-                //amrex::PrintToFile("tempsoln")<<current_time<<"\t"<<soln_n[NUM_SPECIES]<<"\n";
                 current_time += dt;
 
             }

--- a/Reactions/ReactorBDF.cpp
+++ b/Reactions/ReactorBDF.cpp
@@ -308,12 +308,12 @@ namespace pele::physics::reactions {
                     rho = 0.0;
                     for (int sp = 0; sp < NUM_SPECIES; sp++) 
                     {
-                        rho += soln(i, j, k, sp);
+                        rho += soln[sp];
                     }
                     rho_inv = 1.0 / rho;
                     for (int sp = 0; sp < NUM_SPECIES; sp++) 
                     {
-                        massfrac[sp] = soln(i, j, k, sp) * rho_inv;
+                        massfrac[sp] = soln[sp] * rho_inv;
                     }
                     amrex::Real rhs[(NUM_SPECIES+1)]={0.0};
                     amrex::Real Jmat1d[(NUM_SPECIES + 1) * (NUM_SPECIES + 1)] = {0.0};
@@ -340,19 +340,11 @@ namespace pele::physics::reactions {
                         rhs[ii]        = -(soln[ii]-soln_n[ii])/dt_bdf+ydot[ii];
                     }
                     
-                    amrex::Print()<<"rhs:";
-                    for (int ii = 0; ii < neq; ii++) 
-                    {
-                        amrex::Print()<<rhs[ii]<<"\t";
-                    }
-                    amrex::Print()<<"\n";
-
                     performgmres(Jmat2d,rhs,dsoln0,dsoln,captured_gmres_precond,
                                  captured_gmres_restarts,captured_gmres_tol,printflag);
 
                     for (int ii = 0; ii < neq; ii++) 
                     {
-                        amrex::Print()<<"dsoln:"<<dsoln[ii]<<"\n";
                         soln[ii] += dsoln[ii];
                     }
                 }

--- a/Reactions/ReactorBDFsolver.H
+++ b/Reactions/ReactorBDFsolver.H
@@ -1,0 +1,543 @@
+#include "AMReX_Reduce.H"
+#include "ReactorBDF.H"
+#define NEQNS NUM_SPECIES+1
+#define KSPSIZE NEQNS/2
+#define NOPC 0
+#define SGSPC 1
+#define NEARZERO 1e-15
+
+//==============================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void noprecond(amrex::Real MinvX[NEQNS],
+                                              amrex::Real A[NEQNS][NEQNS],
+                                              amrex::Real X[NEQNS],
+                                              amrex::Real dt)
+{
+    for(int i=0;i<NEQNS;i++)
+    {
+        MinvX[i]=X[i];
+    }
+}
+//==============================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void SGSprecond(amrex::Real MinvX[NEQNS],
+                                               amrex::Real A[NEQNS][NEQNS],
+                                               amrex::Real X[NEQNS],
+                                               amrex::Real dt)
+{
+    amrex::Real sum;
+    amrex::Real y_d[NEQNS],y_dd[NEQNS];
+    amrex::Real diag_inv[NEQNS];
+    amrex::Real diag[NEQNS];
+    amrex::Real dt_inv=1.0/dt;
+
+    //solve (D+L)D^-1(D+U)y = X
+    //MinvX = y
+
+    for(int i=0;i<NEQNS;i++)
+    {
+        diag[i]=dt_inv-A[i][i];
+        diag_inv[i]=1.0/diag[i];
+    }
+
+
+    //solve (D+L) y' = X
+    for(int i=0;i<NEQNS;i++)
+    {
+        sum  = 0.0;
+        for(int j=0;j<i;j++)
+        {
+            sum += -A[i][j]*y_d[j];
+        }
+        y_d[i] = (X[i]-sum)*diag_inv[i];
+    } 
+
+    //solve D^(-1)y'' = y' = (D+L)^(-1) X
+    for(int i=0;i<NEQNS;i++)
+    {
+        y_dd[i]  = diag[i] * y_d[i];
+    }
+
+    //solve (D+U) y = y'' = D (D+L)^(-1) X
+    for(int i=NEQNS-1;i>=0;i--)
+    {
+        sum=0.0;
+        for(int j=NEQNS-1;j>i;j--)
+        {
+            sum += -A[i][j]*MinvX[j];
+        }
+
+        MinvX[i] = (y_dd[i]-sum)*diag_inv[i];
+    }
+}
+//==============================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void precond(amrex::Real MinvX[NEQNS],
+                                            amrex::Real A[NEQNS][NEQNS],
+                                            amrex::Real X[NEQNS],
+                                            amrex::Real dt,int type)
+{
+    if(type==NOPC)
+    {
+        noprecond(MinvX,A,X,dt);   
+    }
+    else if(type==SGSPC)
+    {
+        SGSprecond(MinvX,A,X,dt);
+    }
+    else
+    {
+        amrex::Abort("Unknown preconditioner type in BDF");
+    }
+
+}
+//==============================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void findAX(amrex::Real AX[NEQNS],
+                                           amrex::Real A[NEQNS][NEQNS],
+                                           amrex::Real X[NEQNS],
+                                           amrex::Real dt)
+{
+    //The linear system for first order backward Euler 
+    //is of the form
+    //[I/dt - df/du] du = (un-u)/dt + f(u)
+
+    //The linear system for second order Crank Nicholson
+    //is of the form
+    //[I/dt - 0.5*df/du] du = (un-u)/dt + 0.5*f(u) + 0.5*f(un)
+
+    //time stepping contribution
+    for(int i=0;i<NEQNS;i++)
+    {
+        AX[i]=X[i]/dt;
+    }
+
+    //Jacobian contribution
+    for(int i=0;i<NEQNS;i++)
+    {
+        for(int j=0;j<NEQNS;j++)
+        {
+            AX[i] -= A[i][j]*X[j];
+        }
+    }
+
+}
+//========================================================================
+#ifndef AMREX_USE_GPU
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
+printvec(std::string str,amrex::Real v[NEQNS])
+{
+    amrex::Print()<<"\n"<<str<<"\t";
+    for(int i=0;i<NEQNS;i++)
+    {
+        amrex::Print()<<v[i]<<"\t";
+    }
+    amrex::Print()<<"\n";
+
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
+printmat(std::string str,amrex::Real mat[NEQNS][NEQNS])
+{
+    amrex::Print()<<"\n"<<str<<"\n";
+
+    for(int i=0;i<NEQNS;i++)
+    {
+        for(int j=0;j<NEQNS;j++)
+        {
+            amrex::Print()<<mat[i][j]<<"\t";
+        }
+        amrex::Print()<<"\n";
+    }
+    amrex::Print()<<"\n";
+
+}
+#endif
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void scalevector(amrex::Real v1[NEQNS],
+                                                     amrex::Real factor)
+{
+    for(int i=0;i<NEQNS;i++)
+    {
+        v1[i] = v1[i]*factor;
+    }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
+multiplyvectors(amrex::Real v1[NEQNS],
+                amrex::Real v2[NEQNS],
+                amrex::Real v12[NEQNS])
+{
+    for(int i=0;i<NEQNS;i++)
+    {
+        v12[i]=v1[i]*v2[i];
+    }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real findnorm(amrex::Real v1[NEQNS])
+{
+    amrex::Real norm=0.0;
+    for(int i=0;i<NEQNS;i++)
+    {
+        norm=norm+v1[i]*v1[i];
+    }
+
+    return(sqrt(norm));
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real 
+innerproduct(amrex::Real v1[NEQNS],amrex::Real v2[NEQNS])
+{
+    amrex::Real innerprod=0.0;
+    for(int i=0;i<NEQNS;i++)
+    {
+        innerprod=innerprod+v1[i]*v2[i];
+    }
+
+    return(innerprod);
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addvectors(amrex::Real v1[NEQNS],
+                                               amrex::Real v2[NEQNS],
+                                               amrex::Real v12[NEQNS],
+                                               amrex::Real a,amrex::Real b)
+{
+    for(int i=0;i<NEQNS;i++)
+    {
+        v12[i]=a*v1[i]+b*v2[i];
+    }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void copyvector(amrex::Real v1[NEQNS],
+                                               amrex::Real v2[NEQNS]) //(dest,source,size)
+{
+    for(int i=0;i<NEQNS;i++)
+    {
+        v1[i]=v2[i];
+    }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void getkspvector(amrex::Real v1[NEQNS],
+                        amrex::Real kspvectors[KSPSIZE+1][NEQNS],int vecnum)
+{
+    for(int i=0;i<NEQNS;i++)
+    {
+        v1[i]=kspvectors[vecnum][i];
+    }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setkspvector(amrex::Real vec[NEQNS],
+                          amrex::Real kspvectors[KSPSIZE+1][NEQNS],int vecnum)
+{
+    for(int i=0;i<NEQNS;i++)
+    {
+        kspvectors[vecnum][i]=vec[i];
+    }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool isit_NaN(amrex::Real val)
+{
+    amrex::Real valbyval;
+    amrex::Real valplus3;
+
+    valbyval=val/val;
+    valplus3=val+3.0;
+
+    if(val != val)
+    {
+        return(true);
+    }
+    else if((valbyval != valbyval) && (valplus3 == val))
+    {
+        return(true);
+    }
+    else
+    {
+        return(false);
+    }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
+                                                 amrex::Real mat[NEQNS][NEQNS],
+                                                 amrex::Real kspvectors[KSPSIZE+1][NEQNS],
+                                                 amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
+                                                 amrex::Real dt,
+                                                 int precond_type,
+                                                 int luckykspdim,
+                                                 bool &nanflag)
+{
+    int i,n;
+    amrex::Real Avj[NEQNS],vj[NEQNS],vi[NEQNS];
+    amrex::Real wj[NEQNS],tempvec[NEQNS];
+    amrex::Real MinvAvj[NEQNS];
+    luckykspdim = KSPSIZE;
+    
+
+    bool lucky; //when norm becomes 0,
+    //KSP vectors is no longer linearly independent.
+    //we would have got the best solution.
+
+    lucky   = false;
+    nanflag = false;
+
+    getkspvector(vj,kspvectors,j);
+    findAX(Avj,mat,vj,dt);
+    precond(MinvAvj,mat,Avj,dt,precond_type);
+    copyvector(Avj,MinvAvj);
+    //Avj is now M^-1 A vj
+    //remember we are solving M^-1 A X = M^-1 b
+
+    for(i=0;i<=j;i++)
+    {
+        getkspvector(vi,kspvectors,i);
+        Hessmat[i][j]=innerproduct(Avj,vi);
+    }
+
+    copyvector(wj,Avj);
+
+    for(i=0;i<=j;i++)
+    {
+        getkspvector(vi,kspvectors,i);
+        addvectors(wj,vi,tempvec,1.0,-Hessmat[i][j]);
+        copyvector(wj,tempvec);
+    }
+
+    Hessmat[j+1][j] = findnorm(wj);
+
+    if(Hessmat[j+1][j] > NEARZERO)
+    {
+        for(int i=0;i<NEQNS;i++)
+        {
+            wj[i]=wj[i]/Hessmat[j+1][j];
+        }
+        setkspvector(wj,kspvectors,j+1);
+    }
+    else
+    {
+        if( !isit_NaN(Hessmat[j+1][j]) )
+        {
+            lucky=true;
+            luckykspdim=j+1;
+        }
+        else
+        {
+            amrex::Abort("NaN or Inf detected in Hessenberg matrix\n");
+            nanflag=true;
+        }
+    }		
+
+    return(lucky);
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
+leastsqminimize(amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
+                amrex::Real y[KSPSIZE],amrex::Real beta,
+                int currentkspsize,bool lucky)
+{
+    amrex::Real c,s,h_up,h_down,dtr;
+    amrex::Real val1,val2;
+
+    //local copy
+    amrex::Real Hmat[KSPSIZE+1][KSPSIZE];
+    for(int i=0;i<KSPSIZE+1;i++)
+    {
+        for(int j=0;j<KSPSIZE;j++)
+        {
+            Hmat[i][j]=Hessmat[i][j];
+        }
+    }    
+
+    amrex::Real beta_e1[KSPSIZE+1]={0.0};
+    beta_e1[0] = beta;
+
+    //convert H into QR
+    for(int i=0;i<currentkspsize;i++)
+    {
+        h_up   = Hmat[i][i] ;
+        h_down = Hmat[i+1][i];
+
+        dtr = sqrt(h_up*h_up + h_down*h_down);
+
+        c=h_up/dtr; s=h_down/dtr;
+
+        for(int j=0;j<currentkspsize;j++)
+        {
+            h_up   = Hmat[i][j];
+            h_down = Hmat[i+1][j];
+
+            //perform rotations
+            //ith row
+            Hmat[i][j] =  c*h_up + s*h_down;
+            //(i+1)th row
+            Hmat[i+1][j] = -s*h_up + c*h_down;
+
+        }
+
+        val1 =  c*beta_e1[i] + s*beta_e1[i+1];
+        val2 = -s*beta_e1[i] + c*beta_e1[i+1];
+
+        beta_e1[i]=val1; 
+        beta_e1[i+1]=val2;
+
+    }
+
+    // ||Hm y - beta e1|| = || QR y - Q Q^T beta e1||
+    // || Q ( Ry - Q^T beta e1) || = || Ry - Q^T beta e1||
+
+    //solve least squares problem
+    y[currentkspsize-1] = beta_e1[currentkspsize-1]/
+    Hmat[currentkspsize-1][currentkspsize-1];
+
+    for(int i=currentkspsize-2;i>=0;i--)	
+    {
+        y[i] = beta_e1[i];
+
+        for(int j=i+1;j<currentkspsize;j++)
+        {
+            y[i]=y[i] - Hmat[i][j] * y[j];
+        }
+
+        y[i] = y[i]/Hmat[i][i];
+    }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE 
+bool performgmres(amrex::Real Mat1d[NEQNS*NEQNS],
+                  amrex::Real ydot[NEQNS],
+                  amrex::Real  x0[NEQNS], //initial soln for GMRES
+                  amrex::Real x[NEQNS],   //current solution
+                  amrex::Real xn[NEQNS],  //solution at time level n
+                  amrex::Real dt,
+                  int precond_type,
+                  int restart_it,
+                  amrex::Real tol,int printflag)
+{
+    int n;
+    amrex::Real beta;
+    bool arnoldistopped;
+    bool success;
+    bool nanflag;
+    int luckykspdim;
+
+    amrex::Real v1[NEQNS]={0.0};
+    amrex::Real tempvec[NEQNS]={0.0};
+    amrex::Real v[NEQNS]={0.0};
+    amrex::Real y[KSPSIZE]={0.0};
+    amrex::Real r[NEQNS]={0.0};
+    amrex::Real r0[NEQNS]={0.0};
+    amrex::Real Ax0[NEQNS]={0.0};
+    amrex::Real Ax[NEQNS]={0.0};
+    amrex::Real Minvr[NEQNS]={0.0};
+    amrex::Real b[NEQNS]={0.0};
+    amrex::Real Mat[NEQNS][NEQNS]={0.0};
+    amrex::Real kspvectors[KSPSIZE+1][NEQNS]={0.0};
+    amrex::Real Hessmat[KSPSIZE+1][KSPSIZE]={0.0};
+    amrex::Real residnorm;
+
+    success = true;
+
+    //set matrix
+    for(int i=0;i<NEQNS;i++)
+    {
+        for(int j=0;j<NEQNS;j++)
+        {
+              Mat[i][j]=Mat1d[i*NEQNS+j];
+        }
+    }
+
+    //set RHS
+    for(int i=0;i<NEQNS;i++)
+    {
+        b[i]=-((x[i]-xn[i])/dt-ydot[i]);
+    }
+
+    //finding r0
+    findAX(Ax0,Mat,x0,dt);
+    addvectors(b,Ax0,r0,1.0,-1.0);  //b-Ax0
+    precond(Minvr,Mat,r0,dt,precond_type); //Minv * r0
+    copyvector(r0,Minvr);
+
+    //initial residual is r0=M^-1(b-Ax0)
+    //we are solving M^-1 A X = M^-1 b
+    copyvector(r,r0);
+    copyvector(x,x0); 
+#ifndef AMREX_USE_GPU
+    if(printflag) amrex::Print()<<"initial norm of residual:"
+        <<findnorm(r0)<<"\n";
+#endif
+
+    for(int it=0;it<restart_it;it++)
+    {
+#ifndef AMREX_USE_GPU
+        if(printflag) amrex::Print()<<"restart iteration:"
+            <<it<<"\n";
+#endif
+
+        copyvector(x0,x);
+        beta = findnorm(r);
+
+        for(int i=0;i<n;i++)
+        {
+            v1[i]=r[i]/beta;
+        }
+
+        setkspvector(v1,kspvectors,0);
+
+        for(int kspdim=0;kspdim<KSPSIZE;kspdim++)
+        {
+            copyvector(x,x0);
+            // finds the ksp vector at kspdim+1
+            arnoldistopped = arnoldi(kspdim,Mat,kspvectors,Hessmat,dt,precond_type,luckykspdim,nanflag);
+
+            if(nanflag)
+            {
+                success=!nanflag;
+                amrex::Abort("nan detected in arnoldi iteration\n");
+                break;
+            }
+
+            leastsqminimize(Hessmat,y,beta,kspdim+1,arnoldistopped);
+
+            for(int i=0;i<(kspdim+1);i++)
+            {
+                getkspvector(v,kspvectors,i);
+                addvectors(x,v,tempvec,1.0,y[i]);
+                copyvector(x,tempvec);
+            }
+
+            //finding new residual
+            findAX(Ax,Mat,x,dt);
+            addvectors(b,Ax,r,1.0,-1.0);
+            precond(Minvr,Mat,r,dt,precond_type); //Minv * r0
+            copyvector(r,Minvr);
+
+            residnorm = findnorm(r);
+#ifndef AMREX_USE_GPU
+            if(printflag) amrex::Print()<<"norm of residual:"
+                <<residnorm<<"\t"<<tol<<"\t"<<kspdim<<"\n";
+#endif
+
+            if(arnoldistopped) 
+            {
+#ifndef AMREX_USE_GPU
+                if(printflag) amrex::Print()<<"lucky condition:"
+                    <<luckykspdim<<"\n";
+#endif
+                break;
+            }
+
+            if(residnorm <= tol)
+            {
+                break;
+            }
+
+        }
+
+        if( (residnorm <= tol) || (!success) || (arnoldistopped) )
+        {
+            break;
+        }
+
+
+        //amrex::Print()<<"******************\n";
+    }
+
+    return(success);
+}
+//========================================================================

--- a/Reactions/ReactorBDFsolver.H
+++ b/Reactions/ReactorBDFsolver.H
@@ -341,9 +341,6 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
     {
         if( !isit_NaN(Hessmat[j+1][j]) )
         {
-#ifndef AMREX_USE_GPU
-            //amrex::Print()<<"lucky\n";
-#endif
             lucky=true;
         }
         else
@@ -431,6 +428,7 @@ bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
                   amrex::Real x[NEQNS],   //current solution for GMRES
                   int precond_type,
                   int restart_it,
+                  int kspiters,
                   amrex::Real tol,int printflag)
 {
     amrex::Real beta;
@@ -490,7 +488,7 @@ bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
         setkspvector(v1,kspvectors,0);
         
         int optkspsize=KSPSIZE;
-        for(int kspdim=0;kspdim<KSPSIZE;kspdim++)
+        for(int kspdim=0;kspdim<kspiters;kspdim++)
         {
             copyvector(x,x0);
             // finds the ksp vector at kspdim+1

--- a/Reactions/ReactorBDFsolver.H
+++ b/Reactions/ReactorBDFsolver.H
@@ -66,7 +66,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void SGSprecond(amrex::Real MinvX[NEQNS],
         sum  = 0.0;
         for(int j=0;j<i;j++)
         {
-            sum += -A[i][j]*y_d[j];
+            sum += A[i][j]*y_d[j];
         }
         y_d[i] = (X[i]-sum)*diag_inv[i];
     } 
@@ -83,7 +83,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void SGSprecond(amrex::Real MinvX[NEQNS],
         sum=0.0;
         for(int j=NEQNS-1;j>i;j--)
         {
-            sum += -A[i][j]*MinvX[j];
+            sum += A[i][j]*MinvX[j];
         }
 
         MinvX[i] = (y_dd[i]-sum)*diag_inv[i];
@@ -167,6 +167,40 @@ printmat(std::string str,amrex::Real mat[NEQNS][NEQNS])
         for(int j=0;j<NEQNS;j++)
         {
             amrex::Print()<<mat[i][j]<<"  ";
+        }
+        amrex::Print()<<"\n";
+    }
+    amrex::Print()<<"\n";
+
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
+print_hessmat(std::string str,amrex::Real hmat[KSPSIZE+1][KSPSIZE])
+{
+    amrex::Print()<<"\n"<<str<<"\n";
+
+    for(int i=0;i<KSPSIZE+1;i++)
+    {
+        for(int j=0;j<KSPSIZE;j++)
+        {
+            amrex::Print()<<hmat[i][j]<<"  ";
+        }
+        amrex::Print()<<"\n";
+    }
+    amrex::Print()<<"\n";
+
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
+print_arnoldivecs(std::string str,amrex::Real arnoldivecs[KSPSIZE+1][NEQNS])
+{
+    amrex::Print()<<"\n"<<str<<"\n";
+
+    for(int i=0;i<(KSPSIZE+1);i++)
+    {
+        for(int j=0;j<NEQNS;j++)
+        {
+            amrex::Print()<<arnoldivecs[i][j]<<"  ";
         }
         amrex::Print()<<"\n";
     }
@@ -302,11 +336,8 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
     nanflag = false;
 
     getkspvector(vj,kspvectors,j);
-    //printvec("vj:",vj);
     findAX(Avj,mat,vj,dt);
-    //printvec("Avj:",Avj);
     precond(MinvAvj,mat,Avj,dt,precond_type);
-    //printvec("MinvAvj:",MinvAvj);
     copyvector(Avj,MinvAvj);
     //Avj is now M^-1 A vj
     //remember we are solving M^-1 A X = M^-1 b
@@ -353,85 +384,82 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
     return(lucky);
 }
 //========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
-leastsqminimize(amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
-                amrex::Real y[KSPSIZE],amrex::Real beta,
-                int currentkspsize,bool lucky)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+givens_rotate(amrex::Real r,amrex::Real s,amrex::Real &cos,
+              amrex::Real &sin)
 {
-    amrex::Real c,s,h_up,h_down,dtr;
-    amrex::Real val1,val2;
-
-    //local copy
-    amrex::Real Hmat[KSPSIZE+1][KSPSIZE];
-    for(int i=0;i<(KSPSIZE+1);i++)
+    if(r==0)
     {
-        for(int j=0;j<KSPSIZE;j++)
-        {
-            Hmat[i][j]=Hessmat[i][j];
-        }
-    }    
-
-    amrex::Real beta_e1[KSPSIZE+1]={0.0};
-    beta_e1[0] = beta;
-
-    //convert H into QR
-    for(int i=0;i<currentkspsize;i++)
-    {
-        h_up   = Hmat[i][i] ;
-        h_down = Hmat[i+1][i];
-
-        dtr = sqrt(h_up*h_up + h_down*h_down);
-
-        c=h_up/dtr; s=h_down/dtr;
-
-        for(int j=0;j<currentkspsize;j++)
-        {
-            h_up   = Hmat[i][j];
-            h_down = Hmat[i+1][j];
-
-            //perform rotations
-            //ith row
-            Hmat[i][j] =  c*h_up + s*h_down;
-            //(i+1)th row
-            Hmat[i+1][j] = -s*h_up + c*h_down;
-
-        }
-
-        val1 =  c*beta_e1[i] + s*beta_e1[i+1];
-        val2 = -s*beta_e1[i] + c*beta_e1[i+1];
-
-        beta_e1[i]=val1; 
-        beta_e1[i+1]=val2;
-
+        cos=0.0;
+        sin=1.0;
     }
+    else
+    {
+        cos=r/std::sqrt(r*r+s*s);
+        sin=s/std::sqrt(r*r+s*s);
+    }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real 
+triangularize(amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
+              amrex::Real cos_arr[KSPSIZE],
+              amrex::Real sin_arr[KSPSIZE],
+              amrex::Real beta_e1[KSPSIZE+1],
+                int k)
+{
 
-    // ||Hm y - beta e1|| = || QR y - Q Q^T beta e1||
-    // || Q ( Ry - Q^T beta e1) || = || Ry - Q^T beta e1||
+  amrex::Real temp,cos,sin;
 
-    //solve least squares problem
-    y[currentkspsize-1] = beta_e1[currentkspsize-1]/
-    Hmat[currentkspsize-1][currentkspsize-1];
+  //apply for ith column
+  for(int i=0;i<=(k-1); i++)
+  {
+    temp   =  cos_arr[i] * Hessmat[i][k] + sin_arr[i] * Hessmat[i+1][k];
+    Hessmat[i+1][k] = -sin_arr[i] * Hessmat[i][k] + cos_arr[i] * Hessmat[i + 1][k];
+    Hessmat[i][k]   = temp;
+  }
 
-    for(int i=currentkspsize-2;i>=0;i--)	
+  //update the next sin cos values for rotation
+  givens_rotate(Hessmat[k][k], Hessmat[k+1][k], cos, sin);
+
+  //eliminate H(i + 1, i)
+  Hessmat[k][k] = cos * Hessmat[k][k] + sin * Hessmat[k+1][k];
+  Hessmat[k+1][k] = 0.0;
+
+  cos_arr[k]=cos;
+  sin_arr[k]=sin;
+
+  beta_e1[k+1] = -sin*beta_e1[k];
+  beta_e1[k]   =  cos*beta_e1[k];
+
+  amrex::Real error=amrex::Math::abs(beta_e1[k+1]);
+
+  return(error);
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
+uppertrisolve(amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
+         amrex::Real y[KSPSIZE+1],amrex::Real beta_e1[KSPSIZE+1],
+         int k)
+{
+    for(int i=k;i>=0;i--)	
     {
         y[i] = beta_e1[i];
-
-        for(int j=i+1;j<currentkspsize;j++)
+        for(int j=i+1;j<=k;j++)
         {
-            y[i]=y[i] - Hmat[i][j] * y[j];
+            y[i]=y[i] - Hessmat[i][j] * y[j];
         }
 
-        y[i] = y[i]/Hmat[i][i];
+        y[i] = y[i]/Hessmat[i][i];
     }
 }
 //========================================================================
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE 
-bool performgmres(amrex::Real Mat1d[NEQNS2],
+bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
                   amrex::Real ydot[NEQNS],
                   amrex::Real  x0[NEQNS], //initial soln for GMRES
                   amrex::Real x[NEQNS],   //current solution
                   amrex::Real dsoln_n[NEQNS],   //for explicit term
-                  amrex::Real dt_dim,
+                  amrex::Real dt,
                   int precond_type,
                   int restart_it,
                   amrex::Real tol,int printflag)
@@ -442,46 +470,31 @@ bool performgmres(amrex::Real Mat1d[NEQNS2],
     bool nanflag;
     int luckykspdim;
 
-    amrex::Print()<<"kspsize:"<<KSPSIZE<<"\n";
-
     amrex::Real v1[NEQNS]={0.0};
     amrex::Real tempvec[NEQNS]={0.0};
     amrex::Real v[NEQNS]={0.0};
-    amrex::Real y[KSPSIZE]={0.0};
+    amrex::Real y[KSPSIZE+1]={0.0};
     amrex::Real r[NEQNS]={0.0};
     amrex::Real r0[NEQNS]={0.0};
     amrex::Real Ax0[NEQNS]={0.0};
     amrex::Real Ax[NEQNS]={0.0};
     amrex::Real Minvr[NEQNS]={0.0};
     amrex::Real b[NEQNS]={0.0};
-    amrex::Real Mat[NEQNS][NEQNS]={0.0};
     amrex::Real kspvectors[KSPSIZE+1][NEQNS]={0.0};
     amrex::Real Hessmat[KSPSIZE+1][KSPSIZE]={0.0};
+    amrex::Real cos_arr[KSPSIZE]={0.0};
+    amrex::Real sin_arr[KSPSIZE]={0.0};
+    amrex::Real beta_e1[KSPSIZE+1]={0.0};
     amrex::Real residnorm,bnorm;
 
     success = true;
 
-
     //set RHS
     for(int i=0;i<NEQNS;i++)
     {
-        b[i]=-(dsoln_n[i]/dt_dim-ydot[i]);
+        b[i]=-(dsoln_n[i]/dt-ydot[i]);
     }
-    bnorm=findnorm(b);
-    //bnorm=1.0;
-    amrex::Real dt=dt_dim*bnorm;
     
-    //set matrix
-    for(int i=0;i<NEQNS;i++)
-    {
-        for(int j=0;j<NEQNS;j++)
-        {
-              Mat[i][j]=Mat1d[i*NEQNS+j]/bnorm;
-        }
-        b[i]=b[i]/bnorm;
-    }
-
-    printmat("Jacobian",Mat);
     //finding r0
     findAX(Ax0,Mat,x0,dt);
     addvectors(b,Ax0,r0,1.0,-1.0);  //b-Ax0
@@ -491,8 +504,6 @@ bool performgmres(amrex::Real Mat1d[NEQNS2],
     //initial residual is r0=M^-1(b-Ax0)
     //we are solving M^-1 A X = M^-1 b
     copyvector(r,r0);
-    printvec("r0",r0);
-    printvec("r",r);
     copyvector(x,x0); 
 #ifndef AMREX_USE_GPU
     if(printflag) amrex::Print()<<"initial norm of residual:"
@@ -513,15 +524,20 @@ bool performgmres(amrex::Real Mat1d[NEQNS2],
         {
             v1[i]=r[i]/beta;
         }
+        beta_e1[0]=beta;
 
         setkspvector(v1,kspvectors,0);
-
-        for(int kspdim=0;kspdim<KSPSIZE;kspdim++)
+        
+        int kspdim;
+        for(kspdim=0;kspdim<KSPSIZE;kspdim++)
         {
             copyvector(x,x0);
             // finds the ksp vector at kspdim+1
             arnoldistopped = arnoldi(kspdim,Mat,kspvectors,Hessmat,
                                      dt,precond_type,luckykspdim,nanflag);
+
+            residnorm=triangularize(Hessmat,cos_arr,sin_arr,beta_e1,
+                                    kspdim);
 
             if(nanflag)
             {
@@ -530,22 +546,7 @@ bool performgmres(amrex::Real Mat1d[NEQNS2],
                 break;
             }
 
-            leastsqminimize(Hessmat,y,beta,kspdim+1,arnoldistopped);
 
-            for(int i=0;i<(kspdim+1);i++)
-            {
-                getkspvector(v,kspvectors,i);
-                addvectors(x,v,tempvec,1.0,y[i]);
-                copyvector(x,tempvec);
-            }
-
-            //finding new residual
-            findAX(Ax,Mat,x,dt);
-            addvectors(b,Ax,r,1.0,-1.0);
-            precond(Minvr,Mat,r,dt,precond_type); //Minv * r0
-            copyvector(r,Minvr);
-
-            residnorm = findnorm(r);
 #ifndef AMREX_USE_GPU
             if(printflag) amrex::Print()<<"norm of residual:"
                 <<residnorm<<"\t"<<tol<<"\t"<<kspdim<<"\n";
@@ -564,17 +565,22 @@ bool performgmres(amrex::Real Mat1d[NEQNS2],
             {
                 break;
             }
+        }
 
+        uppertrisolve(Hessmat,y,beta_e1,kspdim);
+        for(int i=0;i<=kspdim;i++)
+        {
+            getkspvector(v,kspvectors,i);
+            addvectors(x,v,tempvec,1.0,y[i]);
+            copyvector(x,tempvec);
         }
 
         if( (residnorm <= tol) || (!success) || (arnoldistopped) )
         {
             break;
         }
-
-
-        //amrex::Print()<<"******************\n";
     }
+
 
     return(success);
 }

--- a/Reactions/ReactorBDFsolver.H
+++ b/Reactions/ReactorBDFsolver.H
@@ -2,7 +2,7 @@
 #include <ReactorBDF.H>
 #define NEQNS (NUM_SPECIES+1)
 #define NEQNS2 NEQNS*NEQNS
-#define KSPSIZE NEQNS
+#define KSPSIZE 5
 #define NOPC 0
 #define GJPC 1
 #define SGSPC 2
@@ -11,8 +11,7 @@
 //==============================================================
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void noprecond(amrex::Real MinvX[NEQNS],
                                               amrex::Real A[NEQNS][NEQNS],
-                                              amrex::Real X[NEQNS],
-                                              amrex::Real dt)
+                                              amrex::Real X[NEQNS])
 {
     for(int i=0;i<NEQNS;i++)
     {
@@ -22,40 +21,30 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void noprecond(amrex::Real MinvX[NEQNS],
 //==============================================================
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void GJprecond(amrex::Real MinvX[NEQNS],
                                                amrex::Real A[NEQNS][NEQNS],
-                                               amrex::Real X[NEQNS],
-                                               amrex::Real dt)
+                                               amrex::Real X[NEQNS])
 {
-    amrex::Real sum,diag;
-    amrex::Real y_d[NEQNS],y_dd[NEQNS];
-    amrex::Real dt_inv=1.0/dt;
-
     //solve Dy = X
-    //MinvX = y
-
     for(int i=0;i<NEQNS;i++)
     {
-        diag=dt_inv-A[i][i];
-        MinvX[i]=X[i]/diag;
+        MinvX[i]=X[i]/A[i][i];
     }
 }
 //==============================================================
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void SGSprecond(amrex::Real MinvX[NEQNS],
                                                amrex::Real A[NEQNS][NEQNS],
-                                               amrex::Real X[NEQNS],
-                                               amrex::Real dt)
+                                               amrex::Real X[NEQNS])
 {
     amrex::Real sum;
     amrex::Real y_d[NEQNS],y_dd[NEQNS];
     amrex::Real diag_inv[NEQNS];
     amrex::Real diag[NEQNS];
-    amrex::Real dt_inv=1.0/dt;
 
     //solve (D+L)D^-1(D+U)y = X
     //MinvX = y
 
     for(int i=0;i<NEQNS;i++)
     {
-        diag[i]=dt_inv-A[i][i];
+        diag[i]=A[i][i];
         diag_inv[i]=1.0/diag[i];
     }
 
@@ -92,20 +81,19 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void SGSprecond(amrex::Real MinvX[NEQNS],
 //==============================================================
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void precond(amrex::Real MinvX[NEQNS],
                                             amrex::Real A[NEQNS][NEQNS],
-                                            amrex::Real X[NEQNS],
-                                            amrex::Real dt,int type)
+                                            amrex::Real X[NEQNS],int type)
 {
     if(type==NOPC)
     {
-        noprecond(MinvX,A,X,dt);   
+        noprecond(MinvX,A,X);   
     }
     else if(type==GJPC)
     {
-        GJprecond(MinvX,A,X,dt);
+        GJprecond(MinvX,A,X);
     }
     else if(type==SGSPC)
     {
-        SGSprecond(MinvX,A,X,dt);
+        SGSprecond(MinvX,A,X);
     }
     else
     {
@@ -116,32 +104,16 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void precond(amrex::Real MinvX[NEQNS],
 //==============================================================
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void findAX(amrex::Real AX[NEQNS],
                                            amrex::Real A[NEQNS][NEQNS],
-                                           amrex::Real X[NEQNS],
-                                           amrex::Real dt)
+                                           amrex::Real X[NEQNS])
 {
-    //The linear system for first order backward Euler 
-    //is of the form
-    //[I/dt - df/du] du = (un-u)/dt + f(u)
-
-    //The linear system for second order Crank Nicholson
-    //is of the form
-    //[I/dt - 0.5*df/du] du = (un-u)/dt + 0.5*f(u) + 0.5*f(un)
-
-    //time stepping contribution
     for(int i=0;i<NEQNS;i++)
     {
-        AX[i]=X[i]/dt;
-    }
-
-    //Jacobian contribution
-    for(int i=0;i<NEQNS;i++)
-    {
+        AX[i]=0.0;
         for(int j=0;j<NEQNS;j++)
         {
-            AX[i] -= A[i][j]*X[j];
+            AX[i] += A[i][j]*X[j];
         }
     }
-
 }
 //========================================================================
 #ifndef AMREX_USE_GPU
@@ -316,7 +288,6 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
                                                  amrex::Real mat[NEQNS][NEQNS],
                                                  amrex::Real kspvectors[KSPSIZE+1][NEQNS],
                                                  amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
-                                                 amrex::Real dt,
                                                  int precond_type,
                                                  int luckykspdim,
                                                  bool &nanflag)
@@ -336,8 +307,8 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
     nanflag = false;
 
     getkspvector(vj,kspvectors,j);
-    findAX(Avj,mat,vj,dt);
-    precond(MinvAvj,mat,Avj,dt,precond_type);
+    findAX(Avj,mat,vj);
+    precond(MinvAvj,mat,Avj,precond_type);
     copyvector(Avj,MinvAvj);
     //Avj is now M^-1 A vj
     //remember we are solving M^-1 A X = M^-1 b
@@ -371,6 +342,9 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
     {
         if( !isit_NaN(Hessmat[j+1][j]) )
         {
+#ifndef AMREX_USE_GPU
+            amrex::Print()<<"lucky\n";
+#endif
             lucky=true;
             luckykspdim=j+1;
         }
@@ -455,11 +429,9 @@ uppertrisolve(amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
 //========================================================================
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE 
 bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
-                  amrex::Real ydot[NEQNS],
+                  amrex::Real b[NEQNS],
                   amrex::Real  x0[NEQNS], //initial soln for GMRES
-                  amrex::Real x[NEQNS],   //current solution
-                  amrex::Real dsoln_n[NEQNS],   //for explicit term
-                  amrex::Real dt,
+                  amrex::Real x[NEQNS],   //current solution for GMRES
                   int precond_type,
                   int restart_it,
                   amrex::Real tol,int printflag)
@@ -479,26 +451,19 @@ bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
     amrex::Real Ax0[NEQNS]={0.0};
     amrex::Real Ax[NEQNS]={0.0};
     amrex::Real Minvr[NEQNS]={0.0};
-    amrex::Real b[NEQNS]={0.0};
     amrex::Real kspvectors[KSPSIZE+1][NEQNS]={0.0};
     amrex::Real Hessmat[KSPSIZE+1][KSPSIZE]={0.0};
     amrex::Real cos_arr[KSPSIZE]={0.0};
     amrex::Real sin_arr[KSPSIZE]={0.0};
     amrex::Real beta_e1[KSPSIZE+1]={0.0};
     amrex::Real residnorm,bnorm;
-
+    
     success = true;
 
-    //set RHS
-    for(int i=0;i<NEQNS;i++)
-    {
-        b[i]=-(dsoln_n[i]/dt-ydot[i]);
-    }
-    
     //finding r0
-    findAX(Ax0,Mat,x0,dt);
+    findAX(Ax0,Mat,x0);
     addvectors(b,Ax0,r0,1.0,-1.0);  //b-Ax0
-    precond(Minvr,Mat,r0,dt,precond_type); //Minv * r0
+    precond(Minvr,Mat,r0,precond_type); //Minv * r0
     copyvector(r0,Minvr);
 
     //initial residual is r0=M^-1(b-Ax0)
@@ -534,7 +499,7 @@ bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
             copyvector(x,x0);
             // finds the ksp vector at kspdim+1
             arnoldistopped = arnoldi(kspdim,Mat,kspvectors,Hessmat,
-                                     dt,precond_type,luckykspdim,nanflag);
+                                     precond_type,luckykspdim,nanflag);
 
             residnorm=triangularize(Hessmat,cos_arr,sin_arr,beta_e1,
                                     kspdim);

--- a/Reactions/ReactorBDFsolver.H
+++ b/Reactions/ReactorBDFsolver.H
@@ -1,7 +1,7 @@
 #include "AMReX_Reduce.H"
 #include <ReactorBDF.H>
-#define NEQNS (NUM_SPECIES+1)
-#define NEQNS2 NEQNS*NEQNS
+#define NEQNS (NUM_SPECIES + 1)
+#define NEQNS2 NEQNS* NEQNS
 #define KSPSIZE NEQNS
 #define NOPC 0
 #define GJPC 1
@@ -9,540 +9,490 @@
 #define NEARZERO 1e-15
 
 //==============================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void noprecond(amrex::Real MinvX[NEQNS],
-                                              amrex::Real A[NEQNS][NEQNS],
-                                              amrex::Real X[NEQNS])
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+noprecond(
+  amrex::Real MinvX[NEQNS], amrex::Real A[NEQNS][NEQNS], amrex::Real X[NEQNS])
 {
-    for(int i=0;i<NEQNS;i++)
-    {
-        MinvX[i]=X[i];
-    }
+  for (int i = 0; i < NEQNS; i++) {
+    MinvX[i] = X[i];
+  }
 }
 //==============================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void GJprecond(amrex::Real MinvX[NEQNS],
-                                               amrex::Real A[NEQNS][NEQNS],
-                                               amrex::Real X[NEQNS])
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+GJprecond(
+  amrex::Real MinvX[NEQNS], amrex::Real A[NEQNS][NEQNS], amrex::Real X[NEQNS])
 {
-    //solve Dy = X
-    for(int i=0;i<NEQNS;i++)
-    {
-        MinvX[i]=X[i]/A[i][i];
-    }
+  // solve Dy = X
+  for (int i = 0; i < NEQNS; i++) {
+    MinvX[i] = X[i] / A[i][i];
+  }
 }
 //==============================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void SGSprecond(amrex::Real MinvX[NEQNS],
-                                               amrex::Real A[NEQNS][NEQNS],
-                                               amrex::Real X[NEQNS])
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+SGSprecond(
+  amrex::Real MinvX[NEQNS], amrex::Real A[NEQNS][NEQNS], amrex::Real X[NEQNS])
 {
-    amrex::Real sum;
-    amrex::Real y_d[NEQNS],y_dd[NEQNS];
-    amrex::Real diag_inv[NEQNS];
-    amrex::Real diag[NEQNS];
+  amrex::Real sum;
+  amrex::Real y_d[NEQNS], y_dd[NEQNS];
+  amrex::Real diag_inv[NEQNS];
+  amrex::Real diag[NEQNS];
 
-    //solve (D+L)D^-1(D+U)y = X
-    //MinvX = y
+  // solve (D+L)D^-1(D+U)y = X
+  // MinvX = y
 
-    for(int i=0;i<NEQNS;i++)
-    {
-        diag[i]=A[i][i];
-        diag_inv[i]=1.0/diag[i];
+  for (int i = 0; i < NEQNS; i++) {
+    diag[i] = A[i][i];
+    diag_inv[i] = 1.0 / diag[i];
+  }
+
+  // solve (D+L) y' = X
+  for (int i = 0; i < NEQNS; i++) {
+    sum = 0.0;
+    for (int j = 0; j < i; j++) {
+      sum += A[i][j] * y_d[j];
+    }
+    y_d[i] = (X[i] - sum) * diag_inv[i];
+  }
+
+  // solve D^(-1)y'' = y' = (D+L)^(-1) X
+  for (int i = 0; i < NEQNS; i++) {
+    y_dd[i] = diag[i] * y_d[i];
+  }
+
+  // solve (D+U) y = y'' = D (D+L)^(-1) X
+  for (int i = NEQNS - 1; i >= 0; i--) {
+    sum = 0.0;
+    for (int j = NEQNS - 1; j > i; j--) {
+      sum += A[i][j] * MinvX[j];
     }
 
-
-    //solve (D+L) y' = X
-    for(int i=0;i<NEQNS;i++)
-    {
-        sum  = 0.0;
-        for(int j=0;j<i;j++)
-        {
-            sum += A[i][j]*y_d[j];
-        }
-        y_d[i] = (X[i]-sum)*diag_inv[i];
-    } 
-
-    //solve D^(-1)y'' = y' = (D+L)^(-1) X
-    for(int i=0;i<NEQNS;i++)
-    {
-        y_dd[i]  = diag[i] * y_d[i];
-    }
-
-    //solve (D+U) y = y'' = D (D+L)^(-1) X
-    for(int i=NEQNS-1;i>=0;i--)
-    {
-        sum=0.0;
-        for(int j=NEQNS-1;j>i;j--)
-        {
-            sum += A[i][j]*MinvX[j];
-        }
-
-        MinvX[i] = (y_dd[i]-sum)*diag_inv[i];
-    }
+    MinvX[i] = (y_dd[i] - sum) * diag_inv[i];
+  }
 }
 //==============================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void precond(amrex::Real MinvX[NEQNS],
-                                            amrex::Real A[NEQNS][NEQNS],
-                                            amrex::Real X[NEQNS],int type)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+precond(
+  amrex::Real MinvX[NEQNS],
+  amrex::Real A[NEQNS][NEQNS],
+  amrex::Real X[NEQNS],
+  int type)
 {
-    if(type==NOPC)
-    {
-        noprecond(MinvX,A,X);   
-    }
-    else if(type==GJPC)
-    {
-        GJprecond(MinvX,A,X);
-    }
-    else if(type==SGSPC)
-    {
-        SGSprecond(MinvX,A,X);
-    }
-    else
-    {
-        amrex::Abort("Unknown preconditioner type in BDF");
-    }
-
+  if (type == NOPC) {
+    noprecond(MinvX, A, X);
+  } else if (type == GJPC) {
+    GJprecond(MinvX, A, X);
+  } else if (type == SGSPC) {
+    SGSprecond(MinvX, A, X);
+  } else {
+    amrex::Abort("Unknown preconditioner type in BDF");
+  }
 }
 //==============================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void findAX(amrex::Real AX[NEQNS],
-                                           amrex::Real A[NEQNS][NEQNS],
-                                           amrex::Real X[NEQNS])
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+findAX(amrex::Real AX[NEQNS], amrex::Real A[NEQNS][NEQNS], amrex::Real X[NEQNS])
 {
-    for(int i=0;i<NEQNS;i++)
-    {
-        AX[i]=0.0;
-        for(int j=0;j<NEQNS;j++)
-        {
-            AX[i] += A[i][j]*X[j];
-        }
+  for (int i = 0; i < NEQNS; i++) {
+    AX[i] = 0.0;
+    for (int j = 0; j < NEQNS; j++) {
+      AX[i] += A[i][j] * X[j];
     }
+  }
 }
 //========================================================================
 #ifndef AMREX_USE_GPU
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
-printvec(std::string str,amrex::Real v[NEQNS])
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+printvec(std::string str, amrex::Real v[NEQNS])
 {
-    amrex::Print()<<"\n"<<str<<"\t";
-    for(int i=0;i<NEQNS;i++)
-    {
-        amrex::Print()<<v[i]<<"\t";
-    }
-    amrex::Print()<<"\n";
-
-}
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
-printmat(std::string str,amrex::Real mat[NEQNS][NEQNS])
-{
-    amrex::Print()<<"\n"<<str<<"\n";
-
-    for(int i=0;i<NEQNS;i++)
-    {
-        for(int j=0;j<NEQNS;j++)
-        {
-            amrex::Print()<<mat[i][j]<<"  ";
-        }
-        amrex::Print()<<"\n";
-    }
-    amrex::Print()<<"\n";
-
-}
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
-print_hessmat(std::string str,amrex::Real hmat[KSPSIZE+1][KSPSIZE])
-{
-    amrex::Print()<<"\n"<<str<<"\n";
-
-    for(int i=0;i<KSPSIZE+1;i++)
-    {
-        for(int j=0;j<KSPSIZE;j++)
-        {
-            amrex::Print()<<hmat[i][j]<<"  ";
-        }
-        amrex::Print()<<"\n";
-    }
-    amrex::Print()<<"\n";
-
-}
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
-print_arnoldivecs(std::string str,amrex::Real arnoldivecs[KSPSIZE+1][NEQNS])
-{
-    amrex::Print()<<"\n"<<str<<"\n";
-
-    for(int i=0;i<(KSPSIZE+1);i++)
-    {
-        for(int j=0;j<NEQNS;j++)
-        {
-            amrex::Print()<<arnoldivecs[i][j]<<"  ";
-        }
-        amrex::Print()<<"\n";
-    }
-    amrex::Print()<<"\n";
-
-}
-#endif
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void scalevector(amrex::Real v1[NEQNS],
-                                                     amrex::Real factor)
-{
-    for(int i=0;i<NEQNS;i++)
-    {
-        v1[i] = v1[i]*factor;
-    }
-}
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
-multiplyvectors(amrex::Real v1[NEQNS],
-                amrex::Real v2[NEQNS],
-                amrex::Real v12[NEQNS])
-{
-    for(int i=0;i<NEQNS;i++)
-    {
-        v12[i]=v1[i]*v2[i];
-    }
-}
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real findnorm(amrex::Real v1[NEQNS])
-{
-    amrex::Real norm=0.0;
-    for(int i=0;i<NEQNS;i++)
-    {
-        norm=norm+v1[i]*v1[i];
-    }
-
-    return(sqrt(norm));
-}
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real 
-innerproduct(amrex::Real v1[NEQNS],amrex::Real v2[NEQNS])
-{
-    amrex::Real innerprod=0.0;
-    for(int i=0;i<NEQNS;i++)
-    {
-        innerprod=innerprod+v1[i]*v2[i];
-    }
-
-    return(innerprod);
-}
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addvectors(amrex::Real v1[NEQNS],
-                                               amrex::Real v2[NEQNS],
-                                               amrex::Real v12[NEQNS],
-                                               amrex::Real a,amrex::Real b)
-{
-    for(int i=0;i<NEQNS;i++)
-    {
-        v12[i]=a*v1[i]+b*v2[i];
-    }
-}
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void copyvector(amrex::Real v1[NEQNS],
-                                               amrex::Real v2[NEQNS]) //(dest,source,size)
-{
-    for(int i=0;i<NEQNS;i++)
-    {
-        v1[i]=v2[i];
-    }
-}
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void getkspvector(amrex::Real v1[NEQNS],
-                        amrex::Real kspvectors[KSPSIZE+1][NEQNS],int vecnum)
-{
-    for(int i=0;i<NEQNS;i++)
-    {
-        v1[i]=kspvectors[vecnum][i];
-    }
-}
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setkspvector(amrex::Real vec[NEQNS],
-                          amrex::Real kspvectors[KSPSIZE+1][NEQNS],int vecnum)
-{
-    for(int i=0;i<NEQNS;i++)
-    {
-        kspvectors[vecnum][i]=vec[i];
-    }
-}
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool isit_NaN(amrex::Real val)
-{
-    amrex::Real valbyval;
-    amrex::Real valplus3;
-
-    valbyval=val/val;
-    valplus3=val+3.0;
-
-    if(val != val)
-    {
-        return(true);
-    }
-    else if((valbyval != valbyval) && (valplus3 == val))
-    {
-        return(true);
-    }
-    else
-    {
-        return(false);
-    }
-}
-//========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
-                                                 amrex::Real mat[NEQNS][NEQNS],
-                                                 amrex::Real kspvectors[KSPSIZE+1][NEQNS],
-                                                 amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
-                                                 int precond_type,
-                                                 amrex::Real tol,
-                                                 bool &nanflag)
-{
-    int i;
-    amrex::Real Avj[NEQNS],vj[NEQNS],vi[NEQNS];
-    amrex::Real wj[NEQNS],tempvec[NEQNS];
-    amrex::Real MinvAvj[NEQNS];
-    
-
-    bool lucky; //when norm becomes 0,
-    //KSP vectors is no longer linearly independent.
-    //we would have gotten the best solution.
-
-    lucky   = false;
-    nanflag = false;
-
-    getkspvector(vj,kspvectors,j);
-    findAX(Avj,mat,vj);
-    precond(MinvAvj,mat,Avj,precond_type);
-    copyvector(Avj,MinvAvj);
-    //Avj is now M^-1 A vj
-    //remember we are solving M^-1 A X = M^-1 b
-
-    for(i=0;i<=j;i++)
-    {
-        getkspvector(vi,kspvectors,i);
-        Hessmat[i][j]=innerproduct(Avj,vi);
-    }
-
-    copyvector(wj,Avj);
-
-    for(i=0;i<=j;i++)
-    {
-        getkspvector(vi,kspvectors,i);
-        addvectors(wj,vi,tempvec,1.0,-Hessmat[i][j]);
-        copyvector(wj,tempvec);
-    }
-
-    Hessmat[j+1][j] = findnorm(wj);
-
-    if(Hessmat[j+1][j] > tol)
-    {
-        for(i=0;i<NEQNS;i++)
-        {
-            wj[i]=wj[i]/Hessmat[j+1][j];
-        }
-        setkspvector(wj,kspvectors,j+1);
-    }
-    else
-    {
-        if( !isit_NaN(Hessmat[j+1][j]) )
-        {
-            lucky=true;
-        }
-        else
-        {
-            amrex::Abort("NaN or Inf detected in Hessenberg matrix\n");
-            nanflag=true;
-        }
-    }		
-
-    return(lucky);
+  amrex::Print() << "\n" << str << "\t";
+  for (int i = 0; i < NEQNS; i++) {
+    amrex::Print() << v[i] << "\t";
+  }
+  amrex::Print() << "\n";
 }
 //========================================================================
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
-givens_rotate(amrex::Real r,amrex::Real s,amrex::Real &cos,
-              amrex::Real &sin)
+printmat(std::string str, amrex::Real mat[NEQNS][NEQNS])
 {
-    if(r==0)
-    {
-        cos=0.0;
-        sin=1.0;
+  amrex::Print() << "\n" << str << "\n";
+
+  for (int i = 0; i < NEQNS; i++) {
+    for (int j = 0; j < NEQNS; j++) {
+      amrex::Print() << mat[i][j] << "  ";
     }
-    else
-    {
-        cos=r/std::sqrt(r*r+s*s);
-        sin=s/std::sqrt(r*r+s*s);
-    }
+    amrex::Print() << "\n";
+  }
+  amrex::Print() << "\n";
 }
 //========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real 
-triangularize(amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
-              amrex::Real cos_arr[KSPSIZE],
-              amrex::Real sin_arr[KSPSIZE],
-              amrex::Real beta_e1[KSPSIZE+1],
-                int k)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+print_hessmat(std::string str, amrex::Real hmat[KSPSIZE + 1][KSPSIZE])
 {
+  amrex::Print() << "\n" << str << "\n";
 
-  amrex::Real temp,cos,sin;
+  for (int i = 0; i < KSPSIZE + 1; i++) {
+    for (int j = 0; j < KSPSIZE; j++) {
+      amrex::Print() << hmat[i][j] << "  ";
+    }
+    amrex::Print() << "\n";
+  }
+  amrex::Print() << "\n";
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+print_arnoldivecs(std::string str, amrex::Real arnoldivecs[KSPSIZE + 1][NEQNS])
+{
+  amrex::Print() << "\n" << str << "\n";
 
-  //apply for ith column
-  for(int i=0;i<=(k-1); i++)
-  {
-    temp   =  cos_arr[i] * Hessmat[i][k] + sin_arr[i] * Hessmat[i+1][k];
-    Hessmat[i+1][k] = -sin_arr[i] * Hessmat[i][k] + cos_arr[i] * Hessmat[i + 1][k];
-    Hessmat[i][k]   = temp;
+  for (int i = 0; i < (KSPSIZE + 1); i++) {
+    for (int j = 0; j < NEQNS; j++) {
+      amrex::Print() << arnoldivecs[i][j] << "  ";
+    }
+    amrex::Print() << "\n";
+  }
+  amrex::Print() << "\n";
+}
+#endif
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+scalevector(amrex::Real v1[NEQNS], amrex::Real factor)
+{
+  for (int i = 0; i < NEQNS; i++) {
+    v1[i] = v1[i] * factor;
+  }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+multiplyvectors(
+  amrex::Real v1[NEQNS], amrex::Real v2[NEQNS], amrex::Real v12[NEQNS])
+{
+  for (int i = 0; i < NEQNS; i++) {
+    v12[i] = v1[i] * v2[i];
+  }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+findnorm(amrex::Real v1[NEQNS])
+{
+  amrex::Real norm = 0.0;
+  for (int i = 0; i < NEQNS; i++) {
+    norm = norm + v1[i] * v1[i];
   }
 
-  //update the next sin cos values for rotation
-  givens_rotate(Hessmat[k][k], Hessmat[k+1][k], cos, sin);
-
-  //eliminate H(i + 1, i)
-  Hessmat[k][k] = cos * Hessmat[k][k] + sin * Hessmat[k+1][k];
-  Hessmat[k+1][k] = 0.0;
-
-  cos_arr[k]=cos;
-  sin_arr[k]=sin;
-
-  beta_e1[k+1] = -sin*beta_e1[k];
-  beta_e1[k]   =  cos*beta_e1[k];
-
-  amrex::Real error=amrex::Math::abs(beta_e1[k+1]);
-
-  return(error);
+  return (sqrt(norm));
 }
 //========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
-uppertrisolve(amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
-         amrex::Real y[KSPSIZE],amrex::Real beta_e1[KSPSIZE+1],
-         int k)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+innerproduct(amrex::Real v1[NEQNS], amrex::Real v2[NEQNS])
 {
-    for(int i=k-1;i>=0;i--)	
-    {
-        y[i] = beta_e1[i];
-        for(int j=i+1;j<=k;j++)
-        {
-            y[i]=y[i] - Hessmat[i][j] * y[j];
-        }
-        y[i] = y[i]/Hessmat[i][i];
-    }
+  amrex::Real innerprod = 0.0;
+  for (int i = 0; i < NEQNS; i++) {
+    innerprod = innerprod + v1[i] * v2[i];
+  }
+
+  return (innerprod);
 }
 //========================================================================
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE 
-bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
-                  amrex::Real b[NEQNS],
-                  amrex::Real  x0[NEQNS], //initial soln for GMRES
-                  amrex::Real x[NEQNS],   //current solution for GMRES
-                  int precond_type,
-                  int restart_it,
-                  int kspiters,
-                  amrex::Real tol,int printflag)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+addvectors(
+  amrex::Real v1[NEQNS],
+  amrex::Real v2[NEQNS],
+  amrex::Real v12[NEQNS],
+  amrex::Real a,
+  amrex::Real b)
 {
-    amrex::Real beta;
-    bool arnoldistopped;
-    bool success;
-    bool nanflag;
+  for (int i = 0; i < NEQNS; i++) {
+    v12[i] = a * v1[i] + b * v2[i];
+  }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+copyvector(
+  amrex::Real v1[NEQNS],
+  amrex::Real v2[NEQNS]) //(dest,source,size)
+{
+  for (int i = 0; i < NEQNS; i++) {
+    v1[i] = v2[i];
+  }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+getkspvector(
+  amrex::Real v1[NEQNS], amrex::Real kspvectors[KSPSIZE + 1][NEQNS], int vecnum)
+{
+  for (int i = 0; i < NEQNS; i++) {
+    v1[i] = kspvectors[vecnum][i];
+  }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+setkspvector(
+  amrex::Real vec[NEQNS],
+  amrex::Real kspvectors[KSPSIZE + 1][NEQNS],
+  int vecnum)
+{
+  for (int i = 0; i < NEQNS; i++) {
+    kspvectors[vecnum][i] = vec[i];
+  }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool
+isit_NaN(amrex::Real val)
+{
+  amrex::Real valbyval;
+  amrex::Real valplus3;
 
-    amrex::Real v1[NEQNS]={0.0};
-    amrex::Real tempvec[NEQNS]={0.0};
-    amrex::Real v[NEQNS]={0.0};
-    amrex::Real y[KSPSIZE]={0.0};
-    amrex::Real r[NEQNS]={0.0};
-    amrex::Real r0[NEQNS]={0.0};
-    amrex::Real Ax0[NEQNS]={0.0};
-    amrex::Real Minvr[NEQNS]={0.0};
-    amrex::Real kspvectors[KSPSIZE+1][NEQNS]={0.0};
-    amrex::Real Hessmat[KSPSIZE+1][KSPSIZE]={0.0};
-    amrex::Real cos_arr[KSPSIZE]={0.0};
-    amrex::Real sin_arr[KSPSIZE]={0.0};
-    amrex::Real beta_e1[KSPSIZE+1]={0.0};
-    amrex::Real residnorm;
-    
-    success = true;
+  valbyval = val / val;
+  valplus3 = val + 3.0;
 
-    //finding r0
-    findAX(Ax0,Mat,x0);
-    addvectors(b,Ax0,r0,1.0,-1.0);  //b-Ax0
-    precond(Minvr,Mat,r0,precond_type); //Minv * r0
-    copyvector(r0,Minvr);
+  if (val != val) {
+    return (true);
+  } else if ((valbyval != valbyval) && (valplus3 == val)) {
+    return (true);
+  } else {
+    return (false);
+  }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool
+arnoldi(
+  int j,
+  amrex::Real mat[NEQNS][NEQNS],
+  amrex::Real kspvectors[KSPSIZE + 1][NEQNS],
+  amrex::Real Hessmat[KSPSIZE + 1][KSPSIZE],
+  int precond_type,
+  amrex::Real tol,
+  bool& nanflag)
+{
+  int i;
+  amrex::Real Avj[NEQNS], vj[NEQNS], vi[NEQNS];
+  amrex::Real wj[NEQNS], tempvec[NEQNS];
+  amrex::Real MinvAvj[NEQNS];
 
-    //initial residual is r0=M^-1(b-Ax0)
-    //we are solving M^-1 A X = M^-1 b
-    copyvector(r,r0);
-    copyvector(x,x0); 
+  bool lucky; // when norm becomes 0,
+  // KSP vectors is no longer linearly independent.
+  // we would have gotten the best solution.
+
+  lucky = false;
+  nanflag = false;
+
+  getkspvector(vj, kspvectors, j);
+  findAX(Avj, mat, vj);
+  precond(MinvAvj, mat, Avj, precond_type);
+  copyvector(Avj, MinvAvj);
+  // Avj is now M^-1 A vj
+  // remember we are solving M^-1 A X = M^-1 b
+
+  for (i = 0; i <= j; i++) {
+    getkspvector(vi, kspvectors, i);
+    Hessmat[i][j] = innerproduct(Avj, vi);
+  }
+
+  copyvector(wj, Avj);
+
+  for (i = 0; i <= j; i++) {
+    getkspvector(vi, kspvectors, i);
+    addvectors(wj, vi, tempvec, 1.0, -Hessmat[i][j]);
+    copyvector(wj, tempvec);
+  }
+
+  Hessmat[j + 1][j] = findnorm(wj);
+
+  if (Hessmat[j + 1][j] > tol) {
+    for (i = 0; i < NEQNS; i++) {
+      wj[i] = wj[i] / Hessmat[j + 1][j];
+    }
+    setkspvector(wj, kspvectors, j + 1);
+  } else {
+    if (!isit_NaN(Hessmat[j + 1][j])) {
+      lucky = true;
+    } else {
+      amrex::Abort("NaN or Inf detected in Hessenberg matrix\n");
+      nanflag = true;
+    }
+  }
+
+  return (lucky);
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+givens_rotate(amrex::Real r, amrex::Real s, amrex::Real& cos, amrex::Real& sin)
+{
+  if (r == 0) {
+    cos = 0.0;
+    sin = 1.0;
+  } else {
+    cos = r / std::sqrt(r * r + s * s);
+    sin = s / std::sqrt(r * r + s * s);
+  }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+triangularize(
+  amrex::Real Hessmat[KSPSIZE + 1][KSPSIZE],
+  amrex::Real cos_arr[KSPSIZE],
+  amrex::Real sin_arr[KSPSIZE],
+  amrex::Real beta_e1[KSPSIZE + 1],
+  int k)
+{
+
+  amrex::Real temp, cos, sin;
+
+  // apply for ith column
+  for (int i = 0; i <= (k - 1); i++) {
+    temp = cos_arr[i] * Hessmat[i][k] + sin_arr[i] * Hessmat[i + 1][k];
+    Hessmat[i + 1][k] =
+      -sin_arr[i] * Hessmat[i][k] + cos_arr[i] * Hessmat[i + 1][k];
+    Hessmat[i][k] = temp;
+  }
+
+  // update the next sin cos values for rotation
+  givens_rotate(Hessmat[k][k], Hessmat[k + 1][k], cos, sin);
+
+  // eliminate H(i + 1, i)
+  Hessmat[k][k] = cos * Hessmat[k][k] + sin * Hessmat[k + 1][k];
+  Hessmat[k + 1][k] = 0.0;
+
+  cos_arr[k] = cos;
+  sin_arr[k] = sin;
+
+  beta_e1[k + 1] = -sin * beta_e1[k];
+  beta_e1[k] = cos * beta_e1[k];
+
+  amrex::Real error = amrex::Math::abs(beta_e1[k + 1]);
+
+  return (error);
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+uppertrisolve(
+  amrex::Real Hessmat[KSPSIZE + 1][KSPSIZE],
+  amrex::Real y[KSPSIZE],
+  amrex::Real beta_e1[KSPSIZE + 1],
+  int k)
+{
+  for (int i = k - 1; i >= 0; i--) {
+    y[i] = beta_e1[i];
+    for (int j = i + 1; j <= k; j++) {
+      y[i] = y[i] - Hessmat[i][j] * y[j];
+    }
+    y[i] = y[i] / Hessmat[i][i];
+  }
+}
+//========================================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool
+performgmres(
+  amrex::Real Mat[NEQNS][NEQNS],
+  amrex::Real b[NEQNS],
+  amrex::Real x0[NEQNS], // initial soln for GMRES
+  amrex::Real x[NEQNS],  // current solution for GMRES
+  int precond_type,
+  int restart_it,
+  int kspiters,
+  amrex::Real tol,
+  int printflag)
+{
+  amrex::Real beta;
+  bool arnoldistopped;
+  bool success;
+  bool nanflag;
+
+  amrex::Real v1[NEQNS] = {0.0};
+  amrex::Real tempvec[NEQNS] = {0.0};
+  amrex::Real v[NEQNS] = {0.0};
+  amrex::Real y[KSPSIZE] = {0.0};
+  amrex::Real r[NEQNS] = {0.0};
+  amrex::Real r0[NEQNS] = {0.0};
+  amrex::Real Ax0[NEQNS] = {0.0};
+  amrex::Real Minvr[NEQNS] = {0.0};
+  amrex::Real kspvectors[KSPSIZE + 1][NEQNS] = {0.0};
+  amrex::Real Hessmat[KSPSIZE + 1][KSPSIZE] = {0.0};
+  amrex::Real cos_arr[KSPSIZE] = {0.0};
+  amrex::Real sin_arr[KSPSIZE] = {0.0};
+  amrex::Real beta_e1[KSPSIZE + 1] = {0.0};
+  amrex::Real residnorm;
+
+  success = true;
+
+  // finding r0
+  findAX(Ax0, Mat, x0);
+  addvectors(b, Ax0, r0, 1.0, -1.0);     // b-Ax0
+  precond(Minvr, Mat, r0, precond_type); // Minv * r0
+  copyvector(r0, Minvr);
+
+  // initial residual is r0=M^-1(b-Ax0)
+  // we are solving M^-1 A X = M^-1 b
+  copyvector(r, r0);
+  copyvector(x, x0);
 
 #ifndef AMREX_USE_GPU
-    if(printflag) amrex::Print()<<"initial norm of residual:"
-        <<findnorm(r0)<<"\n";
+  if (printflag)
+    amrex::Print() << "initial norm of residual:" << findnorm(r0) << "\n";
 #endif
 
-    for(int it=0;it<restart_it;it++)
-    {
+  for (int it = 0; it < restart_it; it++) {
 #ifndef AMREX_USE_GPU
-        if(printflag) amrex::Print()<<"restart iteration:"
-            <<it<<"\n";
+    if (printflag)
+      amrex::Print() << "restart iteration:" << it << "\n";
 #endif
 
-        copyvector(x0,x);
-        beta = findnorm(r);
+    copyvector(x0, x);
+    beta = findnorm(r);
 
-        for(int i=0;i<NEQNS;i++)
-        {
-            v1[i]=r[i]/beta;
-        }
-        beta_e1[0]=beta;
+    for (int i = 0; i < NEQNS; i++) {
+      v1[i] = r[i] / beta;
+    }
+    beta_e1[0] = beta;
 
-        setkspvector(v1,kspvectors,0);
-        
-        int optkspsize=KSPSIZE;
-        for(int kspdim=0;kspdim<kspiters;kspdim++)
-        {
-            copyvector(x,x0);
-            // finds the ksp vector at kspdim+1
-            arnoldistopped = arnoldi(kspdim,Mat,kspvectors,Hessmat,
-                                     precond_type,tol*0.01,nanflag);
+    setkspvector(v1, kspvectors, 0);
 
-            residnorm=triangularize(Hessmat,cos_arr,sin_arr,beta_e1,
-                                    kspdim);
-            
-            if(nanflag)
-            {
-                success=!nanflag;
-                amrex::Abort("nan detected in arnoldi iteration\n");
-                break;
-            }
+    int optkspsize = KSPSIZE;
+    for (int kspdim = 0; kspdim < kspiters; kspdim++) {
+      copyvector(x, x0);
+      // finds the ksp vector at kspdim+1
+      arnoldistopped = arnoldi(
+        kspdim, Mat, kspvectors, Hessmat, precond_type, tol * 0.01, nanflag);
 
+      residnorm = triangularize(Hessmat, cos_arr, sin_arr, beta_e1, kspdim);
+
+      if (nanflag) {
+        success = !nanflag;
+        amrex::Abort("nan detected in arnoldi iteration\n");
+        break;
+      }
 
 #ifndef AMREX_USE_GPU
-            if(printflag) amrex::Print()<<"norm of residual:"
-                <<residnorm<<"\t"<<tol<<"\t"<<kspdim<<"\n";
+      if (printflag)
+        amrex::Print() << "norm of residual:" << residnorm << "\t" << tol
+                       << "\t" << kspdim << "\n";
 #endif
 
-            if(arnoldistopped) 
-            {
-                optkspsize=kspdim+1;
+      if (arnoldistopped) {
+        optkspsize = kspdim + 1;
 #ifndef AMREX_USE_GPU
-                if(printflag) amrex::Print()<<"lucky condition:"
-                    <<kspdim<<"\n";
+        if (printflag)
+          amrex::Print() << "lucky condition:" << kspdim << "\n";
 #endif
-                break;
-            }
+        break;
+      }
 
-            if(residnorm <= tol)
-            {
-                optkspsize=kspdim+1;
-                break;
-            }
-        }
-
-        uppertrisolve(Hessmat,y,beta_e1,optkspsize);
-        for(int i=0;i<optkspsize;i++)
-        {
-            getkspvector(v,kspvectors,i);
-            addvectors(x,v,tempvec,1.0,y[i]);
-            copyvector(x,tempvec);
-        }
-
-        if( (residnorm <= tol) || (!success) || (arnoldistopped) )
-        {
-            break;
-        }
+      if (residnorm <= tol) {
+        optkspsize = kspdim + 1;
+        break;
+      }
     }
 
+    uppertrisolve(Hessmat, y, beta_e1, optkspsize);
+    for (int i = 0; i < optkspsize; i++) {
+      getkspvector(v, kspvectors, i);
+      addvectors(x, v, tempvec, 1.0, y[i]);
+      copyvector(x, tempvec);
+    }
 
-    return(success);
+    if ((residnorm <= tol) || (!success) || (arnoldistopped)) {
+      break;
+    }
+  }
+
+  return (success);
 }
 //========================================================================

--- a/Reactions/ReactorBDFsolver.H
+++ b/Reactions/ReactorBDFsolver.H
@@ -342,7 +342,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
         if( !isit_NaN(Hessmat[j+1][j]) )
         {
 #ifndef AMREX_USE_GPU
-            amrex::Print()<<"lucky\n";
+            //amrex::Print()<<"lucky\n";
 #endif
             lucky=true;
         }

--- a/Reactions/ReactorBDFsolver.H
+++ b/Reactions/ReactorBDFsolver.H
@@ -1,9 +1,11 @@
 #include "AMReX_Reduce.H"
-#include "ReactorBDF.H"
-#define NEQNS NUM_SPECIES+1
-#define KSPSIZE NEQNS/2
+#include <ReactorBDF.H>
+#define NEQNS (NUM_SPECIES+1)
+#define NEQNS2 NEQNS*NEQNS
+#define KSPSIZE NEQNS
 #define NOPC 0
-#define SGSPC 1
+#define GJPC 1
+#define SGSPC 2
 #define NEARZERO 1e-15
 
 //==============================================================
@@ -15,6 +17,25 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void noprecond(amrex::Real MinvX[NEQNS],
     for(int i=0;i<NEQNS;i++)
     {
         MinvX[i]=X[i];
+    }
+}
+//==============================================================
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void GJprecond(amrex::Real MinvX[NEQNS],
+                                               amrex::Real A[NEQNS][NEQNS],
+                                               amrex::Real X[NEQNS],
+                                               amrex::Real dt)
+{
+    amrex::Real sum,diag;
+    amrex::Real y_d[NEQNS],y_dd[NEQNS];
+    amrex::Real dt_inv=1.0/dt;
+
+    //solve Dy = X
+    //MinvX = y
+
+    for(int i=0;i<NEQNS;i++)
+    {
+        diag=dt_inv-A[i][i];
+        MinvX[i]=X[i]/diag;
     }
 }
 //==============================================================
@@ -77,6 +98,10 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void precond(amrex::Real MinvX[NEQNS],
     if(type==NOPC)
     {
         noprecond(MinvX,A,X,dt);   
+    }
+    else if(type==GJPC)
+    {
+        GJprecond(MinvX,A,X,dt);
     }
     else if(type==SGSPC)
     {
@@ -141,7 +166,7 @@ printmat(std::string str,amrex::Real mat[NEQNS][NEQNS])
     {
         for(int j=0;j<NEQNS;j++)
         {
-            amrex::Print()<<mat[i][j]<<"\t";
+            amrex::Print()<<mat[i][j]<<"  ";
         }
         amrex::Print()<<"\n";
     }
@@ -271,14 +296,17 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
 
     bool lucky; //when norm becomes 0,
     //KSP vectors is no longer linearly independent.
-    //we would have got the best solution.
+    //we would have gotten the best solution.
 
     lucky   = false;
     nanflag = false;
 
     getkspvector(vj,kspvectors,j);
+    //printvec("vj:",vj);
     findAX(Avj,mat,vj,dt);
+    //printvec("Avj:",Avj);
     precond(MinvAvj,mat,Avj,dt,precond_type);
+    //printvec("MinvAvj:",MinvAvj);
     copyvector(Avj,MinvAvj);
     //Avj is now M^-1 A vj
     //remember we are solving M^-1 A X = M^-1 b
@@ -335,7 +363,7 @@ leastsqminimize(amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
 
     //local copy
     amrex::Real Hmat[KSPSIZE+1][KSPSIZE];
-    for(int i=0;i<KSPSIZE+1;i++)
+    for(int i=0;i<(KSPSIZE+1);i++)
     {
         for(int j=0;j<KSPSIZE;j++)
         {
@@ -398,22 +426,23 @@ leastsqminimize(amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
 }
 //========================================================================
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE 
-bool performgmres(amrex::Real Mat1d[NEQNS*NEQNS],
+bool performgmres(amrex::Real Mat1d[NEQNS2],
                   amrex::Real ydot[NEQNS],
                   amrex::Real  x0[NEQNS], //initial soln for GMRES
                   amrex::Real x[NEQNS],   //current solution
-                  amrex::Real xn[NEQNS],  //solution at time level n
-                  amrex::Real dt,
+                  amrex::Real dsoln_n[NEQNS],   //for explicit term
+                  amrex::Real dt_dim,
                   int precond_type,
                   int restart_it,
                   amrex::Real tol,int printflag)
 {
-    int n;
     amrex::Real beta;
     bool arnoldistopped;
     bool success;
     bool nanflag;
     int luckykspdim;
+
+    amrex::Print()<<"kspsize:"<<KSPSIZE<<"\n";
 
     amrex::Real v1[NEQNS]={0.0};
     amrex::Real tempvec[NEQNS]={0.0};
@@ -428,25 +457,31 @@ bool performgmres(amrex::Real Mat1d[NEQNS*NEQNS],
     amrex::Real Mat[NEQNS][NEQNS]={0.0};
     amrex::Real kspvectors[KSPSIZE+1][NEQNS]={0.0};
     amrex::Real Hessmat[KSPSIZE+1][KSPSIZE]={0.0};
-    amrex::Real residnorm;
+    amrex::Real residnorm,bnorm;
 
     success = true;
 
+
+    //set RHS
+    for(int i=0;i<NEQNS;i++)
+    {
+        b[i]=-(dsoln_n[i]/dt_dim-ydot[i]);
+    }
+    bnorm=findnorm(b);
+    //bnorm=1.0;
+    amrex::Real dt=dt_dim*bnorm;
+    
     //set matrix
     for(int i=0;i<NEQNS;i++)
     {
         for(int j=0;j<NEQNS;j++)
         {
-              Mat[i][j]=Mat1d[i*NEQNS+j];
+              Mat[i][j]=Mat1d[i*NEQNS+j]/bnorm;
         }
+        b[i]=b[i]/bnorm;
     }
 
-    //set RHS
-    for(int i=0;i<NEQNS;i++)
-    {
-        b[i]=-((x[i]-xn[i])/dt-ydot[i]);
-    }
-
+    printmat("Jacobian",Mat);
     //finding r0
     findAX(Ax0,Mat,x0,dt);
     addvectors(b,Ax0,r0,1.0,-1.0);  //b-Ax0
@@ -456,6 +491,8 @@ bool performgmres(amrex::Real Mat1d[NEQNS*NEQNS],
     //initial residual is r0=M^-1(b-Ax0)
     //we are solving M^-1 A X = M^-1 b
     copyvector(r,r0);
+    printvec("r0",r0);
+    printvec("r",r);
     copyvector(x,x0); 
 #ifndef AMREX_USE_GPU
     if(printflag) amrex::Print()<<"initial norm of residual:"
@@ -472,7 +509,7 @@ bool performgmres(amrex::Real Mat1d[NEQNS*NEQNS],
         copyvector(x0,x);
         beta = findnorm(r);
 
-        for(int i=0;i<n;i++)
+        for(int i=0;i<NEQNS;i++)
         {
             v1[i]=r[i]/beta;
         }
@@ -483,7 +520,8 @@ bool performgmres(amrex::Real Mat1d[NEQNS*NEQNS],
         {
             copyvector(x,x0);
             // finds the ksp vector at kspdim+1
-            arnoldistopped = arnoldi(kspdim,Mat,kspvectors,Hessmat,dt,precond_type,luckykspdim,nanflag);
+            arnoldistopped = arnoldi(kspdim,Mat,kspvectors,Hessmat,
+                                     dt,precond_type,luckykspdim,nanflag);
 
             if(nanflag)
             {

--- a/Reactions/ReactorBDFsolver.H
+++ b/Reactions/ReactorBDFsolver.H
@@ -455,9 +455,6 @@ bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
     
     success = true;
 
-    printmat("matrix:",Mat);
-    printvec("rhs:",b);
-
     //finding r0
     findAX(Ax0,Mat,x0);
     addvectors(b,Ax0,r0,1.0,-1.0);  //b-Ax0

--- a/Reactions/ReactorBDFsolver.H
+++ b/Reactions/ReactorBDFsolver.H
@@ -292,7 +292,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
                                                  amrex::Real tol,
                                                  bool &nanflag)
 {
-    int i,n;
+    int i;
     amrex::Real Avj[NEQNS],vj[NEQNS],vi[NEQNS];
     amrex::Real wj[NEQNS],tempvec[NEQNS];
     amrex::Real MinvAvj[NEQNS];
@@ -331,7 +331,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
 
     if(Hessmat[j+1][j] > tol)
     {
-        for(int i=0;i<NEQNS;i++)
+        for(i=0;i<NEQNS;i++)
         {
             wj[i]=wj[i]/Hessmat[j+1][j];
         }
@@ -445,16 +445,18 @@ bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
     amrex::Real r[NEQNS]={0.0};
     amrex::Real r0[NEQNS]={0.0};
     amrex::Real Ax0[NEQNS]={0.0};
-    amrex::Real Ax[NEQNS]={0.0};
     amrex::Real Minvr[NEQNS]={0.0};
     amrex::Real kspvectors[KSPSIZE+1][NEQNS]={0.0};
     amrex::Real Hessmat[KSPSIZE+1][KSPSIZE]={0.0};
     amrex::Real cos_arr[KSPSIZE]={0.0};
     amrex::Real sin_arr[KSPSIZE]={0.0};
     amrex::Real beta_e1[KSPSIZE+1]={0.0};
-    amrex::Real residnorm,bnorm;
+    amrex::Real residnorm;
     
     success = true;
+
+    printmat("matrix:",Mat);
+    printvec("rhs:",b);
 
     //finding r0
     findAX(Ax0,Mat,x0);

--- a/Reactions/ReactorBDFsolver.H
+++ b/Reactions/ReactorBDFsolver.H
@@ -2,7 +2,7 @@
 #include <ReactorBDF.H>
 #define NEQNS (NUM_SPECIES+1)
 #define NEQNS2 NEQNS*NEQNS
-#define KSPSIZE 5
+#define KSPSIZE NEQNS
 #define NOPC 0
 #define GJPC 1
 #define SGSPC 2
@@ -289,14 +289,13 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
                                                  amrex::Real kspvectors[KSPSIZE+1][NEQNS],
                                                  amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
                                                  int precond_type,
-                                                 int luckykspdim,
+                                                 amrex::Real tol,
                                                  bool &nanflag)
 {
     int i,n;
     amrex::Real Avj[NEQNS],vj[NEQNS],vi[NEQNS];
     amrex::Real wj[NEQNS],tempvec[NEQNS];
     amrex::Real MinvAvj[NEQNS];
-    luckykspdim = KSPSIZE;
     
 
     bool lucky; //when norm becomes 0,
@@ -330,7 +329,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
 
     Hessmat[j+1][j] = findnorm(wj);
 
-    if(Hessmat[j+1][j] > NEARZERO)
+    if(Hessmat[j+1][j] > tol)
     {
         for(int i=0;i<NEQNS;i++)
         {
@@ -346,7 +345,6 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE bool arnoldi(int j,
             amrex::Print()<<"lucky\n";
 #endif
             lucky=true;
-            luckykspdim=j+1;
         }
         else
         {
@@ -412,17 +410,16 @@ triangularize(amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
 //========================================================================
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void 
 uppertrisolve(amrex::Real Hessmat[KSPSIZE+1][KSPSIZE],
-         amrex::Real y[KSPSIZE+1],amrex::Real beta_e1[KSPSIZE+1],
+         amrex::Real y[KSPSIZE],amrex::Real beta_e1[KSPSIZE+1],
          int k)
 {
-    for(int i=k;i>=0;i--)	
+    for(int i=k-1;i>=0;i--)	
     {
         y[i] = beta_e1[i];
         for(int j=i+1;j<=k;j++)
         {
             y[i]=y[i] - Hessmat[i][j] * y[j];
         }
-
         y[i] = y[i]/Hessmat[i][i];
     }
 }
@@ -440,12 +437,11 @@ bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
     bool arnoldistopped;
     bool success;
     bool nanflag;
-    int luckykspdim;
 
     amrex::Real v1[NEQNS]={0.0};
     amrex::Real tempvec[NEQNS]={0.0};
     amrex::Real v[NEQNS]={0.0};
-    amrex::Real y[KSPSIZE+1]={0.0};
+    amrex::Real y[KSPSIZE]={0.0};
     amrex::Real r[NEQNS]={0.0};
     amrex::Real r0[NEQNS]={0.0};
     amrex::Real Ax0[NEQNS]={0.0};
@@ -470,6 +466,7 @@ bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
     //we are solving M^-1 A X = M^-1 b
     copyvector(r,r0);
     copyvector(x,x0); 
+
 #ifndef AMREX_USE_GPU
     if(printflag) amrex::Print()<<"initial norm of residual:"
         <<findnorm(r0)<<"\n";
@@ -493,17 +490,17 @@ bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
 
         setkspvector(v1,kspvectors,0);
         
-        int kspdim;
-        for(kspdim=0;kspdim<KSPSIZE;kspdim++)
+        int optkspsize=KSPSIZE;
+        for(int kspdim=0;kspdim<KSPSIZE;kspdim++)
         {
             copyvector(x,x0);
             // finds the ksp vector at kspdim+1
             arnoldistopped = arnoldi(kspdim,Mat,kspvectors,Hessmat,
-                                     precond_type,luckykspdim,nanflag);
+                                     precond_type,tol*0.01,nanflag);
 
             residnorm=triangularize(Hessmat,cos_arr,sin_arr,beta_e1,
                                     kspdim);
-
+            
             if(nanflag)
             {
                 success=!nanflag;
@@ -519,21 +516,23 @@ bool performgmres(amrex::Real Mat[NEQNS][NEQNS],
 
             if(arnoldistopped) 
             {
+                optkspsize=kspdim+1;
 #ifndef AMREX_USE_GPU
                 if(printflag) amrex::Print()<<"lucky condition:"
-                    <<luckykspdim<<"\n";
+                    <<kspdim<<"\n";
 #endif
                 break;
             }
 
             if(residnorm <= tol)
             {
+                optkspsize=kspdim+1;
                 break;
             }
         }
 
-        uppertrisolve(Hessmat,y,beta_e1,kspdim);
-        for(int i=0;i<=kspdim;i++)
+        uppertrisolve(Hessmat,y,beta_e1,optkspsize);
+        for(int i=0;i<optkspsize;i++)
         {
             getkspvector(v,kspvectors,i);
             addvectors(x,v,tempvec,1.0,y[i]);

--- a/Testing/Exec/IgnitionDelay/inputs/inputs.0d_firstpass
+++ b/Testing/Exec/IgnitionDelay/inputs/inputs.0d_firstpass
@@ -32,6 +32,8 @@ amrex.fpe_trap_invalid = 1
 amrex.fpe_trap_zero = 1
 amrex.fpe_trap_overflow = 1
 
+ode.bdf_nsubsteps=2000
+ode.bdf_scheme=3
 
 # 1013250.0 * patm
 hr.press = 5066250.0

--- a/Testing/Exec/ReactEval/inputs.3d_1dArray
+++ b/Testing/Exec/ReactEval/inputs.3d_1dArray
@@ -5,8 +5,8 @@ fuel_name = CH4
 reactFormat = 1dArray
 chem_integrator = "ReactorRK64"
 
-ode.dt  = 1.e-05
-ode.ndt = 1
+ode.dt  = 2.e-05
+ode.ndt = 30
 ode.ode_ncells = 1024
 ode.reactor_type  = 1 # 1=full e, 2=full h
 ode.verbose = 1
@@ -37,3 +37,5 @@ cvode.max_order = 4
 amrex.fpe_trap_invalid = 1
 amrex.fpe_trap_zero = 1
 amrex.fpe_trap_overflow = 1
+
+ode.bdf_nsubsteps=40

--- a/Testing/Exec/ReactEval/inputs.3d_Array4
+++ b/Testing/Exec/ReactEval/inputs.3d_Array4
@@ -38,4 +38,4 @@ amrex.fpe_trap_invalid = 1
 amrex.fpe_trap_zero = 1
 amrex.fpe_trap_overflow = 1
 
-ode.bdf_nsubsteps=50
+ode.bdf_nsubsteps=40

--- a/Testing/Exec/ReactEval/inputs.3d_Array4
+++ b/Testing/Exec/ReactEval/inputs.3d_Array4
@@ -5,8 +5,8 @@ fuel_name = CH4
 reactFormat = Array4
 chem_integrator = "ReactorRK64"
 
-ode.dt  = 1.e-05
-ode.ndt = 1
+ode.dt  = 2.e-05
+ode.ndt = 30
 ode.ode_ncells = 1
 ode.reactor_type  = 1 # 1=full e, 2=full h
 ode.verbose = 1
@@ -37,3 +37,5 @@ cvode.max_order = 4
 amrex.fpe_trap_invalid = 1
 amrex.fpe_trap_zero = 1
 amrex.fpe_trap_overflow = 1
+
+ode.bdf_nsubsteps=50


### PR DESCRIPTION
Adding backward-difference scheme for chemistry integration, everything hand-rolled including a preconditioned GMRES.
Hope this will be useful for probing into finding the right pre-conditioners and extension to new architectures with basic AMReX code. 

some notes and thoughts that will need some future efforts:

1) usage from any application code: do chem_integrator="ReactorBDF"

2) Unlike Cvode, there is no internal estimation of time-step. I did some tests ~ 10-50 substeps per microsec seems to work for the most-often used mechanisms (like Lidryer, drm19, dodecane_lu), but this will be something more to do.

3) ReactorBDF seems ~ 2X faster on CPU than Cvode for the reacteval case giving the same solution, but this number will change based on all the cvode parameters (tols etc..). It is slower than Cvode on GPU though, I am looking at this now.