### PR TITLE
Jacobian transpose

### DIFF
--- a/Eos/Fuego.H
+++ b/Eos/Fuego.H
@@ -195,7 +195,11 @@ struct Fuego
   {
     amrex::Real C[NUM_SPECIES];
     CKYTCR(&R, &T, Y, C);
+#ifdef PELE_ROLL_JAC
+    DWDOT_ROLL(JAC, C, &T, &HP);
+#else
     DWDOT(JAC, C, &T, &HP);
+#endif
   }
 
   AMREX_GPU_HOST_DEVICE

--- a/Reactions/ReactorBDF.cpp
+++ b/Reactions/ReactorBDF.cpp
@@ -69,13 +69,13 @@ get_bdf_matrix_and_rhs(
   for (int ii = 0; ii < NUM_SPECIES; ii++) {
     for (int jj = 0; jj < NUM_SPECIES; jj++) {
       Jmat2d[ii][jj] = -bdfp.FCOEFFMAT[tstepscheme][0] *
-                       Jmat1d[jj * (NUM_SPECIES + 1) + ii] * mw[ii] / mw[jj];
+                       Jmat1d[ii * (NUM_SPECIES + 1) + jj] * mw[ii] / mw[jj];
     }
     Jmat2d[ii][NUM_SPECIES] = -bdfp.FCOEFFMAT[tstepscheme][0] *
-                              Jmat1d[NUM_SPECIES * (NUM_SPECIES + 1) + ii] *
+                              Jmat1d[ii * (NUM_SPECIES + 1) + NUM_SPECIES] *
                               mw[ii];
     Jmat2d[NUM_SPECIES][ii] = -bdfp.FCOEFFMAT[tstepscheme][0] *
-                              Jmat1d[ii * (NUM_SPECIES + 1) + NUM_SPECIES] /
+                              Jmat1d[NUM_SPECIES * (NUM_SPECIES + 1) + ii] /
                               mw[ii];
   }
   Jmat2d[NUM_SPECIES][NUM_SPECIES] =

--- a/Reactions/ReactorCvodeJacobian.cpp
+++ b/Reactions/ReactorCvodeJacobian.cpp
@@ -138,15 +138,15 @@ cJac(
       // cppcheck-suppress cstyleCast
       amrex::Real* J_col = SM_COLUMN_D(J, offset + i);
       for (int k = 0; k < NUM_SPECIES; k++) {
-        J_col[offset + k] = Jmat_tmp[i * (NUM_SPECIES + 1) + k] * mw[k] / mw[i];
+        J_col[offset + k] = Jmat_tmp[k * (NUM_SPECIES + 1) + i] * mw[k] / mw[i];
       }
       J_col[offset + NUM_SPECIES] =
-        Jmat_tmp[i * (NUM_SPECIES + 1) + NUM_SPECIES] / mw[i];
+        Jmat_tmp[NUM_SPECIES * (NUM_SPECIES + 1) + i] / mw[i];
     }
     // cppcheck-suppress cstyleCast
     amrex::Real* J_col = SM_COLUMN_D(J, offset + NUM_SPECIES);
     for (int i = 0; i < NUM_SPECIES; i++) {
-      J_col[offset + i] = Jmat_tmp[NUM_SPECIES * (NUM_SPECIES + 1) + i] * mw[i];
+      J_col[offset + i] = Jmat_tmp[i * (NUM_SPECIES + 1) + NUM_SPECIES] * mw[i];
     }
     // J_col = SM_COLUMN_D(J, offset); // Never read
 #else
@@ -245,12 +245,12 @@ cJac_sps(
       // rescale
       for (int i = 0; i < NUM_SPECIES; i++) {
         for (int k = 0; k < NUM_SPECIES; k++) {
-          Jmat_tmp[k * (NUM_SPECIES + 1) + i] *= mw[i] / mw[k];
+          Jmat_tmp[i * (NUM_SPECIES + k) + i] *= mw[i] / mw[k];
         }
-        Jmat_tmp[i * (NUM_SPECIES + 1) + NUM_SPECIES] /= mw[i];
+        Jmat_tmp[NUM_SPECIES * (NUM_SPECIES + 1) + i] /= mw[i];
       }
       for (int i = 0; i < NUM_SPECIES; i++) {
-        Jmat_tmp[NUM_SPECIES * (NUM_SPECIES + 1) + i] *= mw[i];
+        Jmat_tmp[i * (NUM_SPECIES + 1) + NUM_SPECIES] *= mw[i];
       }
 #else
       temp_save_lcl = temp;
@@ -352,12 +352,12 @@ cJac_KLU(
       // rescale
       for (int i = 0; i < NUM_SPECIES; i++) {
         for (int k = 0; k < NUM_SPECIES; k++) {
-          Jmat_tmp[k * (NUM_SPECIES + 1) + i] *= mw[i] / mw[k];
+          Jmat_tmp[i * (NUM_SPECIES + 1) + k] *= mw[i] / mw[k];
         }
-        Jmat_tmp[i * (NUM_SPECIES + 1) + NUM_SPECIES] /= mw[i];
+        Jmat_tmp[NUM_SPECIES * (NUM_SPECIES + 1) + i] /= mw[i];
       }
       for (int i = 0; i < NUM_SPECIES; i++) {
-        Jmat_tmp[NUM_SPECIES * (NUM_SPECIES + 1) + i] *= mw[i];
+        Jmat_tmp[i * (NUM_SPECIES + 1) + NUM_SPECIES] *= mw[i];
       }
 #else
       temp_save_lcl = temp;

--- a/Reactions/ReactorCvodePreconditioner.cpp
+++ b/Reactions/ReactorCvodePreconditioner.cpp
@@ -215,10 +215,6 @@ Precond(
     amrex::Real Jmat[(NUM_SPECIES + 1) * (NUM_SPECIES + 1)] = {0.0};
 #ifdef PELE_ROLL_JAC
     DWDOT_SIMPLIFIED_ROLL(Jmat, activity, &temp, &consP);
-#else
-    DWDOT_SIMPLIFIED(Jmat, activity, &temp, &consP);
-#endif
-
     // Scale Jacobian.  Load into P.
     SUNDlsMat_denseScale(0.0, Jbd[0][0], NUM_SPECIES + 1, NUM_SPECIES + 1);
     for (int i = 0; i < NUM_SPECIES; i++) {
@@ -234,6 +230,25 @@ Precond(
     }
     (Jbd[0][0])[NUM_SPECIES][NUM_SPECIES] =
       Jmat[(NUM_SPECIES + 1) * (NUM_SPECIES + 1) - 1];
+#else
+    DWDOT_SIMPLIFIED(Jmat, activity, &temp, &consP);
+    // Scale Jacobian.  Load into P.
+    SUNDlsMat_denseScale(0.0, Jbd[0][0], NUM_SPECIES + 1, NUM_SPECIES + 1);
+    for (int i = 0; i < NUM_SPECIES; i++) {
+      for (int k = 0; k < NUM_SPECIES; k++) {
+        (Jbd[0][0])[k][i] = Jmat[k * (NUM_SPECIES + 1) + i] * mw[i] / mw[k];
+      }
+      (Jbd[0][0])[i][NUM_SPECIES] =
+        Jmat[i * (NUM_SPECIES + 1) + NUM_SPECIES] / mw[i];
+    }
+    for (int i = 0; i < NUM_SPECIES; i++) {
+      (Jbd[0][0])[NUM_SPECIES][i] =
+        Jmat[NUM_SPECIES * (NUM_SPECIES + 1) + i] * mw[i];
+    }
+    (Jbd[0][0])[NUM_SPECIES][NUM_SPECIES] =
+      Jmat[(NUM_SPECIES + 1) * (NUM_SPECIES + 1) - 1];
+#endif
+
 
     SUNDlsMat_denseCopy(Jbd[0][0], P[0][0], NUM_SPECIES + 1, NUM_SPECIES + 1);
 
@@ -347,16 +362,12 @@ Precond_sparse(
       auto eos = pele::physics::PhysicsType::eos();
       eos.RTY2C(rho, temp, massfrac, activity);
 
+#ifdef PELE_ROLL_JAC
       // Do we recompute Jac ?
       if (fabs(temp - temp_save_lcl) > 1.0) {
         // Formalism
         int consP = reactor_type == ReactorTypes::h_reactor_type;
-#ifdef PELE_ROLL_JAC
         DWDOT_SIMPLIFIED_ROLL(JSPSmat[tid], activity, &temp, &consP);
-#else
-        DWDOT_SIMPLIFIED(JSPSmat[tid], activity, &temp, &consP);
-#endif
-
         for (int i = 0; i < NUM_SPECIES; i++) {
           for (int k = 0; k < NUM_SPECIES; k++) {
             (JSPSmat[tid])[k * (NUM_SPECIES + 1) + i] *= mw[i] / mw[k];
@@ -376,6 +387,33 @@ Precond_sparse(
           }
         }
       }
+#else
+      // Do we recompute Jac ?
+      if (fabs(temp - temp_save_lcl) > 1.0) {
+        // Formalism
+        int consP = reactor_type == ReactorTypes::h_reactor_type;
+        DWDOT_SIMPLIFIED(JSPSmat[tid], activity, &temp, &consP);
+        for (int i = 0; i < NUM_SPECIES; i++) {
+          for (int k = 0; k < NUM_SPECIES; k++) {
+            (JSPSmat[tid])[k * (NUM_SPECIES + 1) + i] *= mw[i] / mw[k];
+          }
+          (JSPSmat[tid])[i * (NUM_SPECIES + 1) + NUM_SPECIES] /= mw[i];
+        }
+        for (int i = 0; i < NUM_SPECIES; i++) {
+          (JSPSmat[tid])[NUM_SPECIES * (NUM_SPECIES + 1) + i] *= mw[i];
+        }
+        temp_save_lcl = temp;
+      } else {
+        // if not: copy the one from prev cell
+        for (int i = 0; i < NUM_SPECIES + 1; i++) {
+          for (int k = 0; k < NUM_SPECIES + 1; k++) {
+            (JSPSmat[tid])[k * (NUM_SPECIES + 1) + i] =
+              (JSPSmat[tid - 1])[k * (NUM_SPECIES + 1) + i];
+          }
+        }
+      }
+#endif
+
     }
 
     *jcurPtr = SUNTRUE;
@@ -521,17 +559,13 @@ Precond_custom(
       auto eos = pele::physics::PhysicsType::eos();
       eos.RTY2C(rho, temp, massfrac, activity);
 
+#ifdef PELE_ROLL_JAC
       // Do we recompute Jac ?
       if (fabs(temp - temp_save_lcl) > 1.0) {
         // Formalism
         int consP =
           static_cast<int>(reactor_type == ReactorTypes::h_reactor_type);
-#ifdef PELE_ROLL_JAC
         DWDOT_SIMPLIFIED_ROLL(JSPSmat[tid], activity, &temp, &consP);
-#else
-        DWDOT_SIMPLIFIED(JSPSmat[tid], activity, &temp, &consP);
-#endif
-
         for (int i = 0; i < NUM_SPECIES; i++) {
           for (int k = 0; k < NUM_SPECIES; k++) {
             (JSPSmat[tid])[k * (NUM_SPECIES + 1) + i] *= mw[i] / mw[k];
@@ -551,6 +585,33 @@ Precond_custom(
           }
         }
       }
+#else
+      // Do we recompute Jac ?
+      if (fabs(temp - temp_save_lcl) > 1.0) {
+        // Formalism
+        int consP =
+          static_cast<int>(reactor_type == ReactorTypes::h_reactor_type);
+        DWDOT_SIMPLIFIED(JSPSmat[tid], activity, &temp, &consP);
+        for (int i = 0; i < NUM_SPECIES; i++) {
+          for (int k = 0; k < NUM_SPECIES; k++) {
+            (JSPSmat[tid])[k * (NUM_SPECIES + 1) + i] *= mw[i] / mw[k];
+          }
+          (JSPSmat[tid])[i * (NUM_SPECIES + 1) + NUM_SPECIES] /= mw[i];
+        }
+        for (int i = 0; i < NUM_SPECIES; i++) {
+          (JSPSmat[tid])[NUM_SPECIES * (NUM_SPECIES + 1) + i] *= mw[i];
+        }
+        temp_save_lcl = temp;
+      } else {
+        // if not: copy the one from prev cell
+        for (int i = 0; i < NUM_SPECIES + 1; i++) {
+          for (int k = 0; k < NUM_SPECIES + 1; k++) {
+            (JSPSmat[tid])[k * (NUM_SPECIES + 1) + i] =
+              (JSPSmat[tid - 1])[k * (NUM_SPECIES + 1) + i];
+          }
+        }
+      }
+#endif
     }
     *jcurPtr = SUNTRUE;
   }

--- a/Reactions/ReactorCvodePreconditioner.cpp
+++ b/Reactions/ReactorCvodePreconditioner.cpp
@@ -219,14 +219,14 @@ Precond(
     SUNDlsMat_denseScale(0.0, Jbd[0][0], NUM_SPECIES + 1, NUM_SPECIES + 1);
     for (int i = 0; i < NUM_SPECIES; i++) {
       for (int k = 0; k < NUM_SPECIES; k++) {
-        (Jbd[0][0])[k][i] = Jmat[k * (NUM_SPECIES + 1) + i] * mw[i] / mw[k];
+        (Jbd[0][0])[k][i] = Jmat[i * (NUM_SPECIES + 1) + k] * mw[i] / mw[k];
       }
       (Jbd[0][0])[i][NUM_SPECIES] =
-        Jmat[i * (NUM_SPECIES + 1) + NUM_SPECIES] / mw[i];
+        Jmat[NUM_SPECIES * (NUM_SPECIES + 1) + i] / mw[i];
     }
     for (int i = 0; i < NUM_SPECIES; i++) {
       (Jbd[0][0])[NUM_SPECIES][i] =
-        Jmat[NUM_SPECIES * (NUM_SPECIES + 1) + i] * mw[i];
+        Jmat[i * (NUM_SPECIES + 1) + NUM_SPECIES] * mw[i];
     }
     (Jbd[0][0])[NUM_SPECIES][NUM_SPECIES] =
       Jmat[(NUM_SPECIES + 1) * (NUM_SPECIES + 1) - 1];
@@ -370,20 +370,20 @@ Precond_sparse(
         DWDOT_SIMPLIFIED_ROLL(JSPSmat[tid], activity, &temp, &consP);
         for (int i = 0; i < NUM_SPECIES; i++) {
           for (int k = 0; k < NUM_SPECIES; k++) {
-            (JSPSmat[tid])[k * (NUM_SPECIES + 1) + i] *= mw[i] / mw[k];
+            (JSPSmat[tid])[i * (NUM_SPECIES + 1) + k] *= mw[i] / mw[k];
           }
-          (JSPSmat[tid])[i * (NUM_SPECIES + 1) + NUM_SPECIES] /= mw[i];
+          (JSPSmat[tid])[NUM_SPECIES * (NUM_SPECIES + 1) + i] /= mw[i];
         }
         for (int i = 0; i < NUM_SPECIES; i++) {
-          (JSPSmat[tid])[NUM_SPECIES * (NUM_SPECIES + 1) + i] *= mw[i];
+          (JSPSmat[tid])[i * (NUM_SPECIES + 1) + NUM_SPECIES] *= mw[i];
         }
         temp_save_lcl = temp;
       } else {
         // if not: copy the one from prev cell
         for (int i = 0; i < NUM_SPECIES + 1; i++) {
           for (int k = 0; k < NUM_SPECIES + 1; k++) {
-            (JSPSmat[tid])[k * (NUM_SPECIES + 1) + i] =
-              (JSPSmat[tid - 1])[k * (NUM_SPECIES + 1) + i];
+            (JSPSmat[tid])[i * (NUM_SPECIES + 1) + k] =
+              (JSPSmat[tid - 1])[i * (NUM_SPECIES + 1) + k];
           }
         }
       }
@@ -568,20 +568,20 @@ Precond_custom(
         DWDOT_SIMPLIFIED_ROLL(JSPSmat[tid], activity, &temp, &consP);
         for (int i = 0; i < NUM_SPECIES; i++) {
           for (int k = 0; k < NUM_SPECIES; k++) {
-            (JSPSmat[tid])[k * (NUM_SPECIES + 1) + i] *= mw[i] / mw[k];
+            (JSPSmat[tid])[i * (NUM_SPECIES + 1) + k] *= mw[i] / mw[k];
           }
-          (JSPSmat[tid])[i * (NUM_SPECIES + 1) + NUM_SPECIES] /= mw[i];
+          (JSPSmat[tid])[NUM_SPECIES * (NUM_SPECIES + 1) + i] /= mw[i];
         }
         for (int i = 0; i < NUM_SPECIES; i++) {
-          (JSPSmat[tid])[NUM_SPECIES * (NUM_SPECIES + 1) + i] *= mw[i];
+          (JSPSmat[tid])[i * (NUM_SPECIES + 1) + NUM_SPECIES] *= mw[i];
         }
         temp_save_lcl = temp;
       } else {
         // if not: copy the one from prev cell
         for (int i = 0; i < NUM_SPECIES + 1; i++) {
           for (int k = 0; k < NUM_SPECIES + 1; k++) {
-            (JSPSmat[tid])[k * (NUM_SPECIES + 1) + i] =
-              (JSPSmat[tid - 1])[k * (NUM_SPECIES + 1) + i];
+            (JSPSmat[tid])[i * (NUM_SPECIES + 1) + k] =
+              (JSPSmat[tid - 1])[i * (NUM_SPECIES + 1) + k];
           }
         }
       }

--- a/Reactions/ReactorCvodePreconditioner.cpp
+++ b/Reactions/ReactorCvodePreconditioner.cpp
@@ -213,7 +213,11 @@ Precond(
     eos.RTY2C(rho, temp, massfrac, activity);
     int consP = static_cast<int>(reactor_type == ReactorTypes::h_reactor_type);
     amrex::Real Jmat[(NUM_SPECIES + 1) * (NUM_SPECIES + 1)] = {0.0};
+#ifdef PELE_ROLL_JAC
+    DWDOT_SIMPLIFIED_ROLL(Jmat, activity, &temp, &consP);
+#else
     DWDOT_SIMPLIFIED(Jmat, activity, &temp, &consP);
+#endif
 
     // Scale Jacobian.  Load into P.
     SUNDlsMat_denseScale(0.0, Jbd[0][0], NUM_SPECIES + 1, NUM_SPECIES + 1);
@@ -347,7 +351,11 @@ Precond_sparse(
       if (fabs(temp - temp_save_lcl) > 1.0) {
         // Formalism
         int consP = reactor_type == ReactorTypes::h_reactor_type;
+#ifdef PELE_ROLL_JAC
+        DWDOT_SIMPLIFIED_ROLL(JSPSmat[tid], activity, &temp, &consP);
+#else
         DWDOT_SIMPLIFIED(JSPSmat[tid], activity, &temp, &consP);
+#endif
 
         for (int i = 0; i < NUM_SPECIES; i++) {
           for (int k = 0; k < NUM_SPECIES; k++) {
@@ -518,7 +526,11 @@ Precond_custom(
         // Formalism
         int consP =
           static_cast<int>(reactor_type == ReactorTypes::h_reactor_type);
+#ifdef PELE_ROLL_JAC
+        DWDOT_SIMPLIFIED_ROLL(JSPSmat[tid], activity, &temp, &consP);
+#else
         DWDOT_SIMPLIFIED(JSPSmat[tid], activity, &temp, &consP);
+#endif
 
         for (int i = 0; i < NUM_SPECIES; i++) {
           for (int k = 0; k < NUM_SPECIES; k++) {

--- a/Reactions/ReactorCvodePreconditioner.cpp
+++ b/Reactions/ReactorCvodePreconditioner.cpp
@@ -249,7 +249,6 @@ Precond(
       Jmat[(NUM_SPECIES + 1) * (NUM_SPECIES + 1) - 1];
 #endif
 
-
     SUNDlsMat_denseCopy(Jbd[0][0], P[0][0], NUM_SPECIES + 1, NUM_SPECIES + 1);
 
     *jcurPtr = SUNTRUE;
@@ -413,7 +412,6 @@ Precond_sparse(
         }
       }
 #endif
-
     }
 
     *jcurPtr = SUNTRUE;

--- a/Reactions/ReactorCvodeUtils.H
+++ b/Reactions/ReactorCvodeUtils.H
@@ -185,10 +185,10 @@ fKernelComputeallAJ(
   amrex::Real* csr_val_cell = csr_val_arg + jac_offset;
   for (int i = 0; i < NUM_SPECIES; i++) {
     for (int k = 0; k < NUM_SPECIES; k++) {
-      Jmat_pt[k * neqs + i] *= mw[i] / mw[k];
+      Jmat_pt[i * neqs + k] *= mw[i] / mw[k];
     }
-    Jmat_pt[i * neqs + NUM_SPECIES] /= mw[i];
-    Jmat_pt[NUM_SPECIES * neqs + i] *= mw[i];
+    Jmat_pt[NUM_SPECIES * neqs + i] /= mw[i];
+    Jmat_pt[i * neqs + NUM_SPECIES] *= mw[i];
   }
   for (int i = 1; i < NUM_SPECIES + 2; i++) {
     int nbVals = csr_row_count_d[i] - csr_row_count_d[i - 1];
@@ -201,9 +201,9 @@ fKernelComputeallAJ(
           Jmat_pt[idx * neqs + idx];
       } else {
         csr_val_cell[csr_row_count_d[i - 1] + j - 1] =
-          -gamma * Jmat_pt[idx * neqs + i - 1];
+          -gamma * Jmat_pt[(i-1) * neqs + idx];
         csr_jac_cell[csr_row_count_d[i - 1] + j - 1] =
-          Jmat_pt[idx * neqs + i - 1];
+          Jmat_pt[(i-1) * neqs + idx];
       }
     }
   }
@@ -312,10 +312,10 @@ fKernelComputeAJchem(
   get_mw(mw);
   for (int i = 0; i < NUM_SPECIES; i++) {
     for (int k = 0; k < NUM_SPECIES; k++) {
-      Jmat_pt[k * neqs + i] *= mw[i] / mw[k];
+      Jmat_pt[i * neqs + k] *= mw[i] / mw[k];
     }
-    Jmat_pt[i * neqs + NUM_SPECIES] /= mw[i];
-    Jmat_pt[NUM_SPECIES * neqs + i] *= mw[i];
+    Jmat_pt[NUM_SPECIES * neqs + i] /= mw[i];
+    Jmat_pt[i * neqs + NUM_SPECIES] *= mw[i];
   }
 
   // Fill the sparse outgoing Jacobian matrix
@@ -326,7 +326,7 @@ fKernelComputeAJchem(
     int nbVals = csr_row_count_d[i] - csr_row_count_d[i - 1];
     for (int j = 0; j < nbVals; j++) {
       int idx_cell = csr_col_index_d[csr_row_count_d[i - 1] + j];
-      Jcurr[csr_row_count_d[i - 1] + j] = Jmat_pt[idx_cell * neqs + i - 1];
+      Jcurr[csr_row_count_d[i - 1] + j] = Jmat_pt[(i - 1) * neqs + idx_cell];
     }
   }
 #else
@@ -392,10 +392,10 @@ fKernelDenseAJchem(
 
   for (int i = 0; i < NUM_SPECIES; i++) {
     for (int k = 0; k < NUM_SPECIES; k++) {
-      Jcurr[k * neqs + i] = Jmat_pt[k * neqs + i] * mw[i] / mw[k];
+      Jcurr[k * neqs + i] = Jmat_pt[i * neqs + k] * mw[i] / mw[k];
     }
-    Jcurr[i * neqs + NUM_SPECIES] = Jmat_pt[i * neqs + NUM_SPECIES] / mw[i];
-    Jcurr[NUM_SPECIES * neqs + i] = Jmat_pt[NUM_SPECIES * neqs + i] * mw[i];
+    Jcurr[i * neqs + NUM_SPECIES] = Jmat_pt[NUM_SPECIES * neqs + i] / mw[i];
+    Jcurr[NUM_SPECIES * neqs + i] = Jmat_pt[i * neqs + NUM_SPECIES] * mw[i];
   }
 #else
   // Scale Jacobian and pass into outgoing data ptr.

--- a/Reactions/ReactorCvodeUtils.H
+++ b/Reactions/ReactorCvodeUtils.H
@@ -201,9 +201,9 @@ fKernelComputeallAJ(
           Jmat_pt[idx * neqs + idx];
       } else {
         csr_val_cell[csr_row_count_d[i - 1] + j - 1] =
-          -gamma * Jmat_pt[(i-1) * neqs + idx];
+          -gamma * Jmat_pt[(i - 1) * neqs + idx];
         csr_jac_cell[csr_row_count_d[i - 1] + j - 1] =
-          Jmat_pt[(i-1) * neqs + idx];
+          Jmat_pt[(i - 1) * neqs + idx];
       }
     }
   }

--- a/Reactions/ReactorCvodeUtils.H
+++ b/Reactions/ReactorCvodeUtils.H
@@ -178,8 +178,11 @@ fKernelComputeallAJ(
   eos.RTY2C(rho_pt, temp_pt, massfrac.arr, activity.arr);
 
   int consP = reactor_type == ReactorTypes::h_reactor_type;
+#ifdef PELE_ROLL_JAC
+  DWDOT_SIMPLIFIED_ROLL(Jmat_pt.arr, activity.arr, &temp_pt, &consP);
+#else
   DWDOT_SIMPLIFIED(Jmat_pt.arr, activity.arr, &temp_pt, &consP);
-
+#endif
   int jac_offset = ncell * NNZ;
   amrex::Real* csr_jac_cell = csr_jac_d + jac_offset;
   amrex::Real* csr_val_cell = csr_val_arg + jac_offset;

--- a/Reactions/ReactorCvodeUtils.H
+++ b/Reactions/ReactorCvodeUtils.H
@@ -180,9 +180,6 @@ fKernelComputeallAJ(
   int consP = reactor_type == ReactorTypes::h_reactor_type;
 #ifdef PELE_ROLL_JAC
   DWDOT_SIMPLIFIED_ROLL(Jmat_pt.arr, activity.arr, &temp_pt, &consP);
-#else
-  DWDOT_SIMPLIFIED(Jmat_pt.arr, activity.arr, &temp_pt, &consP);
-#endif
   int jac_offset = ncell * NNZ;
   amrex::Real* csr_jac_cell = csr_jac_d + jac_offset;
   amrex::Real* csr_val_cell = csr_val_arg + jac_offset;
@@ -210,6 +207,36 @@ fKernelComputeallAJ(
       }
     }
   }
+#else
+  DWDOT_SIMPLIFIED(Jmat_pt.arr, activity.arr, &temp_pt, &consP);
+  int jac_offset = ncell * NNZ;
+  amrex::Real* csr_jac_cell = csr_jac_d + jac_offset;
+  amrex::Real* csr_val_cell = csr_val_arg + jac_offset;
+  for (int i = 0; i < NUM_SPECIES; i++) {
+    for (int k = 0; k < NUM_SPECIES; k++) {
+      Jmat_pt[k * neqs + i] *= mw[i] / mw[k];
+    }
+    Jmat_pt[i * neqs + NUM_SPECIES] /= mw[i];
+    Jmat_pt[NUM_SPECIES * neqs + i] *= mw[i];
+  }
+  for (int i = 1; i < NUM_SPECIES + 2; i++) {
+    int nbVals = csr_row_count_d[i] - csr_row_count_d[i - 1];
+    for (int j = 0; j < nbVals; j++) {
+      int idx = csr_col_index_d[csr_row_count_d[i - 1] + j - 1] - 1;
+      if (idx == (i - 1)) {
+        csr_val_cell[csr_row_count_d[i - 1] + j - 1] =
+          1.0 - gamma * Jmat_pt[idx * neqs + idx];
+        csr_jac_cell[csr_row_count_d[i - 1] + j - 1] =
+          Jmat_pt[idx * neqs + idx];
+      } else {
+        csr_val_cell[csr_row_count_d[i - 1] + j - 1] =
+          -gamma * Jmat_pt[idx * neqs + i - 1];
+        csr_jac_cell[csr_row_count_d[i - 1] + j - 1] =
+          Jmat_pt[idx * neqs + i - 1];
+      }
+    }
+  }
+#endif
 }
 
 AMREX_GPU_DEVICE
@@ -279,6 +306,7 @@ fKernelComputeAJchem(
   auto eos = pele::physics::PhysicsType::eos();
   eos.RTY2JAC(rho_pt, temp_pt, massfrac.arr, Jmat_pt.arr, consP);
 
+#ifdef PELE_ROLL_JAC
   // Scale Jacobian
   amrex::Real mw[NUM_SPECIES] = {0.0};
   get_mw(mw);
@@ -301,6 +329,30 @@ fKernelComputeAJchem(
       Jcurr[csr_row_count_d[i - 1] + j] = Jmat_pt[idx_cell * neqs + i - 1];
     }
   }
+#else
+  // Scale Jacobian
+  amrex::Real mw[NUM_SPECIES] = {0.0};
+  get_mw(mw);
+  for (int i = 0; i < NUM_SPECIES; i++) {
+    for (int k = 0; k < NUM_SPECIES; k++) {
+      Jmat_pt[k * neqs + i] *= mw[i] / mw[k];
+    }
+    Jmat_pt[i * neqs + NUM_SPECIES] /= mw[i];
+    Jmat_pt[NUM_SPECIES * neqs + i] *= mw[i];
+  }
+
+  // Fill the sparse outgoing Jacobian matrix
+  int jac_offset = icell * NNZ;
+  amrex::Real* Jcurr = Jdata + jac_offset;
+
+  for (int i = 1; i < NUM_SPECIES + 2; i++) {
+    int nbVals = csr_row_count_d[i] - csr_row_count_d[i - 1];
+    for (int j = 0; j < nbVals; j++) {
+      int idx_cell = csr_col_index_d[csr_row_count_d[i - 1] + j];
+      Jcurr[csr_row_count_d[i - 1] + j] = Jmat_pt[idx_cell * neqs + i - 1];
+    }
+  }
+#endif
 }
 
 AMREX_GPU_DEVICE
@@ -330,6 +382,7 @@ fKernelDenseAJchem(
   auto eos = pele::physics::PhysicsType::eos();
   eos.RTY2JAC(rho_pt, temp_pt, massfrac.arr, Jmat_pt.arr, consP);
 
+#ifdef PELE_ROLL_JAC
   // Scale Jacobian and pass into outgoing data ptr.
   amrex::Real mw[NUM_SPECIES] = {0.0};
   get_mw(mw);
@@ -344,6 +397,22 @@ fKernelDenseAJchem(
     Jcurr[i * neqs + NUM_SPECIES] = Jmat_pt[i * neqs + NUM_SPECIES] / mw[i];
     Jcurr[NUM_SPECIES * neqs + i] = Jmat_pt[NUM_SPECIES * neqs + i] * mw[i];
   }
+#else
+  // Scale Jacobian and pass into outgoing data ptr.
+  amrex::Real mw[NUM_SPECIES] = {0.0};
+  get_mw(mw);
+
+  int jac_offset = icell * (neqs * neqs);
+  amrex::Real* Jcurr = Jdata + jac_offset;
+
+  for (int i = 0; i < NUM_SPECIES; i++) {
+    for (int k = 0; k < NUM_SPECIES; k++) {
+      Jcurr[k * neqs + i] = Jmat_pt[k * neqs + i] * mw[i] / mw[k];
+    }
+    Jcurr[i * neqs + NUM_SPECIES] = Jmat_pt[i * neqs + NUM_SPECIES] / mw[i];
+    Jcurr[NUM_SPECIES * neqs + i] = Jmat_pt[NUM_SPECIES * neqs + i] * mw[i];
+  }
+#endif
 }
 
 #endif

--- a/Support/ceptr/ceptr/ceptr.py
+++ b/Support/ceptr/ceptr/ceptr.py
@@ -10,6 +10,7 @@ import ceptr.converter as converter
 def convert(
     fname,
     jacobian,
+    roll_jacobian,
     qss_format_input,
     qss_symbolic_jac,
 ):
@@ -18,6 +19,7 @@ def convert(
     conv = converter.Converter(
         mechanism,
         jacobian,
+        roll_jacobian,
         qss_format_input,
         qss_symbolic_jac,
     )
@@ -28,6 +30,7 @@ def convert(
 def convert_lst(
     lst,
     jacobian,
+    roll_jacobian,
     qss_format_input,
     qss_symbolic_jac,
 ):
@@ -41,6 +44,7 @@ def convert_lst(
                 convert(
                     mechname,
                     jacobian,
+                    roll_jacobian,
                     qss_format_input,
                     qss_symbolic_jac,
                 )
@@ -79,12 +83,20 @@ def main():
         help="Do not generate a jacobian",
     )
 
+    parser.add_argument(
+        "-rj",
+        "--roll_jacobian",
+        action="store_true",
+        help="Preroll the jacobian",
+    )
+
     args = parser.parse_args()
 
     if args.fname:
         convert(
             args.fname,
             not args.no_jacobian,
+            args.roll_jacobian,
             args.qss_format_input,
             args.qss_symbolic_jacobian,
         )
@@ -92,6 +104,7 @@ def main():
         convert_lst(
             args.lst,
             not args.no_jacobian,
+            args.roll_jacobian,
             args.qss_format_input,
             args.qss_symbolic_jacobian,
         )

--- a/Support/ceptr/ceptr/converter.py
+++ b/Support/ceptr/ceptr/converter.py
@@ -211,7 +211,7 @@ class Converter:
             cck.ckncf(cpp, self.mechanism, self.species_info)
             cck.cksyme_str(cpp, self.mechanism, self.species_info)
             cck.cksyms_str(cpp, self.mechanism, self.species_info)
-            csp.sparsity(cpp, self.species_info)
+            csp.sparsity(cpp, self.species_info, roll_jacobian=self.roll_jacobian)
 
             # This is for the header file
             cw.writer(hdr, "#ifndef MECHANISM_H")

--- a/Support/ceptr/ceptr/converter.py
+++ b/Support/ceptr/ceptr/converter.py
@@ -27,12 +27,14 @@ class Converter:
         self,
         mechanism,
         jacobian=True,
+        roll_jacobian=False,
         qss_format_input=None,
         qss_symbolic_jacobian=False,
     ):
         self.mechanism = mechanism
 
         self.jacobian = jacobian
+        self.roll_jacobian = roll_jacobian
 
         # Symbolic computations
         self.qss_symbolic_jacobian = qss_symbolic_jacobian
@@ -375,6 +377,7 @@ class Converter:
                     self.species_info,
                     self.reaction_info,
                     jacobian=self.jacobian,
+                    roll_jacobian=self.roll_jacobian,
                     precond=True,
                     syms=self.syms,
                 )
@@ -383,6 +386,7 @@ class Converter:
                     self.mechanism,
                     self.species_info,
                     self.reaction_info,
+                    roll_jacobian=self.roll_jacobian,
                     precond=True,
                 )
                 # Analytical jacobian on GPU -- not used on CPU, define in mechanism.cpp
@@ -393,6 +397,7 @@ class Converter:
                         self.species_info,
                         self.reaction_info,
                         jacobian=self.jacobian,
+                        roll_jacobian=self.roll_jacobian,
                         syms=self.syms,
                     )
                 else:
@@ -402,9 +407,14 @@ class Converter:
                         self.species_info,
                         self.reaction_info,
                         jacobian=self.jacobian,
+                        roll_jacobian=self.roll_jacobian,
                     )
                 cj.dproduction_rate(
-                    hdr, self.mechanism, self.species_info, self.reaction_info
+                    hdr,
+                    self.mechanism,
+                    self.species_info,
+                    self.reaction_info,
+                    roll_jacobian=self.roll_jacobian,
                 )
 
             else:
@@ -430,6 +440,7 @@ class Converter:
                     self.species_info,
                     self.reaction_info,
                     jacobian=self.jacobian,
+                    roll_jacobian=self.roll_jacobian,
                     precond=True,
                 )
                 cj.dproduction_rate(
@@ -437,6 +448,7 @@ class Converter:
                     self.mechanism,
                     self.species_info,
                     self.reaction_info,
+                    roll_jacobian=self.roll_jacobian,
                     precond=True,
                 )
                 # Analytical jacobian on GPU -- not used on CPU, define in mechanism.cpp
@@ -446,9 +458,14 @@ class Converter:
                     self.species_info,
                     self.reaction_info,
                     jacobian=self.jacobian,
+                    roll_jacobian=self.roll_jacobian,
                 )
                 cj.dproduction_rate(
-                    hdr, self.mechanism, self.species_info, self.reaction_info
+                    hdr,
+                    self.mechanism,
+                    self.species_info,
+                    self.reaction_info,
+                    roll_jacobian=self.roll_jacobian,
                 )
 
             # Transport

--- a/Support/ceptr/ceptr/converter.py
+++ b/Support/ceptr/ceptr/converter.py
@@ -211,7 +211,9 @@ class Converter:
             cck.ckncf(cpp, self.mechanism, self.species_info)
             cck.cksyme_str(cpp, self.mechanism, self.species_info)
             cck.cksyms_str(cpp, self.mechanism, self.species_info)
-            csp.sparsity(cpp, self.species_info, roll_jacobian=self.roll_jacobian)
+            csp.sparsity(
+                cpp, self.species_info, roll_jacobian=self.roll_jacobian
+            )
 
             # This is for the header file
             cw.writer(hdr, "#ifndef MECHANISM_H")

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -33,30 +33,58 @@ def ajac(
     cw.writer(fstream, "AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE")
     if n_reactions > 0:
         if precond:
-            cw.writer(
-                fstream,
-                "void aJacobian_precond(amrex::Real *  J, const amrex::Real *  sc,"
-                " const amrex::Real T, const int HP)",
-            )
+            if not roll_jacobian:
+                cw.writer(
+                    fstream,
+                    "void aJacobian_precond(amrex::Real *  J, const amrex::Real *  sc,"
+                    " const amrex::Real T, const int HP)",
+                )
+            else:
+                cw.writer(
+                    fstream,
+                    "void aJacobian_precond_roll(amrex::Real *  J, const amrex::Real *  sc,"
+                    " const amrex::Real T, const int HP)",
+                )
         else:
-            cw.writer(
-                fstream,
-                "void aJacobian(amrex::Real * J, const amrex::Real * sc, const amrex::Real T,"
-                " const int consP)",
-            )
+            if not roll_jacobian:
+                cw.writer(
+                    fstream,
+                    "void aJacobian(amrex::Real * J, const amrex::Real * sc, const amrex::Real T,"
+                    " const int consP)",
+                )
+            else:
+                cw.writer(
+                    fstream,
+                    "void aJacobian_roll(amrex::Real * J, const amrex::Real * sc, const amrex::Real T,"
+                    " const int consP)",
+                )
     else:
         if precond:
-            cw.writer(
-                fstream,
-                "void aJacobian_precond(amrex::Real *  J, const amrex::Real *  /*sc*/,"
-                " const amrex::Real /*T*/, const int /*HP*/)",
-            )
+            if not roll_jacobian:
+                cw.writer(
+                    fstream,
+                    "void aJacobian_precond(amrex::Real *  J, const amrex::Real *  /*sc*/,"
+                    " const amrex::Real /*T*/, const int /*HP*/)",
+                )
+            else:
+                cw.writer(
+                    fstream,
+                    "void aJacobian_precond_roll(amrex::Real *  J, const amrex::Real *  /*sc*/,"
+                    " const amrex::Real /*T*/, const int /*HP*/)",
+                )
         else:
-            cw.writer(
-                fstream,
-                "void aJacobian(amrex::Real * J, const amrex::Real * /*sc*/,"
-                " const amrex::Real /*T*/, const int /*consP*/)",
-            )
+            if not roll_jacobian:
+                cw.writer(
+                    fstream,
+                    "void aJacobian(amrex::Real * J, const amrex::Real * /*sc*/,"
+                    " const amrex::Real /*T*/, const int /*consP*/)",
+                )
+            else:
+                cw.writer(
+                    fstream,
+                    "void aJacobian_roll(amrex::Real * J, const amrex::Real * /*sc*/,"
+                    " const amrex::Real /*T*/, const int /*consP*/)",
+                )
     cw.writer(fstream, "{")
 
     cw.writer(fstream)
@@ -351,11 +379,18 @@ def ajac_symbolic(
     cw.writer(fstream)
 
     # main
-    cw.writer(
-        fstream,
-        "AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void  aJacobian(amrex::Real"
-        " * J, amrex::Real * sc, amrex::Real T, const int consP)",
-    )
+    if not roll_jacobian:
+        cw.writer(
+            fstream,
+            "AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void  aJacobian(amrex::Real"
+            " * J, amrex::Real * sc, amrex::Real T, const int consP)",
+        )
+    else:
+        cw.writer(
+            fstream,
+            "AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void  aJacobian_roll(amrex::Real"
+            " * J, amrex::Real * sc, amrex::Real T, const int consP)",
+        )
     cw.writer(fstream, "{")
 
     if not jacobian:
@@ -1730,9 +1765,15 @@ def dproduction_rate(
 
     cw.writer(fstream)
     if precond:
-        cw.writer(fstream, "aJacobian_precond(J, c, *Tp, *HP);")
+        if not roll_jacobian:
+            cw.writer(fstream, "aJacobian_precond(J, c, *Tp, *HP);")
+        else:
+            cw.writer(fstream, "aJacobian_precond_roll(J, c, *Tp, *HP);")
     else:
-        cw.writer(fstream, "aJacobian(J, c, *Tp, *consP);")
+        if not roll_jacobian:
+            cw.writer(fstream, "aJacobian(J, c, *Tp, *consP);")
+        else:
+            cw.writer(fstream, "aJacobian_roll(J, c, *Tp, *consP);")
 
     cw.writer(fstream)
     cw.writer(fstream, cw.comment("dwdot[k]/dT"))

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -15,6 +15,7 @@ def ajac(
     species_info,
     reaction_info,
     jacobian=True,
+    roll_jacobian=False,
     precond=False,
     syms=None,
 ):
@@ -228,6 +229,7 @@ def ajac(
                     reaction_info,
                     reaction,
                     orig_idx,
+                    roll_jacobian=roll_jacobian,
                     precond=precond,
                     syms=syms,
                 )
@@ -316,6 +318,7 @@ def ajac_symbolic(
     species_info,
     reaction_info,
     jacobian=True,
+    roll_jacobian=False,
     syms=None,
 ):
     """Print the Jacobian obtained from symbolic recording."""
@@ -613,6 +616,7 @@ def ajac_reaction_d(
     reaction_info,
     reaction,
     orig_idx,
+    roll_jacobian=False,
     precond=False,
     syms=None,
 ):
@@ -1599,7 +1603,12 @@ def dphase_space(mechanism, species_info, reagents, r, syms):
 
 
 def dproduction_rate(
-    fstream, mechanism, species_info, reaction_info, precond=False
+    fstream,
+    mechanism,
+    species_info,
+    reaction_info,
+    roll_jacobian=False,
+    precond=False,
 ):
     """Write the reaction jacobian."""
     n_species = species_info.n_species

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -36,26 +36,30 @@ def ajac(
             if not roll_jacobian:
                 cw.writer(
                     fstream,
-                    "void aJacobian_precond(amrex::Real *  J, const amrex::Real *  sc,"
+                    "void aJacobian_precond"
+                    "(amrex::Real *  J, const amrex::Real *  sc,"
                     " const amrex::Real T, const int HP)",
                 )
             else:
                 cw.writer(
                     fstream,
-                    "void aJacobian_precond_roll(amrex::Real *  J, const amrex::Real *  sc,"
+                    "void aJacobian_precond_roll"
+                    "(amrex::Real *  J, const amrex::Real *  sc,"
                     " const amrex::Real T, const int HP)",
                 )
         else:
             if not roll_jacobian:
                 cw.writer(
                     fstream,
-                    "void aJacobian(amrex::Real * J, const amrex::Real * sc, const amrex::Real T,"
+                    "void aJacobian"
+                    "(amrex::Real * J, const amrex::Real * sc, const amrex::Real T,"
                     " const int consP)",
                 )
             else:
                 cw.writer(
                     fstream,
-                    "void aJacobian_roll(amrex::Real * J, const amrex::Real * sc, const amrex::Real T,"
+                    "void aJacobian_roll"
+                    "(amrex::Real * J, const amrex::Real * sc, const amrex::Real T,"
                     " const int consP)",
                 )
     else:
@@ -63,26 +67,30 @@ def ajac(
             if not roll_jacobian:
                 cw.writer(
                     fstream,
-                    "void aJacobian_precond(amrex::Real *  J, const amrex::Real *  /*sc*/,"
+                    "void aJacobian_precond"
+                    "(amrex::Real *  J, const amrex::Real *  /*sc*/,"
                     " const amrex::Real /*T*/, const int /*HP*/)",
                 )
             else:
                 cw.writer(
                     fstream,
-                    "void aJacobian_precond_roll(amrex::Real *  J, const amrex::Real *  /*sc*/,"
+                    "void aJacobian_precond_roll"
+                    "(amrex::Real *  J, const amrex::Real *  /*sc*/,"
                     " const amrex::Real /*T*/, const int /*HP*/)",
                 )
         else:
             if not roll_jacobian:
                 cw.writer(
                     fstream,
-                    "void aJacobian(amrex::Real * J, const amrex::Real * /*sc*/,"
+                    "void aJacobian"
+                    "(amrex::Real * J, const amrex::Real * /*sc*/,"
                     " const amrex::Real /*T*/, const int /*consP*/)",
                 )
             else:
                 cw.writer(
                     fstream,
-                    "void aJacobian_roll(amrex::Real * J, const amrex::Real * /*sc*/,"
+                    "void aJacobian_roll"
+                    "(amrex::Real * J, const amrex::Real * /*sc*/,"
                     " const amrex::Real /*T*/, const int /*consP*/)",
                 )
     cw.writer(fstream, "{")
@@ -327,11 +335,13 @@ def ajac(
             # Access dwdot[m]/dx[k]
             if not roll_jacobian:
                 cw.writer(
-                    fstream, "dehmixdc += eh_RT[m]*J[k*%s+m];" % (n_species + 1)
+                    fstream,
+                    "dehmixdc += eh_RT[m]*J[k*%s+m];" % (n_species + 1),
                 )
             else:
                 cw.writer(
-                    fstream, "dehmixdc += eh_RT[m]*J[m*%s+k];" % (n_species + 1)
+                    fstream,
+                    "dehmixdc += eh_RT[m]*J[m*%s+k];" % (n_species + 1),
                 )
             cw.writer(fstream, "}")
             # Access dTdot/dx[k]
@@ -570,9 +580,13 @@ def ajac_symbolic(
             # Now write out the species jacobian terms
             cw.writer(fstream, cw.comment("Species terms"))
             if syms.hformat == "cpu":
-                syms.write_symjac_to_cpp_cpu(species_info, cw, fstream, roll_jacobian=roll_jacobian)
+                syms.write_symjac_to_cpp_cpu(
+                    species_info, cw, fstream, roll_jacobian=roll_jacobian
+                )
             else:
-                syms.write_symjac_to_cpp_gpu(species_info, cw, fstream, roll_jacobian=roll_jacobian)
+                syms.write_symjac_to_cpp_gpu(
+                    species_info, cw, fstream, roll_jacobian=roll_jacobian
+                )
 
             cw.writer(fstream)
 
@@ -675,7 +689,7 @@ def ajac_symbolic(
         cw.writer(
             fstream,
             "J[%d+k] = tmp2*c_R[k] - tmp3*dehmixdc;"
-            % ((n_species + 1)*n_species),
+            % ((n_species + 1) * n_species),
         )
     cw.writer(fstream, "}")
 

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -570,9 +570,9 @@ def ajac_symbolic(
             # Now write out the species jacobian terms
             cw.writer(fstream, cw.comment("Species terms"))
             if syms.hformat == "cpu":
-                syms.write_symjac_to_cpp_cpu(species_info, cw, fstream)
+                syms.write_symjac_to_cpp_cpu(species_info, cw, fstream, roll_jacobian=roll_jacobian)
             else:
-                syms.write_symjac_to_cpp_gpu(species_info, cw, fstream)
+                syms.write_symjac_to_cpp_gpu(species_info, cw, fstream, roll_jacobian=roll_jacobian)
 
             cw.writer(fstream)
 

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -1742,19 +1742,34 @@ def dproduction_rate(
                 " preconditioning)"
             ),
         )
-        cw.writer(
-            fstream,
-            "AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void"
-            " DWDOT_SIMPLIFIED(amrex::Real *  J, const amrex::Real *  sc,"
-            " const amrex::Real *  Tp, const int * HP)",
-        )
+        if not roll_jacobian:
+            cw.writer(
+                fstream,
+                "AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void"
+                " DWDOT_SIMPLIFIED(amrex::Real *  J, const amrex::Real *  sc,"
+                " const amrex::Real *  Tp, const int * HP)",
+            )
+        else:
+            cw.writer(
+                fstream,
+                "AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void"
+                " DWDOT_SIMPLIFIED_ROLL(amrex::Real *  J, const amrex::Real *  sc,"
+                " const amrex::Real *  Tp, const int * HP)",
+            )
     else:
         cw.writer(fstream, cw.comment("compute the reaction Jacobian"))
-        cw.writer(
-            fstream,
-            "AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void DWDOT(amrex::Real *"
-            "  J, const amrex::Real *  sc, const amrex::Real *  Tp, const int * consP)",
-        )
+        if not roll_jacobian:
+            cw.writer(
+                fstream,
+                "AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void DWDOT(amrex::Real *"
+                "  J, const amrex::Real *  sc, const amrex::Real *  Tp, const int * consP)",
+            )
+        else:
+            cw.writer(
+                fstream,
+                "AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void DWDOT_ROLL(amrex::Real *"
+                "  J, const amrex::Real *  sc, const amrex::Real *  Tp, const int * consP)",
+            )
 
     cw.writer(fstream, "{")
     cw.writer(fstream, "amrex::Real c[%d];" % (n_species))

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -1779,8 +1779,16 @@ def dproduction_rate(
     cw.writer(fstream, cw.comment("dwdot[k]/dT"))
     cw.writer(fstream, cw.comment("dTdot/d[X]"))
     cw.writer(fstream, "for (int k=0; k<%d; k++) {" % n_species)
-    cw.writer(fstream, "J[%d+k] *= 1.e-6;" % (n_species * (n_species + 1)))
-    cw.writer(fstream, "J[k*%d+%d] *= 1.e6;" % (n_species + 1, n_species))
+    # Access dwdot[k]/dT
+    if not roll_jacobian:
+        cw.writer(fstream, "J[%d+k] *= 1.e-6;" % (n_species * (n_species + 1)))
+    else:
+        cw.writer(fstream, "J[k*%d+%d] *= 1.e-6;" % (n_species + 1, n_species))
+    # Access dTdot/dx[k]
+    if not roll_jacobian:
+        cw.writer(fstream, "J[k*%d+%d] *= 1.e6;" % (n_species + 1, n_species))
+    else:
+        cw.writer(fstream, "J[%d+k] *= 1.e6;" % (n_species * (n_species + 1)))
     cw.writer(fstream, "}")
 
     cw.writer(fstream)

--- a/Support/ceptr/ceptr/sparsity.py
+++ b/Support/ceptr/ceptr/sparsity.py
@@ -2,7 +2,7 @@
 import ceptr.writer as cw
 
 
-def sparsity(fstream, species_info):
+def sparsity(fstream, species_info, roll_jacobian=False):
     """Write sparsity pattern of Jacobian."""
     n_species = species_info.n_species
 
@@ -27,7 +27,10 @@ def sparsity(fstream, species_info):
     cw.writer(fstream, "for (int n=0; n<%d; n++) {" % (n_species))
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
     cw.writer(fstream, "}")
-    cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+    if not roll_jacobian:
+        cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+    else:
+        cw.writer(fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);")
     cw.writer(fstream)
 
     cw.writer(fstream, "int nJdata_tmp = 0;")
@@ -74,7 +77,10 @@ def sparsity(fstream, species_info):
     cw.writer(fstream, "for (int n=0; n<%d; n++) {" % (n_species))
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
     cw.writer(fstream, "}")
-    cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+    if not roll_jacobian:
+        cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+    else:
+        cw.writer(fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);")
     cw.writer(fstream)
 
     cw.writer(fstream, "int nJdata_tmp = 0;")
@@ -131,9 +137,14 @@ def sparsity(fstream, species_info):
     cw.writer(fstream, "for (int n=0; n<%d; n++) {" % (n_species))
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
     cw.writer(fstream, "}")
-    cw.writer(
-        fstream, "aJacobian_precond(Jac.data(), conc.data(), 1500.0, *consP);"
-    )
+    if not roll_jacobian:
+        cw.writer(
+            fstream, "aJacobian_precond(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
+    else:
+        cw.writer(
+            fstream, "aJacobian_precond_roll(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     cw.writer(fstream)
 
     cw.writer(fstream, "int nJdata_tmp = 0;")
@@ -190,7 +201,10 @@ def sparsity(fstream, species_info):
     cw.writer(fstream, "for (int n=0; n<%d; n++) {" % (n_species))
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
     cw.writer(fstream, "}")
-    cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+    if not roll_jacobian:
+        cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+    else:
+        cw.writer(fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);")
     cw.writer(fstream)
 
     cw.writer(fstream, "colPtrs[0] = 0;")
@@ -244,7 +258,10 @@ def sparsity(fstream, species_info):
     cw.writer(fstream, "for (int n=0; n<%d; n++) {" % (n_species))
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
     cw.writer(fstream, "}")
-    cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+    if not roll_jacobian:
+        cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+    else:
+        cw.writer(fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);")
     cw.writer(fstream)
 
     cw.writer(fstream, "if (base == 1) {")
@@ -324,7 +341,10 @@ def sparsity(fstream, species_info):
     cw.writer(fstream, "for (int n=0; n<%d; n++) {" % (n_species))
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
     cw.writer(fstream, "}")
-    cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+    if not roll_jacobian:
+        cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+    else:
+        cw.writer(fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);")
     cw.writer(fstream)
 
     cw.writer(fstream, "if (base == 1) {")
@@ -424,10 +444,15 @@ def sparsity(fstream, species_info):
     )
     cw.writer(fstream, "for (int n=0; n<%d; n++) {" % (n_species))
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
-    cw.writer(fstream, "}")
-    cw.writer(
-        fstream, "aJacobian_precond(Jac.data(), conc.data(), 1500.0, *consP);"
-    )
+    cw.writer(fstream, "}")    
+    if not roll_jacobian:
+        cw.writer(
+            fstream, "aJacobian_precond(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
+    else:
+        cw.writer(
+            fstream, "aJacobian_precond_roll(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     cw.writer(fstream)
 
     cw.writer(fstream, "colPtrs[0] = 0;")
@@ -487,9 +512,14 @@ def sparsity(fstream, species_info):
     cw.writer(fstream, "for (int n=0; n<%d; n++) {" % (n_species))
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
     cw.writer(fstream, "}")
-    cw.writer(
-        fstream, "aJacobian_precond(Jac.data(), conc.data(), 1500.0, *consP);"
-    )
+    if not roll_jacobian:
+        cw.writer(
+            fstream, "aJacobian_precond(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
+    else:
+        cw.writer(
+            fstream, "aJacobian_precond_roll(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     cw.writer(fstream)
 
     cw.writer(fstream, "if (base == 1) {")

--- a/Support/ceptr/ceptr/sparsity.py
+++ b/Support/ceptr/ceptr/sparsity.py
@@ -28,9 +28,13 @@ def sparsity(fstream, species_info, roll_jacobian=False):
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
     cw.writer(fstream, "}")
     if not roll_jacobian:
-        cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+        cw.writer(
+            fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     else:
-        cw.writer(fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);")
+        cw.writer(
+            fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     cw.writer(fstream)
 
     cw.writer(fstream, "int nJdata_tmp = 0;")
@@ -78,9 +82,13 @@ def sparsity(fstream, species_info, roll_jacobian=False):
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
     cw.writer(fstream, "}")
     if not roll_jacobian:
-        cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+        cw.writer(
+            fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     else:
-        cw.writer(fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);")
+        cw.writer(
+            fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     cw.writer(fstream)
 
     cw.writer(fstream, "int nJdata_tmp = 0;")
@@ -139,11 +147,13 @@ def sparsity(fstream, species_info, roll_jacobian=False):
     cw.writer(fstream, "}")
     if not roll_jacobian:
         cw.writer(
-            fstream, "aJacobian_precond(Jac.data(), conc.data(), 1500.0, *consP);"
+            fstream,
+            "aJacobian_precond(Jac.data(), conc.data(), 1500.0, *consP);",
         )
     else:
         cw.writer(
-            fstream, "aJacobian_precond_roll(Jac.data(), conc.data(), 1500.0, *consP);"
+            fstream,
+            "aJacobian_precond_roll(Jac.data(), conc.data(), 1500.0, *consP);",
         )
     cw.writer(fstream)
 
@@ -202,9 +212,13 @@ def sparsity(fstream, species_info, roll_jacobian=False):
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
     cw.writer(fstream, "}")
     if not roll_jacobian:
-        cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+        cw.writer(
+            fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     else:
-        cw.writer(fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);")
+        cw.writer(
+            fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     cw.writer(fstream)
 
     cw.writer(fstream, "colPtrs[0] = 0;")
@@ -259,9 +273,13 @@ def sparsity(fstream, species_info, roll_jacobian=False):
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
     cw.writer(fstream, "}")
     if not roll_jacobian:
-        cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+        cw.writer(
+            fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     else:
-        cw.writer(fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);")
+        cw.writer(
+            fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     cw.writer(fstream)
 
     cw.writer(fstream, "if (base == 1) {")
@@ -342,9 +360,13 @@ def sparsity(fstream, species_info, roll_jacobian=False):
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
     cw.writer(fstream, "}")
     if not roll_jacobian:
-        cw.writer(fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);")
+        cw.writer(
+            fstream, "aJacobian(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     else:
-        cw.writer(fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);")
+        cw.writer(
+            fstream, "aJacobian_roll(Jac.data(), conc.data(), 1500.0, *consP);"
+        )
     cw.writer(fstream)
 
     cw.writer(fstream, "if (base == 1) {")
@@ -444,14 +466,16 @@ def sparsity(fstream, species_info, roll_jacobian=False):
     )
     cw.writer(fstream, "for (int n=0; n<%d; n++) {" % (n_species))
     cw.writer(fstream, "    conc[n] = 1.0/ %f ;" % (n_species))
-    cw.writer(fstream, "}")    
+    cw.writer(fstream, "}")
     if not roll_jacobian:
         cw.writer(
-            fstream, "aJacobian_precond(Jac.data(), conc.data(), 1500.0, *consP);"
+            fstream,
+            "aJacobian_precond(Jac.data(), conc.data(), 1500.0, *consP);",
         )
     else:
         cw.writer(
-            fstream, "aJacobian_precond_roll(Jac.data(), conc.data(), 1500.0, *consP);"
+            fstream,
+            "aJacobian_precond_roll(Jac.data(), conc.data(), 1500.0, *consP);",
         )
     cw.writer(fstream)
 
@@ -514,11 +538,13 @@ def sparsity(fstream, species_info, roll_jacobian=False):
     cw.writer(fstream, "}")
     if not roll_jacobian:
         cw.writer(
-            fstream, "aJacobian_precond(Jac.data(), conc.data(), 1500.0, *consP);"
+            fstream,
+            "aJacobian_precond(Jac.data(), conc.data(), 1500.0, *consP);",
         )
     else:
         cw.writer(
-            fstream, "aJacobian_precond_roll(Jac.data(), conc.data(), 1500.0, *consP);"
+            fstream,
+            "aJacobian_precond_roll(Jac.data(), conc.data(), 1500.0, *consP);",
         )
     cw.writer(fstream)
 

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -1138,14 +1138,24 @@ class SymbolicMath:
                 for ics in range(len(chain_string) - 1):
                     final_string += f" + {chain_string[ics+1]}"
 
-                cw.writer(
-                    fstream,
-                    "J[%s] = %s;"
-                    % (
-                        f"""{(species_info.n_species+1)*scnum + item["number"]}""",
-                        final_string,
-                    ),
-                )
+                if not roll_jacobian:
+                    cw.writer(
+                        fstream,
+                        "J[%s] = %s;"
+                        % (
+                            f"""{(species_info.n_species+1)*scnum + item["number"]}""",
+                            final_string,
+                        ),
+                    )
+                else:
+                    cw.writer(
+                        fstream,
+                        "J[%s] = %s;"
+                        % (
+                            f"""{(species_info.n_species+1)*item["number"] + scnum}""",
+                            final_string,
+                        ),
+                    )
 
     def write_symjac_to_cpp_gpu(self, species_info, cw, fstream):
         """Write species jacobian terms as functions of common subexpressions.
@@ -1340,14 +1350,24 @@ class SymbolicMath:
                 else:
                     final_string = start_string
 
-                cw.writer(
-                    fstream,
-                    "J[%s] = %s;"
-                    % (
-                        f"""{(species_info.n_species+1)*sc_item["number"]+wdot_item["number"]}""",
-                        final_string,
-                    ),
-                )
+                if not roll_jacobian:
+                    cw.writer(
+                        fstream,
+                        "J[%s] = %s;"
+                        % (
+                            f"""{(species_info.n_species+1)*sc_item["number"]+wdot_item["number"]}""",
+                            final_string,
+                        ),
+                    )
+                else:
+                    cw.writer(
+                        fstream,
+                        "J[%s] = %s;"
+                        % (
+                            f"""{(species_info.n_species+1)*wdot_item["number"]+sc_item["number"]}""",
+                            final_string,
+                        ),
+                    )
 
     def write_array_to_cpp_no_cse(
         self, list_smp, array_str, cw, fstream, index_list=None

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -966,7 +966,7 @@ class SymbolicMath:
                     ),
                 )
 
-    def write_symjac_to_cpp_cpu(self, species_info, cw, fstream):
+    def write_symjac_to_cpp_cpu(self, species_info, cw, fstream, roll_jacobian=False):
         """Write species jacobian terms as functions of common subexpressions.
 
         Many variables are created to ensure readability.
@@ -1157,7 +1157,7 @@ class SymbolicMath:
                         ),
                     )
 
-    def write_symjac_to_cpp_gpu(self, species_info, cw, fstream):
+    def write_symjac_to_cpp_gpu(self, species_info, cw, fstream, roll_jacobian=False):
         """Write species jacobian terms as functions of common subexpressions.
 
         As little as possible intermediate variables are declared which

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -966,7 +966,9 @@ class SymbolicMath:
                     ),
                 )
 
-    def write_symjac_to_cpp_cpu(self, species_info, cw, fstream, roll_jacobian=False):
+    def write_symjac_to_cpp_cpu(
+        self, species_info, cw, fstream, roll_jacobian=False
+    ):
         """Write species jacobian terms as functions of common subexpressions.
 
         Many variables are created to ensure readability.
@@ -1157,7 +1159,9 @@ class SymbolicMath:
                         ),
                     )
 
-    def write_symjac_to_cpp_gpu(self, species_info, cw, fstream, roll_jacobian=False):
+    def write_symjac_to_cpp_gpu(
+        self, species_info, cw, fstream, roll_jacobian=False
+    ):
         """Write species jacobian terms as functions of common subexpressions.
 
         As little as possible intermediate variables are declared which

--- a/Testing/Exec/Make.PelePhysics
+++ b/Testing/Exec/Make.PelePhysics
@@ -39,6 +39,9 @@ Blocs             += $(PP_SRC_HOME)
 ifeq ($(PELE_COMPILE_AJACOBIAN), TRUE)
   DEFINES += -DPELE_COMPILE_AJACOBIAN
 endif
+ifeq ($(PELE_ROLL_JAC), TRUE)
+  DEFINES += -DPELE_ROLL_JAC
+endif
 
 # EOS
 # Both Fortran and cpp can be loaded for EOS


### PR DESCRIPTION
This is the implementation of the row major Jacobian we discussed.

## CEPTR

- pass an option `-rj`  to signify that the Jacobian needs to be transposed
- Change the name of `DWDOT` to `DWDOT_ROLL` so that the transposed Jacobian can be used only if the correct flags are used (`PELE_ROLL_JAC`)
- When we transpose the Jacobian, we transpose also the precond Jacobian

## EOS

- Call `DWDOT_ROLL` if  `PELE_ROLL_JAC` flag is used. This makes sure that `Reactors` that are fed a transposed Jacobian expect it. Otherwise it would throw an error.

## Reactor

- Transpose the indices when using Jacobian

## Validation

I run a 0D reactor with `dodecane_lu` and `dodecane_lu_qss` (symbolic Jacobian + memory optimization) with CVODE and AJ. I run the transposed and non transposed version. The results seem consistent. The Cantera line is integration of the skeletal mechanism with Cantera. 


![Screen Shot 2023-02-15 at 5 04 45 PM](https://user-images.githubusercontent.com/5544573/219223966-681b2789-90c7-4d9b-8dc0-639089c4d30d.png)

