### PR TITLE
Revert "Use global_(i)mw throughout Eos and Reactors."

### DIFF
--- a/Eos/Fuego.H
+++ b/Eos/Fuego.H
@@ -209,8 +209,10 @@ struct Fuego
     CKYTCR(R, T, Y, C);
     CKWC(T, C, WDOT);
 
+    amrex::Real mw[NUM_SPECIES];
+    get_mw(mw);
     for (int n = 0; n < NUM_SPECIES; n++) {
-      WDOT[n] *= global_mw[n];
+      WDOT[n] *= mw[n];
     }
   }
 
@@ -421,9 +423,11 @@ struct Fuego
   AMREX_FORCE_INLINE
   static void Y2WBAR(const amrex::Real Y[NUM_SPECIES], amrex::Real& WBAR)
   {
+    amrex::Real tmp[NUM_SPECIES];
+    get_imw(tmp);
     amrex::Real summ = 0.0;
     for (int i = 0; i < NUM_SPECIES; i++) {
-      summ += Y[i] * global_imw[i];
+      summ += Y[i] * tmp[i];
     }
     WBAR = 1.0 / summ;
   }

--- a/Eos/SRK.H
+++ b/Eos/SRK.H
@@ -564,11 +564,14 @@ struct SRK
     amrex::Real acti[NUM_SPECIES])
   {
     amrex::Real am, bm, dAmdY[NUM_SPECIES];
+    amrex::Real inv_mwt[NUM_SPECIES], mwt[NUM_SPECIES];
     amrex::Real K1, InvEosT1Denom, InvEosT3Denom, wbar = 0.0, RmT, InvRuT,
                                                   InvBm, tau;
 
     MixingRuleAmBm(T, Y, am, bm);
     Calc_dAmdY(T, Y, dAmdY);
+    get_imw(inv_mwt);
+    get_mw(mwt);
     CKMMWY(Y, wbar);
 
     InvBm = 1.0 / bm;
@@ -582,10 +585,10 @@ struct SRK
     for (int ii = 0; ii < NUM_SPECIES; ii++) {
       acti[ii] =
         (exp(
-           (global_mw[ii] * InvRuT) *
+           (mwt[ii] * InvRuT) *
            (RmT * InvEosT1Denom * Bi[ii] - K1 * dAmdY[ii] +
             am * InvBm * K1 * Bi[ii] - am * InvEosT3Denom * Bi[ii] * InvBm)) *
-         Y[ii] * global_imw[ii] * InvEosT1Denom);
+         Y[ii] * inv_mwt[ii] * InvEosT1Denom);
     }
   }
 
@@ -601,8 +604,10 @@ struct SRK
     RTY2C(R, T, Y, C);
     CKWC(T, C, WDOT);
 
+    amrex::Real mw[NUM_SPECIES];
+    get_mw(mw);
     for (int n = 0; n < NUM_SPECIES; n++) {
-      WDOT[n] *= global_mw[n];
+      WDOT[n] *= mw[n];
     }
   }
 
@@ -771,7 +776,7 @@ struct SRK
     amrex::Real Hi[NUM_SPECIES])
   {
     amrex::Real am, bm, dAmdT, d2AmdT2;
-    amrex::Real dAmdY[NUM_SPECIES], d2AmdTY[NUM_SPECIES];
+    amrex::Real dAmdY[NUM_SPECIES], d2AmdTY[NUM_SPECIES], inv_mwt[NUM_SPECIES];
     amrex::Real wbar = 0.0;
     amrex::Real dpdtau, dhmdtau;
 
@@ -785,6 +790,7 @@ struct SRK
     Calc_dAmdY(T, Y, dAmdY);
     Calc_d2AmdTY(T, Y, d2AmdTY);
     CKMMWY(Y, wbar);
+    get_imw(inv_mwt);
 
     amrex::Real tau = 1.0 / R;
     amrex::Real K1 = (1.0 / bm) * log1p(bm * R);
@@ -800,7 +806,7 @@ struct SRK
               Rm * T * bm * InvEosT1Denom * InvEosT1Denom;
 
     for (int ii = 0; ii < NUM_SPECIES; ii++) {
-      amrex::Real Rmk = Constants::RU * global_imw[ii];
+      amrex::Real Rmk = Constants::RU * inv_mwt[ii];
       amrex::Real dpdYk = Rmk * T * InvEosT1Denom - dAmdY[ii] * InvEosT2Denom +
                           Bi[ii] * (Rm * T * InvEosT1Denom * InvEosT1Denom +
                                     am * InvEosT2Denom * InvEosT3Denom);
@@ -928,9 +934,11 @@ struct SRK
   AMREX_FORCE_INLINE
   static void Y2WBAR(const amrex::Real Y[NUM_SPECIES], amrex::Real& WBAR)
   {
+    amrex::Real tmp[NUM_SPECIES];
+    get_imw(tmp);
     amrex::Real summ = 0.0;
     for (int i = 0; i < NUM_SPECIES; i++) {
-      summ += Y[i] * global_imw[i];
+      summ += Y[i] * tmp[i];
     }
     WBAR = 1.0 / summ;
   }
@@ -995,10 +1003,11 @@ struct SRK
   {
     amrex::Real bm, am, dAmdY[NUM_SPECIES], d2AmdY2[NUM_SPECIES][NUM_SPECIES];
     amrex::Real wbar = 0.0;
-    amrex::Real dpdtau, dpdYk[NUM_SPECIES];
+    amrex::Real dpdtau, dpdYk[NUM_SPECIES], inv_mwt[NUM_SPECIES];
 
     // Optimize by combining Am derivate calls?
     CKMMWY(Y, wbar);
+    get_imw(inv_mwt);
     MixingRuleAmBm(T, Y, am, bm);
     Calc_dAmdY(T, Y, dAmdY);
     Calc_d2AmdY2(T, Y, d2AmdY2);
@@ -1015,7 +1024,7 @@ struct SRK
              am * (2.0 * tau + bm) * InvEosT2Denom * InvEosT2Denom;
 
     for (int ii = 0; ii < NUM_SPECIES; ii++) {
-      amrex::Real Rmk = Constants::RU * global_imw[ii];
+      amrex::Real Rmk = Constants::RU * inv_mwt[ii];
       dpdYk[ii] = Rmk * T * InvEosT1Denom - dAmdY[ii] * InvEosT2Denom +
                   Bi[ii] * (Rm * T * InvEosT1Denom * InvEosT1Denom +
                             am * InvEosT2Denom * InvEosT3Denom);
@@ -1027,18 +1036,18 @@ struct SRK
                  ((dAmdY[ii] - am * Bi[ii] * InvBm) * InvEosT2Denom +
                   am * Bi[ii] * InvBm * InvEosT1Denom * InvEosT1Denom)) -
                 Y[ii] * (Bi[ii] * InvEosT1Denom * InvEosT1Denom +
-                         wbar * global_imw[ii] * InvEosT1Denom);
+                         wbar * inv_mwt[ii] * InvEosT1Denom);
       diP[ii] /= dpdtau;
 
       for (int jj = 0; jj < NUM_SPECIES; jj++) {
         dijY[ii][jj] = 0.0;
       }
-      dijY[ii][ii] = wbar * global_imw[ii];
+      dijY[ii][ii] = wbar * inv_mwt[ii];
       for (int jj = 0; jj < NUM_SPECIES; jj++) {
         dijY[ii][jj] +=
           -diP[ii] * dpdYk[jj] +
           wbar * Y[ii] * InvEosT1Denom *
-            (Bi[ii] * global_imw[jj] + Bi[jj] * global_imw[ii]) +
+            (Bi[ii] * inv_mwt[jj] + Bi[jj] * inv_mwt[ii]) +
           Y[ii] * InvEosT1Denom * InvEosT1Denom * Bi[ii] * Bi[jj] +
           Y[ii] / (Rm * T) *
             ((K1 - InvEosT3Denom) * dAmdY[jj] * Bi[ii] * InvBm -

--- a/Reactions/ReactorBDF.cpp
+++ b/Reactions/ReactorBDF.cpp
@@ -37,6 +37,7 @@ get_bdf_matrix_and_rhs(
   amrex::Real soln_n[NUM_SPECIES + 1],
   amrex::Real soln_nm1[NUM_SPECIES + 1],
   amrex::Real soln_nm2[NUM_SPECIES + 1],
+  amrex::Real mw[NUM_SPECIES],
   int reactor_type,
   int tstepscheme,
   amrex::Real dt,
@@ -67,15 +68,14 @@ get_bdf_matrix_and_rhs(
   for (int ii = 0; ii < NUM_SPECIES; ii++) {
     for (int jj = 0; jj < NUM_SPECIES; jj++) {
       Jmat2d[ii][jj] = -bdfp.FCOEFFMAT[tstepscheme][0] *
-                       Jmat1d[jj * (NUM_SPECIES + 1) + ii] * global_mw[ii] *
-                       global_imw[jj];
+                       Jmat1d[jj * (NUM_SPECIES + 1) + ii] * mw[ii] / mw[jj];
     }
     Jmat2d[ii][NUM_SPECIES] = -bdfp.FCOEFFMAT[tstepscheme][0] *
                               Jmat1d[NUM_SPECIES * (NUM_SPECIES + 1) + ii] *
-                              global_mw[ii];
+                              mw[ii];
     Jmat2d[NUM_SPECIES][ii] = -bdfp.FCOEFFMAT[tstepscheme][0] *
-                              Jmat1d[ii * (NUM_SPECIES + 1) + NUM_SPECIES] *
-                              global_imw[ii];
+                              Jmat1d[ii * (NUM_SPECIES + 1) + NUM_SPECIES] /
+                              mw[ii];
   }
   Jmat2d[NUM_SPECIES][NUM_SPECIES] =
     -bdfp.FCOEFFMAT[tstepscheme][0] *
@@ -189,7 +189,9 @@ ReactorBDF::react(
     amrex::Real dsoln0[NUM_SPECIES + 1] = {
       0.0}; // initial newton_soln_k+1 -newton_soln_k
     amrex::Real rYsrc_ext[NUM_SPECIES] = {0.0};
+    amrex::Real mw[NUM_SPECIES] = {0.0};
     const int neq = (NUM_SPECIES + 1);
+    get_mw(mw);
 
     // initialization of variables before timestepping
     amrex::Real current_time = time_init;
@@ -237,9 +239,9 @@ ReactorBDF::react(
           dsoln0[ii] = dsoln[ii];
         }
         get_bdf_matrix_and_rhs(
-          soln, soln_n, soln_nm1, soln_nm2, captured_reactor_type, tstepscheme,
-          dt, rhoe_init, rhoesrc_ext, rYsrc_ext, current_time, time_init,
-          Jmat2d, rhs);
+          soln, soln_n, soln_nm1, soln_nm2, mw, captured_reactor_type,
+          tstepscheme, dt, rhoe_init, rhoesrc_ext, rYsrc_ext, current_time,
+          time_init, Jmat2d, rhs);
 
         performgmres(
           Jmat2d, rhs, dsoln0, dsoln, captured_gmres_precond,
@@ -353,7 +355,9 @@ ReactorBDF::react(
     amrex::Real dsoln0[NUM_SPECIES + 1] = {
       0.0}; // initial newton_soln_k+1 -newton_soln_k
     amrex::Real rYsrc_ext[NUM_SPECIES] = {0.0};
+    amrex::Real mw[NUM_SPECIES] = {0.0};
     const int neq = (NUM_SPECIES + 1);
+    get_mw(mw);
 
     // initialization of variables before timestepping
     amrex::Real current_time = time_init;
@@ -410,9 +414,9 @@ ReactorBDF::react(
           dsoln0[ii] = dsoln[ii];
         }
         get_bdf_matrix_and_rhs(
-          soln, soln_n, soln_nm1, soln_nm2, captured_reactor_type, tstepscheme,
-          dt, rhoe_init, rhoesrc_ext, rYsrc_ext, current_time, time_init,
-          Jmat2d, rhs);
+          soln, soln_n, soln_nm1, soln_nm2, mw, captured_reactor_type,
+          tstepscheme, dt, rhoe_init, rhoesrc_ext, rYsrc_ext, current_time,
+          time_init, Jmat2d, rhs);
 
         performgmres(
           Jmat2d, rhs, dsoln0, dsoln, captured_gmres_precond,

--- a/Reactions/ReactorCvodeUtils.H
+++ b/Reactions/ReactorCvodeUtils.H
@@ -159,6 +159,9 @@ fKernelComputeallAJ(
   int u_offset = ncell * neqs;
   amrex::Real* u_curr = u_d + u_offset;
 
+  amrex::Real mw[NUM_SPECIES] = {0.0};
+  get_mw(mw);
+
   amrex::Real rho_pt = 0.0;
   for (int n = 0; n < NUM_SPECIES; n++) {
     rho_pt = rho_pt + u_curr[n];
@@ -182,10 +185,10 @@ fKernelComputeallAJ(
   amrex::Real* csr_val_cell = csr_val_arg + jac_offset;
   for (int i = 0; i < NUM_SPECIES; i++) {
     for (int k = 0; k < NUM_SPECIES; k++) {
-      Jmat_pt[k * neqs + i] *= global_mw[i] * global_imw[k];
+      Jmat_pt[k * neqs + i] *= mw[i] / mw[k];
     }
-    Jmat_pt[i * neqs + NUM_SPECIES] *= global_imw[i];
-    Jmat_pt[NUM_SPECIES * neqs + i] *= global_mw[i];
+    Jmat_pt[i * neqs + NUM_SPECIES] /= mw[i];
+    Jmat_pt[NUM_SPECIES * neqs + i] *= mw[i];
   }
   for (int i = 1; i < NUM_SPECIES + 2; i++) {
     int nbVals = csr_row_count_d[i] - csr_row_count_d[i - 1];
@@ -274,12 +277,14 @@ fKernelComputeAJchem(
   eos.RTY2JAC(rho_pt, temp_pt, massfrac.arr, Jmat_pt.arr, consP);
 
   // Scale Jacobian
+  amrex::Real mw[NUM_SPECIES] = {0.0};
+  get_mw(mw);
   for (int i = 0; i < NUM_SPECIES; i++) {
     for (int k = 0; k < NUM_SPECIES; k++) {
-      Jmat_pt[k * neqs + i] *= global_mw[i] * global_imw[k];
+      Jmat_pt[k * neqs + i] *= mw[i] / mw[k];
     }
-    Jmat_pt[i * neqs + NUM_SPECIES] *= global_imw[i];
-    Jmat_pt[NUM_SPECIES * neqs + i] *= global_mw[i];
+    Jmat_pt[i * neqs + NUM_SPECIES] /= mw[i];
+    Jmat_pt[NUM_SPECIES * neqs + i] *= mw[i];
   }
 
   // Fill the sparse outgoing Jacobian matrix
@@ -323,18 +328,18 @@ fKernelDenseAJchem(
   eos.RTY2JAC(rho_pt, temp_pt, massfrac.arr, Jmat_pt.arr, consP);
 
   // Scale Jacobian and pass into outgoing data ptr.
+  amrex::Real mw[NUM_SPECIES] = {0.0};
+  get_mw(mw);
+
   int jac_offset = icell * (neqs * neqs);
   amrex::Real* Jcurr = Jdata + jac_offset;
 
   for (int i = 0; i < NUM_SPECIES; i++) {
     for (int k = 0; k < NUM_SPECIES; k++) {
-      Jcurr[k * neqs + i] =
-        Jmat_pt[k * neqs + i] * global_mw[i] * global_imw[k];
+      Jcurr[k * neqs + i] = Jmat_pt[k * neqs + i] * mw[i] / mw[k];
     }
-    Jcurr[i * neqs + NUM_SPECIES] =
-      Jmat_pt[i * neqs + NUM_SPECIES] * global_imw[i];
-    Jcurr[NUM_SPECIES * neqs + i] =
-      Jmat_pt[NUM_SPECIES * neqs + i] * global_mw[i];
+    Jcurr[i * neqs + NUM_SPECIES] = Jmat_pt[i * neqs + NUM_SPECIES] / mw[i];
+    Jcurr[NUM_SPECIES * neqs + i] = Jmat_pt[NUM_SPECIES * neqs + i] * mw[i];
   }
 }
 

--- a/Support/Mechanism/Models/Null/mechanism.H
+++ b/Support/Mechanism/Models/Null/mechanism.H
@@ -54,14 +54,6 @@ get_mw(amrex::Real mw_new[])
   mw_new[0] = 1.0;
 }
 
-AMREX_GPU_CONSTANT const amrex::Real global_imw[1] = {
-  1.0,
-};
-
-AMREX_GPU_CONSTANT const amrex::Real global_mw[1] = {
-  1.0,
-};
-
 /* Returns R, Rc, Patm */
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
 CKRP(amrex::Real& ru, amrex::Real& ruc, amrex::Real& pa)


### PR DESCRIPTION
Reverts AMReX-Combustion/PelePhysics#376

I think we need to go through and change what we can to `AMREX_GPU_DEVICE` instead of `AMREX_GPU_HOST_DEVICE`. I know we can't do all of them because certain problems do call EOS routines on the host.

Or we can just have two arrays for each imw and mw, one on the host and one on device.