### PR TITLE
Disallow Sutherland transport with SRK and GammaLaw

### DIFF
--- a/Source/PelePhysicsConstraints.H
+++ b/Source/PelePhysicsConstraints.H
@@ -28,7 +28,19 @@ struct is_valid_physics_combination<eos::GammaLaw, transport::SimpleTransport>
 };
 
 template <>
+struct is_valid_physics_combination<eos::GammaLaw, transport::SutherlandTransport>
+  : public std::false_type
+{
+};
+
+template <>
 struct is_valid_physics_combination<eos::SRK, transport::ConstTransport>
+  : public std::false_type
+{
+};
+
+template <>
+struct is_valid_physics_combination<eos::SRK, transport::SutherlandTransport>
   : public std::false_type
 {
 };

--- a/Source/PelePhysicsConstraints.H
+++ b/Source/PelePhysicsConstraints.H
@@ -28,8 +28,9 @@ struct is_valid_physics_combination<eos::GammaLaw, transport::SimpleTransport>
 };
 
 template <>
-struct is_valid_physics_combination<eos::GammaLaw, transport::SutherlandTransport>
-  : public std::false_type
+struct is_valid_physics_combination<
+  eos::GammaLaw,
+  transport::SutherlandTransport> : public std::false_type
 {
 };
 


### PR DESCRIPTION
Sutherland transport uses the CKCPBS function from the mechanism to compute heat capacity. This does not included real gas effects and is not physically accurate for SRK. I don't think there would be any physical inconsistency for Sutherland Transport + Gamma Law, but this function is not implemented in the Null mechanism, so that combination is not valid either. 