### PR TITLE
Quiet warnings in Utility/Diagnostics

### DIFF
--- a/Utility/Diagnostics/DiagBase.cpp
+++ b/Utility/Diagnostics/DiagBase.cpp
@@ -31,9 +31,9 @@ DiagBase::init(const std::string& a_prefix, std::string_view a_diagName)
 void
 DiagBase::prepare(
   int a_nlevels,
-  const amrex::Vector<amrex::Geometry>& a_geoms,
-  const amrex::Vector<amrex::BoxArray>& a_grids,
-  const amrex::Vector<amrex::DistributionMapping>& a_dmap,
+  const amrex::Vector<amrex::Geometry>& /*a_geoms*/,
+  const amrex::Vector<amrex::BoxArray>& /*a_grids*/,
+  const amrex::Vector<amrex::DistributionMapping>& /*a_dmap*/,
   const amrex::Vector<std::string>& a_varNames)
 {
   if (first_time) {

--- a/Utility/Diagnostics/DiagConditional.cpp
+++ b/Utility/Diagnostics/DiagConditional.cpp
@@ -157,10 +157,10 @@ DiagConditional::processDiag(
         [=, nBins = m_nBins, lowBnd = m_lowBnd] AMREX_GPU_DEVICE(
           int box_no, int i, int j, int k) noexcept {
           if (marrs[box_no](i, j, k)) {
-            int cbin = std::floor(
-              (sarrs[box_no](i, j, k, cFieldIdx) - lowBnd) / binWidth);
+            int cbin = static_cast<int>(std::floor(
+              (sarrs[box_no](i, j, k, cFieldIdx) - lowBnd) / binWidth));
             if (cbin >= 0 && cbin < nBins) {
-              for (size_t f{0}; f < nProcessFields; ++f) {
+              for (int f{0}; f < nProcessFields; ++f) {
                 int fidx = idx_d_p[f];
                 int binOffset = f * nBins;
                 amrex::HostDevice::Atomic::Add(
@@ -185,10 +185,10 @@ DiagConditional::processDiag(
         [=, nBins = m_nBins, lowBnd = m_lowBnd] AMREX_GPU_DEVICE(
           int box_no, int i, int j, int k) noexcept {
           if (marrs[box_no](i, j, k)) {
-            int cbin = std::floor(
-              (sarrs[box_no](i, j, k, cFieldIdx) - lowBnd) / binWidth);
+            int cbin = static_cast<int>(std::floor(
+              (sarrs[box_no](i, j, k, cFieldIdx) - lowBnd) / binWidth));
             if (cbin >= 0 && cbin < nBins) {
-              for (size_t f{0}; f < nProcessFields; ++f) {
+              for (int f{0}; f < nProcessFields; ++f) {
                 int fidx = idx_d_p[f];
                 int binOffset = f * nBins;
                 amrex::HostDevice::Atomic::Add(
@@ -207,10 +207,10 @@ DiagConditional::processDiag(
         [=, nBins = m_nBins, lowBnd = m_lowBnd] AMREX_GPU_DEVICE(
           int box_no, int i, int j, int k) noexcept {
           if (marrs[box_no](i, j, k)) {
-            int cbin = std::floor(
-              (sarrs[box_no](i, j, k, cFieldIdx) - lowBnd) / binWidth);
+            int cbin = static_cast<int>(std::floor(
+              (sarrs[box_no](i, j, k, cFieldIdx) - lowBnd) / binWidth));
             if (cbin >= 0 && cbin < nBins) {
-              for (size_t f{0}; f < nProcessFields; ++f) {
+              for (int f{0}; f < nProcessFields; ++f) {
                 int fidx = idx_d_p[f];
                 int binOffset = f * nBins;
                 amrex::HostDevice::Atomic::Add(
@@ -246,16 +246,16 @@ DiagConditional::processDiag(
       condSq.begin());
     amrex::Gpu::streamSynchronize();
     amrex::ParallelDescriptor::ReduceRealSum(condSq.data(), condSq.size());
-    for (size_t f{0}; f < nProcessFields; ++f) {
+    for (int f{0}; f < nProcessFields; ++f) {
       int binOffset = f * m_nBins;
-      for (size_t n{0}; n < m_nBins; ++n) {
+      for (int n{0}; n < m_nBins; ++n) {
         if (condVol[n] != 0.0) {
           cond[binOffset + n] /= condVol[n];
           condSq[binOffset + n] /= condVol[n];
         }
       }
     }
-    for (size_t n{0}; n < m_nBins; ++n) {
+    for (int n{0}; n < m_nBins; ++n) {
       if (condVol[n] != 0.0) {
         condAbs[n] /= condVol[n];
       }
@@ -342,14 +342,14 @@ DiagConditional::writeAverageDataToFile(
     int nProcessFields = m_fieldIndices_d.size();
     amrex::Real binWidth = (m_highBnd - m_lowBnd) / (m_nBins);
 
-    for (size_t n{0}; n < m_nBins; ++n) {
+    for (int n{0}; n < m_nBins; ++n) {
       condFile << std::left << std::setw(width) << std::setprecision(prec)
                << std::scientific << m_lowBnd + (n + 0.5) * binWidth << " ";
       condFile << std::left << std::setw(width) << std::setprecision(prec)
                << std::scientific << a_condAbs[n] << " ";
       condFile << std::left << std::setw(width) << std::setprecision(prec)
                << std::scientific << a_condVol[n] << " ";
-      for (size_t f{0}; f < nProcessFields; ++f) {
+      for (int f{0}; f < nProcessFields; ++f) {
         int binOffset = f * m_nBins;
         condFile << std::left << std::setw(width) << std::setprecision(prec)
                  << std::scientific << a_cond[binOffset + n] << " "
@@ -399,12 +399,11 @@ DiagConditional::writeIntegralDataToFile(
 
     // Retrieve some data
     int nProcessFields = m_fieldIndices_d.size();
-    amrex::Real binWidth = (m_highBnd - m_lowBnd) / (m_nBins);
 
-    for (size_t n{0}; n < m_nBins; ++n) {
+    for (int n{0}; n < m_nBins; ++n) {
       condFile << std::left << std::setw(width) << std::setprecision(prec)
                << std::scientific << a_condAbs[n] << " ";
-      for (size_t f{0}; f < nProcessFields; ++f) {
+      for (int f{0}; f < nProcessFields; ++f) {
         int binOffset = f * m_nBins;
         condFile << std::left << std::setw(width) << std::setprecision(prec)
                  << std::scientific << a_cond[binOffset + n] << " ";
@@ -448,12 +447,11 @@ DiagConditional::writeSumDataToFile(
 
     // Retrieve some data
     int nProcessFields = m_fieldIndices_d.size();
-    amrex::Real binWidth = (m_highBnd - m_lowBnd) / (m_nBins);
 
-    for (size_t n{0}; n < m_nBins; ++n) {
+    for (int n{0}; n < m_nBins; ++n) {
       condFile << std::left << std::setw(width) << std::setprecision(prec)
                << std::scientific << a_condAbs[n] << " ";
-      for (size_t f{0}; f < nProcessFields; ++f) {
+      for (int f{0}; f < nProcessFields; ++f) {
         int binOffset = f * m_nBins;
         condFile << std::left << std::setw(width) << std::setprecision(prec)
                  << std::scientific << a_cond[binOffset + n] << " ";

--- a/Utility/Diagnostics/DiagFramePlane.cpp
+++ b/Utility/Diagnostics/DiagFramePlane.cpp
@@ -213,7 +213,7 @@ DiagFramePlane::processDiag(
   int a_nstep,
   const amrex::Real& a_time,
   const amrex::Vector<const amrex::MultiFab*>& a_state,
-  const amrex::Vector<std::string>& a_stateVar)
+  const amrex::Vector<std::string>& /*a_stateVar*/)
 {
   // Interpolate data to slice
   amrex::Vector<amrex::MultiFab> planeData(a_state.size());

--- a/Utility/Diagnostics/DiagPDF.cpp
+++ b/Utility/Diagnostics/DiagPDF.cpp
@@ -116,8 +116,8 @@ DiagPDF::processDiag(
         [=, lowBnd = m_lowBnd] AMREX_GPU_DEVICE(
           int box_no, int i, int j, int k) noexcept {
           if (marrs[box_no](i, j, k)) {
-            int cbin = std::floor(
-              (sarrs[box_no](i, j, k, fieldIdx) - lowBnd) / binWidth);
+            int cbin = static_cast<int>(std::floor(
+              (sarrs[box_no](i, j, k, fieldIdx) - lowBnd) / binWidth));
             amrex::HostDevice::Atomic::Add(
               &(pdf_d_p[cbin]), varrs[box_no](i, j, k));
           }
@@ -129,8 +129,8 @@ DiagPDF::processDiag(
         [=, lowBnd = m_lowBnd] AMREX_GPU_DEVICE(
           int box_no, int i, int j, int k) noexcept {
           if (marrs[box_no](i, j, k)) {
-            int cbin = std::floor(
-              (sarrs[box_no](i, j, k, fieldIdx) - lowBnd) / binWidth);
+            int cbin = static_cast<int>(std::floor(
+              (sarrs[box_no](i, j, k, fieldIdx) - lowBnd) / binWidth));
             amrex::HostDevice::Atomic::Add(&(pdf_d_p[cbin]), amrex::Real(1.0));
           }
         });
@@ -204,7 +204,7 @@ DiagPDF::writePDFToFile(
             << m_fieldName + "_PDF"
             << "\n";
 
-    for (size_t i{0}; i < a_pdf.size(); ++i) {
+    for (int i{0}; i < a_pdf.size(); ++i) {
       pdfFile << std::setw(width) << std::setprecision(prec) << std::scientific
               << m_lowBnd + (static_cast<amrex::Real>(i) + 0.5) * binWidth
               << " " << std::setw(width) << std::setprecision(prec)


### PR DESCRIPTION
Drop usage of size_t and static_cast std::floor return value into int.