### PR TITLE
Yet another missing warning.

### DIFF
--- a/Utility/Diagnostics/DiagBase.H
+++ b/Utility/Diagnostics/DiagBase.H
@@ -15,7 +15,7 @@ public:
 
   virtual void close() = 0;
 
-  bool needUpdate() { return need_update; };
+  bool needUpdate() { return need_update; }
 
   virtual bool doDiag(const amrex::Real& a_time, int a_nstep);
 


### PR DESCRIPTION
Should be the last one. PelePhysics CI don't catch those but PeleC one does.