### PR TITLE
Fully GPU enabled set_sundials_solver_tols

### DIFF
--- a/Reactions/ReactorUtils.H
+++ b/Reactions/ReactorUtils.H
@@ -111,7 +111,7 @@ set_sundials_solver_tols(
     neq_tot, /*use_managed_mem=*/false,
     *amrex::sundials::The_SUNMemory_Helper(),
     &amrex::Gpu::Device::streamQueue(), sunctx);
-    amrex::Real* ratol = N_VGetDeviceArrayPointer_Sycl(atol);
+  amrex::Real* ratol = N_VGetDeviceArrayPointer_Sycl(atol);
 #else
   N_Vector atol = N_VNew_Serial(neq_tot, sunctx);
   amrex::Real* ratol = N_VGetArrayPointer(atol);
@@ -138,16 +138,17 @@ set_sundials_solver_tols(
         }
       });
 #else
-    amrex::launch<32>((NUM_SPECIES+1)*ncells, [=] AMREX_GPU_DEVICE (int id) noexcept
-    {
-        const int k = id/ncells;
-        if (k > NUM_SPECIES) return;
+    amrex::launch<32>(
+      (NUM_SPECIES + 1) * ncells, [=] AMREX_GPU_DEVICE(int id) noexcept {
+        const int k = id / ncells;
+        if (k > NUM_SPECIES)
+          return;
 
         amrex::Real T = typ_vals[k] * absTol;
-        const int icell = id - k*ncells;
-        
+        const int icell = id - k * ncells;
+
         ratol[vec_index<OrderType>(k, icell, ncells)] = T;
-    });
+      });
 #endif
   } else {
     // cppcheck-suppress knownConditionTrueFalse
@@ -167,11 +168,11 @@ set_sundials_solver_tols(
         }
       });
 #else
-    amrex::launch<1>(neq_tot, [=] AMREX_GPU_DEVICE (int i) noexcept
-    {
-        if (i >= neq_tot) return;
+    amrex::launch<1>(neq_tot, [=] AMREX_GPU_DEVICE(int i) noexcept {
+      if (i >= neq_tot)
+        return;
 
-        ratol[i] = absTol;
+      ratol[i] = absTol;
     });
 #endif
   }

--- a/Reactions/ReactorUtils.H
+++ b/Reactions/ReactorUtils.H
@@ -111,7 +111,7 @@ set_sundials_solver_tols(
     neq_tot, /*use_managed_mem=*/false,
     *amrex::sundials::The_SUNMemory_Helper(),
     &amrex::Gpu::Device::streamQueue(), sunctx);
-  amrex::Real* ratol = N_VGetHostArrayPointer_Sycl(atol);
+    amrex::Real* ratol = N_VGetDeviceArrayPointer_Sycl(atol);
 #else
   N_Vector atol = N_VNew_Serial(neq_tot, sunctx);
   amrex::Real* ratol = N_VGetArrayPointer(atol);
@@ -138,12 +138,16 @@ set_sundials_solver_tols(
         }
       });
 #else
-    for (int k = 0; k < NUM_SPECIES + 1; k++) {
-      amrex::Real T = typ_vals[k] * absTol;
-      for (int icell = 0; icell < ncells; icell++) {
+    amrex::launch<32>((NUM_SPECIES+1)*ncells, [=] AMREX_GPU_DEVICE (int id) noexcept
+    {
+        const int k = id/ncells;
+        if (k > NUM_SPECIES) return;
+
+        amrex::Real T = typ_vals[k] * absTol;
+        const int icell = id - k*ncells;
+        
         ratol[vec_index<OrderType>(k, icell, ncells)] = T;
-      }
-    }
+    });
 #endif
   } else {
     // cppcheck-suppress knownConditionTrueFalse
@@ -163,15 +167,14 @@ set_sundials_solver_tols(
         }
       });
 #else
-    for (int i = 0; i < neq_tot; i++) {
-      ratol[i] = absTol;
-    }
+    amrex::launch<1>(neq_tot, [=] AMREX_GPU_DEVICE (int i) noexcept
+    {
+        if (i >= neq_tot) return;
+
+        ratol[i] = absTol;
+    });
 #endif
   }
-
-#if defined(AMREX_USE_SYCL)
-  N_VCopyToDevice_Sycl(atol);
-#endif
 
   // Call CVodeSVtolerances to specify the scalar relative tolerance
   // and vector absolute tolerances


### PR DESCRIPTION
The SYCL computations in set_sundials_solver_tols were still performed on the CPU, resulting in a big bottleneck. I implemented them on the GPU.