### PR TITLE
Fix fixed width formatting in diag headers

### DIFF
--- a/Utility/Diagnostics/DiagConditional.cpp
+++ b/Utility/Diagnostics/DiagConditional.cpp
@@ -327,38 +327,44 @@ DiagConditional::writeAverageDataToFile(
     std::ofstream condFile;
     condFile.open(diagfile.c_str(), std::ios::out);
     int prec = 8;
-    int width = 16;
+    size_t width = 16;
+    int nProcessFields = static_cast<int>(m_fieldIndices_d.size());
+    amrex::Vector<int> widths(3 + 2 * nProcessFields, width);
 
-    condFile << std::left << std::setw(width) << "BinCenter"
+    condFile << std::left << std::setw(widths[0]) << "BinCenter"
              << " ";
-    condFile << std::left << std::setw(width) << m_cFieldName << " ";
-    condFile << std::left << std::setw(width) << "Volume"
+    widths[1] = amrex::max(width, m_cFieldName.length() + 1);
+    condFile << std::left << std::setw(widths[1]) << m_cFieldName << " ";
+    condFile << std::left << std::setw(widths[2]) << "Volume"
              << " ";
-    for (auto& f : m_fieldNames) {
-      condFile << std::left << std::setw(width) << f + "_Avg"
+    for (int f{0}; f < nProcessFields; ++f) {
+      widths[3 + 2 * f] = amrex::max(width, m_fieldNames[f].length() + 5);
+      condFile << std::left << std::setw(widths[3 + 2 * f])
+               << m_fieldNames[f] + "_Avg"
                << " ";
-      condFile << std::left << std::setw(width) << f + "_StdDev"
+      widths[4 + 2 * f] = amrex::max(width, m_fieldNames[f].length() + 7);
+      condFile << std::left << std::setw(widths[4 + 2 * f])
+               << m_fieldNames[f] + "_StdDev"
                << " ";
     }
     condFile << "\n";
 
     // Retrieve some data
-    int nProcessFields = static_cast<int>(m_fieldIndices_d.size());
     amrex::Real binWidth = (m_highBnd - m_lowBnd) / (m_nBins);
 
     for (int n{0}; n < m_nBins; ++n) {
-      condFile << std::left << std::setw(width) << std::setprecision(prec)
+      condFile << std::left << std::setw(widths[0]) << std::setprecision(prec)
                << std::scientific << m_lowBnd + (n + 0.5) * binWidth << " ";
-      condFile << std::left << std::setw(width) << std::setprecision(prec)
+      condFile << std::left << std::setw(widths[1]) << std::setprecision(prec)
                << std::scientific << a_condAbs[n] << " ";
-      condFile << std::left << std::setw(width) << std::setprecision(prec)
+      condFile << std::left << std::setw(widths[2]) << std::setprecision(prec)
                << std::scientific << a_condVol[n] << " ";
       for (int f{0}; f < nProcessFields; ++f) {
         int binOffset = f * m_nBins;
-        condFile << std::left << std::setw(width) << std::setprecision(prec)
-                 << std::scientific << a_cond[binOffset + n] << " "
-                 << std::setw(width) << std::setprecision(prec)
-                 << std::scientific
+        condFile << std::left << std::setw(widths[3 + 2 * f])
+                 << std::setprecision(prec) << std::scientific
+                 << a_cond[binOffset + n] << " " << std::setw(widths[4 + 2 * f])
+                 << std::setprecision(prec) << std::scientific
                  << std::sqrt(std::abs(
                       a_condSq[binOffset + n] -
                       a_cond[binOffset + n] * a_cond[binOffset + n]))
@@ -392,25 +398,28 @@ DiagConditional::writeIntegralDataToFile(
     std::ofstream condFile;
     condFile.open(diagfile.c_str(), std::ios::out | std::ios::app);
     int prec = 8;
-    int width = 16;
+    size_t width = 16;
+    int nProcessFields = static_cast<int>(m_fieldIndices_d.size());
+    amrex::Vector<int> widths(1 + nProcessFields, width);
 
-    condFile << std::left << std::setw(width) << m_cFieldName << " ";
-    for (auto& f : m_fieldNames) {
-      condFile << std::left << std::setw(width) << f + "_Int"
+    widths[0] = amrex::max(width, m_cFieldName.length() + 1);
+    condFile << std::left << std::setw(widths[0]) << m_cFieldName << " ";
+    for (int f{0}; f < nProcessFields; ++f) {
+      widths[1 + f] = amrex::max(width, m_fieldNames[f].length() + 5);
+      condFile << std::left << std::setw(widths[1 + f])
+               << m_fieldNames[f] + "_Int"
                << " ";
     }
     condFile << "\n";
 
-    // Retrieve some data
-    int nProcessFields = static_cast<int>(m_fieldIndices_d.size());
-
     for (int n{0}; n < m_nBins; ++n) {
-      condFile << std::left << std::setw(width) << std::setprecision(prec)
+      condFile << std::left << std::setw(widths[0]) << std::setprecision(prec)
                << std::scientific << a_condAbs[n] << " ";
       for (int f{0}; f < nProcessFields; ++f) {
         int binOffset = f * m_nBins;
-        condFile << std::left << std::setw(width) << std::setprecision(prec)
-                 << std::scientific << a_cond[binOffset + n] << " ";
+        condFile << std::left << std::setw(widths[1 + f])
+                 << std::setprecision(prec) << std::scientific
+                 << a_cond[binOffset + n] << " ";
       }
       condFile << "\n";
     }
@@ -440,25 +449,28 @@ DiagConditional::writeSumDataToFile(
     std::ofstream condFile;
     condFile.open(diagfile.c_str(), std::ios::out | std::ios::app);
     int prec = 8;
-    int width = 16;
+    size_t width = 16;
+    int nProcessFields = static_cast<int>(m_fieldIndices_d.size());
+    amrex::Vector<int> widths(1 + nProcessFields, width);
 
-    condFile << std::left << std::setw(width) << m_cFieldName << " ";
-    for (auto& f : m_fieldNames) {
-      condFile << std::left << std::setw(width) << f + "_Sum"
+    widths[0] = amrex::max(width, m_cFieldName.length() + 1);
+    condFile << std::left << std::setw(widths[0]) << m_cFieldName << " ";
+    for (int f{0}; f < nProcessFields; ++f) {
+      widths[1 + f] = amrex::max(width, m_fieldNames[f].length() + 5);
+      condFile << std::left << std::setw(widths[1 + f])
+               << m_fieldNames[f] + "_Sum"
                << " ";
     }
     condFile << "\n";
 
-    // Retrieve some data
-    int nProcessFields = static_cast<int>(m_fieldIndices_d.size());
-
     for (int n{0}; n < m_nBins; ++n) {
-      condFile << std::left << std::setw(width) << std::setprecision(prec)
+      condFile << std::left << std::setw(widths[0]) << std::setprecision(prec)
                << std::scientific << a_condAbs[n] << " ";
       for (int f{0}; f < nProcessFields; ++f) {
         int binOffset = f * m_nBins;
-        condFile << std::left << std::setw(width) << std::setprecision(prec)
-                 << std::scientific << a_cond[binOffset + n] << " ";
+        condFile << std::left << std::setw(widths[1 + f])
+                 << std::setprecision(prec) << std::scientific
+                 << a_cond[binOffset + n] << " ";
       }
       condFile << "\n";
     }

--- a/Utility/Diagnostics/DiagPDF.cpp
+++ b/Utility/Diagnostics/DiagPDF.cpp
@@ -197,18 +197,22 @@ DiagPDF::writePDFToFile(
     std::ofstream pdfFile;
     pdfFile.open(diagfile.c_str(), std::ios::out);
     int prec = 8;
-    int width = 16;
+    size_t width = 16;
+    amrex::Vector<int> widths(2, width);
 
     amrex::Real binWidth = (m_highBnd - m_lowBnd) / (m_nBins);
 
-    pdfFile << std::setw(width) << m_fieldName << " " << std::setw(width)
-            << m_fieldName + "_PDF"
+    widths[0] = amrex::max(width, m_fieldName.length() + 1);
+    widths[1] = amrex::max(width, m_fieldName.length() + 5);
+    pdfFile << std::setw(widths[0]) << m_fieldName << " "
+            << std::setw(widths[1]) << m_fieldName + "_PDF"
             << "\n";
 
     for (int i{0}; i < a_pdf.size(); ++i) {
-      pdfFile << std::setw(width) << std::setprecision(prec) << std::scientific
+      pdfFile << std::setw(widths[0]) << std::setprecision(prec)
+              << std::scientific
               << m_lowBnd + (static_cast<amrex::Real>(i) + 0.5) * binWidth
-              << " " << std::setw(width) << std::setprecision(prec)
+              << " " << std::setw(widths[1]) << std::setprecision(prec)
               << std::scientific << a_pdf[i] / a_sum / binWidth << "\n";
     }
 


### PR DESCRIPTION
When column names have too many characters, extend the column width rather than allowing the column headers and data to become misaligned.

PeleLMeX conditional average diagnostic output, current:
![Screen Shot 2023-09-13 at 2 49 17 PM](https://github.com/AMReX-Combustion/PelePhysics/assets/53018946/eac61bf0-ca8d-400d-b3d2-20462425a80f)


With these changes:
![Screen Shot 2023-09-13 at 2 48 39 PM](https://github.com/AMReX-Combustion/PelePhysics/assets/53018946/0b0aeb5f-f2b7-46cc-bd8d-0d9d5cad2738)
