### PR TITLE
Clip the concentrations on fractional pows

### DIFF
--- a/Support/Mechanism/Models/JL4/mechanism.H
+++ b/Support/Mechanism/Models/JL4/mechanism.H
@@ -1913,15 +1913,17 @@ comp_qfqr(
 {
 
   // reaction 0: 2 CH4 + O2 => 2 CO + 4 H2
-  qf[0] = pow(sc[0], 0.500000) * pow(sc[1], 1.250000);
+  qf[0] =
+    std::sqrt(std::max(sc[0], 1e-14)) * pow(std::max(sc[1], 1e-14), 1.250000);
   qr[0] = 0.0;
 
   // reaction 1: CH4 + H2O <=> CO + 3 H2
   qf[1] = sc[0] * sc[2];
-  qr[1] = sc[4] * pow(sc[6], 3.000000);
+  qr[1] = sc[4] * sc[6] * sc[6] * sc[6];
 
   // reaction 2: 2 H2 + O2 => 2 H2O
-  qf[2] = pow(sc[1], 1.500000) * pow(sc[6], 0.250000);
+  qf[2] = pow(std::max(sc[1], 1e-14), 1.500000) *
+          pow(std::max(sc[6], 1e-14), 0.250000);
   qr[2] = 0.0;
 
   // reaction 3: CO + H2O <=> CO2 + H2
@@ -1997,7 +1999,8 @@ productionRate(amrex::Real* wdot, const amrex::Real* sc, const amrex::Real T)
   {
     // reaction 0:  2 CH4 + O2 => 2 CO + 4 H2
     const amrex::Real k_f = 1236450565.12584 * exp(-(15096.4999741416) * invT);
-    const amrex::Real qf = k_f * (pow(sc[0], 0.500000) * pow(sc[1], 1.250000));
+    const amrex::Real qf = k_f * (std::sqrt(std::max(sc[0], 1e-14)) *
+                                  pow(std::max(sc[1], 1e-14), 1.250000));
     const amrex::Real qr = 0.0;
     const amrex::Real qdot = qf - qr;
     wdot[0] -= 2.000000 * qdot;
@@ -2012,7 +2015,7 @@ productionRate(amrex::Real* wdot, const amrex::Real* sc, const amrex::Real T)
     const amrex::Real qf = k_f * (sc[0] * sc[2]);
     const amrex::Real qr =
       k_f * exp(-(g_RT[0] + g_RT[2] - g_RT[4] - 3.000000 * g_RT[6])) *
-      ((refCinv * refCinv)) * (sc[4] * pow(sc[6], 3.000000));
+      ((refCinv * refCinv)) * (sc[4] * sc[6] * sc[6] * sc[6]);
     const amrex::Real qdot = qf - qr;
     wdot[0] -= qdot;
     wdot[2] -= qdot;
@@ -2024,7 +2027,8 @@ productionRate(amrex::Real* wdot, const amrex::Real* sc, const amrex::Real T)
     // reaction 2:  2 H2 + O2 => 2 H2O
     const amrex::Real k_f =
       191159684557179 * exp((-1) * tc[0] - (20128.6666321888) * invT);
-    const amrex::Real qf = k_f * (pow(sc[1], 1.500000) * pow(sc[6], 0.250000));
+    const amrex::Real qf = k_f * (pow(std::max(sc[1], 1e-14), 1.500000) *
+                                  pow(std::max(sc[6], 1e-14), 0.250000));
     const amrex::Real qr = 0.0;
     const amrex::Real qdot = qf - qr;
     wdot[1] -= qdot;
@@ -2324,7 +2328,8 @@ aJacobian_precond(
   // reaction 0: 2 CH4 + O2 => 2 CO + 4 H2
   // a non-third-body and non-pressure-fall-off reaction
   // forward
-  phi_f = pow(sc[0], 0.500000) * pow(sc[1], 1.250000);
+  phi_f =
+    std::sqrt(std::max(sc[0], 1e-14)) * pow(std::max(sc[1], 1e-14), 1.250000);
   k_f = 1236450565.12584 * exp(-(15096.4999741416) * invT);
   dlnkfdT = (15096.4999741416) * invT2;
   // rate of progress
@@ -2362,7 +2367,7 @@ aJacobian_precond(
   k_f = 300000 * exp(-(15096.4999741416) * invT);
   dlnkfdT = (15096.4999741416) * invT2;
   // reverse
-  phi_r = sc[4] * pow(sc[6], 3.000000);
+  phi_r = sc[4] * sc[6] * sc[6] * sc[6];
   Kc = (refC * refC) * exp(g_RT[0] + g_RT[2] - g_RT[4] - 3.000000 * g_RT[6]);
   k_r = k_f / Kc;
   dlnKcdT =
@@ -2409,7 +2414,8 @@ aJacobian_precond(
   // reaction 2: 2 H2 + O2 => 2 H2O
   // a non-third-body and non-pressure-fall-off reaction
   // forward
-  phi_f = pow(sc[1], 1.500000) * pow(sc[6], 0.250000);
+  phi_f = pow(std::max(sc[1], 1e-14), 1.500000) *
+          pow(std::max(sc[6], 1e-14), 0.250000);
   k_f = 191159684557179 * exp(-1 * tc[0] - (20128.6666321888) * invT);
   dlnkfdT = -1 * invT + (20128.6666321888) * invT2;
   // rate of progress
@@ -2600,7 +2606,8 @@ aJacobian(
   // reaction 0: 2 CH4 + O2 => 2 CO + 4 H2
   // a non-third-body and non-pressure-fall-off reaction
   // forward
-  phi_f = pow(sc[0], 0.500000) * pow(sc[1], 1.250000);
+  phi_f =
+    std::sqrt(std::max(sc[0], 1e-14)) * pow(std::max(sc[1], 1e-14), 1.250000);
   k_f = 1236450565.12584 * exp(-(15096.4999741416) * invT);
   dlnkfdT = (15096.4999741416) * invT2;
   // rate of progress
@@ -2638,7 +2645,7 @@ aJacobian(
   k_f = 300000 * exp(-(15096.4999741416) * invT);
   dlnkfdT = (15096.4999741416) * invT2;
   // reverse
-  phi_r = sc[4] * pow(sc[6], 3.000000);
+  phi_r = sc[4] * sc[6] * sc[6] * sc[6];
   Kc = (refC * refC) * exp(g_RT[0] + g_RT[2] - g_RT[4] - 3.000000 * g_RT[6]);
   k_r = k_f / Kc;
   dlnKcdT =
@@ -2685,7 +2692,8 @@ aJacobian(
   // reaction 2: 2 H2 + O2 => 2 H2O
   // a non-third-body and non-pressure-fall-off reaction
   // forward
-  phi_f = pow(sc[1], 1.500000) * pow(sc[6], 0.250000);
+  phi_f = pow(std::max(sc[1], 1e-14), 1.500000) *
+          pow(std::max(sc[6], 1e-14), 0.250000);
   k_f = 191159684557179 * exp(-1 * tc[0] - (20128.6666321888) * invT);
   dlnkfdT = -1 * invT + (20128.6666321888) * invT2;
   // rate of progress

--- a/Support/Mechanism/Models/JL4/mechanism.H
+++ b/Support/Mechanism/Models/JL4/mechanism.H
@@ -1913,8 +1913,7 @@ comp_qfqr(
 {
 
   // reaction 0: 2 CH4 + O2 => 2 CO + 4 H2
-  qf[0] =
-    std::sqrt(std::max(sc[0], 1e-14)) * pow(std::max(sc[1], 1e-14), 1.250000);
+  qf[0] = std::sqrt(std::max(sc[0], 0.0)) * pow(std::max(sc[1], 0.0), 1.250000);
   qr[0] = 0.0;
 
   // reaction 1: CH4 + H2O <=> CO + 3 H2
@@ -1922,8 +1921,8 @@ comp_qfqr(
   qr[1] = sc[4] * sc[6] * sc[6] * sc[6];
 
   // reaction 2: 2 H2 + O2 => 2 H2O
-  qf[2] = pow(std::max(sc[1], 1e-14), 1.500000) *
-          pow(std::max(sc[6], 1e-14), 0.250000);
+  qf[2] =
+    pow(std::max(sc[1], 0.0), 1.500000) * pow(std::max(sc[6], 0.0), 0.250000);
   qr[2] = 0.0;
 
   // reaction 3: CO + H2O <=> CO2 + H2
@@ -1999,8 +1998,8 @@ productionRate(amrex::Real* wdot, const amrex::Real* sc, const amrex::Real T)
   {
     // reaction 0:  2 CH4 + O2 => 2 CO + 4 H2
     const amrex::Real k_f = 1236450565.12584 * exp(-(15096.4999741416) * invT);
-    const amrex::Real qf = k_f * (std::sqrt(std::max(sc[0], 1e-14)) *
-                                  pow(std::max(sc[1], 1e-14), 1.250000));
+    const amrex::Real qf = k_f * (std::sqrt(std::max(sc[0], 0.0)) *
+                                  pow(std::max(sc[1], 0.0), 1.250000));
     const amrex::Real qr = 0.0;
     const amrex::Real qdot = qf - qr;
     wdot[0] -= 2.000000 * qdot;
@@ -2027,8 +2026,8 @@ productionRate(amrex::Real* wdot, const amrex::Real* sc, const amrex::Real T)
     // reaction 2:  2 H2 + O2 => 2 H2O
     const amrex::Real k_f =
       191159684557179 * exp((-1) * tc[0] - (20128.6666321888) * invT);
-    const amrex::Real qf = k_f * (pow(std::max(sc[1], 1e-14), 1.500000) *
-                                  pow(std::max(sc[6], 1e-14), 0.250000));
+    const amrex::Real qf = k_f * (pow(std::max(sc[1], 0.0), 1.500000) *
+                                  pow(std::max(sc[6], 0.0), 0.250000));
     const amrex::Real qr = 0.0;
     const amrex::Real qdot = qf - qr;
     wdot[1] -= qdot;
@@ -2328,8 +2327,7 @@ aJacobian_precond(
   // reaction 0: 2 CH4 + O2 => 2 CO + 4 H2
   // a non-third-body and non-pressure-fall-off reaction
   // forward
-  phi_f =
-    std::sqrt(std::max(sc[0], 1e-14)) * pow(std::max(sc[1], 1e-14), 1.250000);
+  phi_f = std::sqrt(std::max(sc[0], 0.0)) * pow(std::max(sc[1], 0.0), 1.250000);
   k_f = 1236450565.12584 * exp(-(15096.4999741416) * invT);
   dlnkfdT = (15096.4999741416) * invT2;
   // rate of progress
@@ -2341,15 +2339,15 @@ aJacobian_precond(
   wdot[4] += 2 * q; // CO
   wdot[6] += 4 * q; // H2
   // d()/d[CH4]
-  dqdci = +k_f * 0.500000 * pow(std::max(sc[0], 1e-14), -0.500000) *
-          pow(std::max(sc[1], 1e-14), 1.250000);
+  dqdci = +k_f * 0.500000 * pow(std::max(sc[0], 1e-16), -0.500000) *
+          pow(std::max(sc[1], 0.0), 1.250000);
   J[0] += -2 * dqdci; // dwdot[CH4]/d[CH4]
   J[1] -= dqdci;      // dwdot[O2]/d[CH4]
   J[4] += 2 * dqdci;  // dwdot[CO]/d[CH4]
   J[6] += 4 * dqdci;  // dwdot[H2]/d[CH4]
   // d()/d[O2]
-  dqdci = +k_f * std::sqrt(std::max(sc[0], 1e-14)) * 1.250000 *
-          pow(std::max(sc[1], 1e-14), 0.250000);
+  dqdci = +k_f * std::sqrt(std::max(sc[0], 0.0)) * 1.250000 *
+          pow(std::max(sc[1], 0.0), 0.250000);
   J[8] += -2 * dqdci; // dwdot[CH4]/d[O2]
   J[9] -= dqdci;      // dwdot[O2]/d[O2]
   J[12] += 2 * dqdci; // dwdot[CO]/d[O2]
@@ -2414,8 +2412,8 @@ aJacobian_precond(
   // reaction 2: 2 H2 + O2 => 2 H2O
   // a non-third-body and non-pressure-fall-off reaction
   // forward
-  phi_f = pow(std::max(sc[1], 1e-14), 1.500000) *
-          pow(std::max(sc[6], 1e-14), 0.250000);
+  phi_f =
+    pow(std::max(sc[1], 0.0), 1.500000) * pow(std::max(sc[6], 0.0), 0.250000);
   k_f = 191159684557179 * exp(-1 * tc[0] - (20128.6666321888) * invT);
   dlnkfdT = -1 * invT + (20128.6666321888) * invT2;
   // rate of progress
@@ -2426,14 +2424,14 @@ aJacobian_precond(
   wdot[2] += 2 * q; // H2O
   wdot[6] -= 2 * q; // H2
   // d()/d[O2]
-  dqdci = +k_f * 1.500000 * std::sqrt(std::max(sc[1], 1e-14)) *
-          pow(std::max(sc[6], 1e-14), 0.250000);
+  dqdci = +k_f * 1.500000 * std::sqrt(std::max(sc[1], 0.0)) *
+          pow(std::max(sc[6], 0.0), 0.250000);
   J[9] -= dqdci;       // dwdot[O2]/d[O2]
   J[10] += 2 * dqdci;  // dwdot[H2O]/d[O2]
   J[14] += -2 * dqdci; // dwdot[H2]/d[O2]
   // d()/d[H2]
-  dqdci = +k_f * pow(std::max(sc[1], 1e-14), 1.500000) * 0.250000 *
-          pow(std::max(sc[6], 1e-14), -0.750000);
+  dqdci = +k_f * pow(std::max(sc[1], 0.0), 1.500000) * 0.250000 *
+          pow(std::max(sc[6], 1e-16), -0.750000);
   J[49] -= dqdci;      // dwdot[O2]/d[H2]
   J[50] += 2 * dqdci;  // dwdot[H2O]/d[H2]
   J[54] += -2 * dqdci; // dwdot[H2]/d[H2]
@@ -2606,8 +2604,7 @@ aJacobian(
   // reaction 0: 2 CH4 + O2 => 2 CO + 4 H2
   // a non-third-body and non-pressure-fall-off reaction
   // forward
-  phi_f =
-    std::sqrt(std::max(sc[0], 1e-14)) * pow(std::max(sc[1], 1e-14), 1.250000);
+  phi_f = std::sqrt(std::max(sc[0], 0.0)) * pow(std::max(sc[1], 0.0), 1.250000);
   k_f = 1236450565.12584 * exp(-(15096.4999741416) * invT);
   dlnkfdT = (15096.4999741416) * invT2;
   // rate of progress
@@ -2619,15 +2616,15 @@ aJacobian(
   wdot[4] += 2 * q; // CO
   wdot[6] += 4 * q; // H2
   // d()/d[CH4]
-  dqdci = +k_f * 0.500000 * pow(std::max(sc[0], 1e-14), -0.500000) *
-          pow(std::max(sc[1], 1e-14), 1.250000);
+  dqdci = +k_f * 0.500000 * pow(std::max(sc[0], 1e-16), -0.500000) *
+          pow(std::max(sc[1], 0.0), 1.250000);
   J[0] += -2 * dqdci; // dwdot[CH4]/d[CH4]
   J[1] -= dqdci;      // dwdot[O2]/d[CH4]
   J[4] += 2 * dqdci;  // dwdot[CO]/d[CH4]
   J[6] += 4 * dqdci;  // dwdot[H2]/d[CH4]
   // d()/d[O2]
-  dqdci = +k_f * std::sqrt(std::max(sc[0], 1e-14)) * 1.250000 *
-          pow(std::max(sc[1], 1e-14), 0.250000);
+  dqdci = +k_f * std::sqrt(std::max(sc[0], 0.0)) * 1.250000 *
+          pow(std::max(sc[1], 0.0), 0.250000);
   J[8] += -2 * dqdci; // dwdot[CH4]/d[O2]
   J[9] -= dqdci;      // dwdot[O2]/d[O2]
   J[12] += 2 * dqdci; // dwdot[CO]/d[O2]
@@ -2692,8 +2689,8 @@ aJacobian(
   // reaction 2: 2 H2 + O2 => 2 H2O
   // a non-third-body and non-pressure-fall-off reaction
   // forward
-  phi_f = pow(std::max(sc[1], 1e-14), 1.500000) *
-          pow(std::max(sc[6], 1e-14), 0.250000);
+  phi_f =
+    pow(std::max(sc[1], 0.0), 1.500000) * pow(std::max(sc[6], 0.0), 0.250000);
   k_f = 191159684557179 * exp(-1 * tc[0] - (20128.6666321888) * invT);
   dlnkfdT = -1 * invT + (20128.6666321888) * invT2;
   // rate of progress
@@ -2704,14 +2701,14 @@ aJacobian(
   wdot[2] += 2 * q; // H2O
   wdot[6] -= 2 * q; // H2
   // d()/d[O2]
-  dqdci = +k_f * 1.500000 * std::sqrt(std::max(sc[1], 1e-14)) *
-          pow(std::max(sc[6], 1e-14), 0.250000);
+  dqdci = +k_f * 1.500000 * std::sqrt(std::max(sc[1], 0.0)) *
+          pow(std::max(sc[6], 0.0), 0.250000);
   J[9] -= dqdci;       // dwdot[O2]/d[O2]
   J[10] += 2 * dqdci;  // dwdot[H2O]/d[O2]
   J[14] += -2 * dqdci; // dwdot[H2]/d[O2]
   // d()/d[H2]
-  dqdci = +k_f * pow(std::max(sc[1], 1e-14), 1.500000) * 0.250000 *
-          pow(std::max(sc[6], 1e-14), -0.750000);
+  dqdci = +k_f * pow(std::max(sc[1], 0.0), 1.500000) * 0.250000 *
+          pow(std::max(sc[6], 1e-16), -0.750000);
   J[49] -= dqdci;      // dwdot[O2]/d[H2]
   J[50] += 2 * dqdci;  // dwdot[H2O]/d[H2]
   J[54] += -2 * dqdci; // dwdot[H2]/d[H2]

--- a/Support/Mechanism/Models/JL4/mechanism.H
+++ b/Support/Mechanism/Models/JL4/mechanism.H
@@ -2336,14 +2336,15 @@ aJacobian_precond(
   wdot[4] += 2 * q; // CO
   wdot[6] += 4 * q; // H2
   // d()/d[CH4]
-  dqdci = +k_f * 0.500000 * pow(std::max(sc[0], 1e-12), -0.500000) *
-          pow(sc[1], 1.250000);
+  dqdci = +k_f * 0.500000 * pow(std::max(sc[0], 1e-14), -0.500000) *
+          pow(std::max(sc[1], 1e-14), 1.250000);
   J[0] += -2 * dqdci; // dwdot[CH4]/d[CH4]
   J[1] -= dqdci;      // dwdot[O2]/d[CH4]
   J[4] += 2 * dqdci;  // dwdot[CO]/d[CH4]
   J[6] += 4 * dqdci;  // dwdot[H2]/d[CH4]
   // d()/d[O2]
-  dqdci = +k_f * pow(sc[0], 0.500000) * 1.250000 * pow(sc[1], 0.250000);
+  dqdci = +k_f * std::sqrt(std::max(sc[0], 1e-14)) * 1.250000 *
+          pow(std::max(sc[1], 1e-14), 0.250000);
   J[8] += -2 * dqdci; // dwdot[CH4]/d[O2]
   J[9] -= dqdci;      // dwdot[O2]/d[O2]
   J[12] += 2 * dqdci; // dwdot[CO]/d[O2]
@@ -2419,13 +2420,14 @@ aJacobian_precond(
   wdot[2] += 2 * q; // H2O
   wdot[6] -= 2 * q; // H2
   // d()/d[O2]
-  dqdci = +k_f * 1.500000 * pow(sc[1], 0.500000) * pow(sc[6], 0.250000);
+  dqdci = +k_f * 1.500000 * std::sqrt(std::max(sc[1], 1e-14)) *
+          pow(std::max(sc[6], 1e-14), 0.250000);
   J[9] -= dqdci;       // dwdot[O2]/d[O2]
   J[10] += 2 * dqdci;  // dwdot[H2O]/d[O2]
   J[14] += -2 * dqdci; // dwdot[H2]/d[O2]
   // d()/d[H2]
-  dqdci = +k_f * pow(sc[1], 1.500000) * 0.250000 *
-          pow(std::max(sc[6], 1e-12), -0.750000);
+  dqdci = +k_f * pow(std::max(sc[1], 1e-14), 1.500000) * 0.250000 *
+          pow(std::max(sc[6], 1e-14), -0.750000);
   J[49] -= dqdci;      // dwdot[O2]/d[H2]
   J[50] += 2 * dqdci;  // dwdot[H2O]/d[H2]
   J[54] += -2 * dqdci; // dwdot[H2]/d[H2]
@@ -2610,14 +2612,15 @@ aJacobian(
   wdot[4] += 2 * q; // CO
   wdot[6] += 4 * q; // H2
   // d()/d[CH4]
-  dqdci = +k_f * 0.500000 * pow(std::max(sc[0], 1e-12), -0.500000) *
-          pow(sc[1], 1.250000);
+  dqdci = +k_f * 0.500000 * pow(std::max(sc[0], 1e-14), -0.500000) *
+          pow(std::max(sc[1], 1e-14), 1.250000);
   J[0] += -2 * dqdci; // dwdot[CH4]/d[CH4]
   J[1] -= dqdci;      // dwdot[O2]/d[CH4]
   J[4] += 2 * dqdci;  // dwdot[CO]/d[CH4]
   J[6] += 4 * dqdci;  // dwdot[H2]/d[CH4]
   // d()/d[O2]
-  dqdci = +k_f * pow(sc[0], 0.500000) * 1.250000 * pow(sc[1], 0.250000);
+  dqdci = +k_f * std::sqrt(std::max(sc[0], 1e-14)) * 1.250000 *
+          pow(std::max(sc[1], 1e-14), 0.250000);
   J[8] += -2 * dqdci; // dwdot[CH4]/d[O2]
   J[9] -= dqdci;      // dwdot[O2]/d[O2]
   J[12] += 2 * dqdci; // dwdot[CO]/d[O2]
@@ -2693,13 +2696,14 @@ aJacobian(
   wdot[2] += 2 * q; // H2O
   wdot[6] -= 2 * q; // H2
   // d()/d[O2]
-  dqdci = +k_f * 1.500000 * pow(sc[1], 0.500000) * pow(sc[6], 0.250000);
+  dqdci = +k_f * 1.500000 * std::sqrt(std::max(sc[1], 1e-14)) *
+          pow(std::max(sc[6], 1e-14), 0.250000);
   J[9] -= dqdci;       // dwdot[O2]/d[O2]
   J[10] += 2 * dqdci;  // dwdot[H2O]/d[O2]
   J[14] += -2 * dqdci; // dwdot[H2]/d[O2]
   // d()/d[H2]
-  dqdci = +k_f * pow(sc[1], 1.500000) * 0.250000 *
-          pow(std::max(sc[6], 1e-12), -0.750000);
+  dqdci = +k_f * pow(std::max(sc[1], 1e-14), 1.500000) * 0.250000 *
+          pow(std::max(sc[6], 1e-14), -0.750000);
   J[49] -= dqdci;      // dwdot[O2]/d[H2]
   J[50] += 2 * dqdci;  // dwdot[H2O]/d[H2]
   J[54] += -2 * dqdci; // dwdot[H2]/d[H2]

--- a/Support/Mechanism/Models/chem-CH4-2step/mechanism.H
+++ b/Support/Mechanism/Models/chem-CH4-2step/mechanism.H
@@ -1787,8 +1787,8 @@ comp_qfqr(
   qr[0] = 0.0;
 
   // reaction 1: 2 CO + O2 => 2 CO2
-  qf[1] = pow(std::max(sc[0], 1e-14), 0.250000) *
-          std::sqrt(std::max(sc[1], 1e-14)) * sc[3];
+  qf[1] = pow(std::max(sc[0], 0.0), 0.250000) *
+          std::sqrt(std::max(sc[1], 0.0)) * sc[3];
   qr[1] = 0.0;
 
   // reaction 2: 2 CO2 => 2 CO + O2
@@ -1873,8 +1873,8 @@ productionRate(amrex::Real* wdot, const amrex::Real* sc, const amrex::Real T)
   {
     // reaction 1:  2 CO + O2 => 2 CO2
     const amrex::Real k_f = 6296094821.39524 * exp(-(20128.6666321888) * invT);
-    const amrex::Real qf = k_f * (pow(std::max(sc[0], 1e-14), 0.250000) *
-                                  std::sqrt(std::max(sc[1], 1e-14)) * sc[3]);
+    const amrex::Real qf = k_f * (pow(std::max(sc[0], 0.0), 0.250000) *
+                                  std::sqrt(std::max(sc[1], 0.0)) * sc[3]);
     const amrex::Real qr = 0.0;
     const amrex::Real qdot = qf - qr;
     wdot[0] -= qdot;
@@ -2196,8 +2196,8 @@ aJacobian_precond(
   // reaction 1: 2 CO + O2 => 2 CO2
   // a non-third-body and non-pressure-fall-off reaction
   // forward
-  phi_f = pow(std::max(sc[0], 1e-14), 0.250000) *
-          std::sqrt(std::max(sc[1], 1e-14)) * sc[3];
+  phi_f = pow(std::max(sc[0], 0.0), 0.250000) *
+          std::sqrt(std::max(sc[1], 0.0)) * sc[3];
   k_f = 6296094821.39524 * exp(-(20128.6666321888) * invT);
   dlnkfdT = (20128.6666321888) * invT2;
   // rate of progress
@@ -2208,20 +2208,20 @@ aJacobian_precond(
   wdot[3] -= 2 * q; // CO
   wdot[4] += 2 * q; // CO2
   // d()/d[O2]
-  dqdci = +k_f * 0.250000 * pow(std::max(sc[0], 1e-14), -0.750000) *
-          std::sqrt(std::max(sc[1], 1e-14)) * sc[3];
+  dqdci = +k_f * 0.250000 * pow(std::max(sc[0], 1e-16), -0.750000) *
+          std::sqrt(std::max(sc[1], 0.0)) * sc[3];
   J[0] -= dqdci;      // dwdot[O2]/d[O2]
   J[3] += -2 * dqdci; // dwdot[CO]/d[O2]
   J[4] += 2 * dqdci;  // dwdot[CO2]/d[O2]
   // d()/d[H2O]
-  dqdci = +k_f * pow(std::max(sc[0], 1e-14), 0.250000) * 0.500000 *
-          pow(std::max(sc[1], 1e-14), -0.500000) * sc[3];
+  dqdci = +k_f * pow(std::max(sc[0], 0.0), 0.250000) * 0.500000 *
+          pow(std::max(sc[1], 1e-16), -0.500000) * sc[3];
   J[7] -= dqdci;       // dwdot[O2]/d[H2O]
   J[10] += -2 * dqdci; // dwdot[CO]/d[H2O]
   J[11] += 2 * dqdci;  // dwdot[CO2]/d[H2O]
   // d()/d[CO]
-  dqdci = +k_f * pow(std::max(sc[0], 1e-14), 0.250000) *
-          std::sqrt(std::max(sc[1], 1e-14));
+  dqdci = +k_f * pow(std::max(sc[0], 0.0), 0.250000) *
+          std::sqrt(std::max(sc[1], 0.0));
   J[21] -= dqdci;      // dwdot[O2]/d[CO]
   J[24] += -2 * dqdci; // dwdot[CO]/d[CO]
   J[25] += 2 * dqdci;  // dwdot[CO2]/d[CO]
@@ -2399,8 +2399,8 @@ aJacobian(
   // reaction 1: 2 CO + O2 => 2 CO2
   // a non-third-body and non-pressure-fall-off reaction
   // forward
-  phi_f = pow(std::max(sc[0], 1e-14), 0.250000) *
-          std::sqrt(std::max(sc[1], 1e-14)) * sc[3];
+  phi_f = pow(std::max(sc[0], 0.0), 0.250000) *
+          std::sqrt(std::max(sc[1], 0.0)) * sc[3];
   k_f = 6296094821.39524 * exp(-(20128.6666321888) * invT);
   dlnkfdT = (20128.6666321888) * invT2;
   // rate of progress
@@ -2411,20 +2411,20 @@ aJacobian(
   wdot[3] -= 2 * q; // CO
   wdot[4] += 2 * q; // CO2
   // d()/d[O2]
-  dqdci = +k_f * 0.250000 * pow(std::max(sc[0], 1e-14), -0.750000) *
-          std::sqrt(std::max(sc[1], 1e-14)) * sc[3];
+  dqdci = +k_f * 0.250000 * pow(std::max(sc[0], 1e-16), -0.750000) *
+          std::sqrt(std::max(sc[1], 0.0)) * sc[3];
   J[0] -= dqdci;      // dwdot[O2]/d[O2]
   J[3] += -2 * dqdci; // dwdot[CO]/d[O2]
   J[4] += 2 * dqdci;  // dwdot[CO2]/d[O2]
   // d()/d[H2O]
-  dqdci = +k_f * pow(std::max(sc[0], 1e-14), 0.250000) * 0.500000 *
-          pow(std::max(sc[1], 1e-14), -0.500000) * sc[3];
+  dqdci = +k_f * pow(std::max(sc[0], 0.0), 0.250000) * 0.500000 *
+          pow(std::max(sc[1], 1e-16), -0.500000) * sc[3];
   J[7] -= dqdci;       // dwdot[O2]/d[H2O]
   J[10] += -2 * dqdci; // dwdot[CO]/d[H2O]
   J[11] += 2 * dqdci;  // dwdot[CO2]/d[H2O]
   // d()/d[CO]
-  dqdci = +k_f * pow(std::max(sc[0], 1e-14), 0.250000) *
-          std::sqrt(std::max(sc[1], 1e-14));
+  dqdci = +k_f * pow(std::max(sc[0], 0.0), 0.250000) *
+          std::sqrt(std::max(sc[1], 0.0));
   J[21] -= dqdci;      // dwdot[O2]/d[CO]
   J[24] += -2 * dqdci; // dwdot[CO]/d[CO]
   J[25] += 2 * dqdci;  // dwdot[CO2]/d[CO]

--- a/Support/Mechanism/Models/chem-CH4-2step/mechanism.H
+++ b/Support/Mechanism/Models/chem-CH4-2step/mechanism.H
@@ -2206,19 +2206,20 @@ aJacobian_precond(
   wdot[3] -= 2 * q; // CO
   wdot[4] += 2 * q; // CO2
   // d()/d[O2]
-  dqdci = +k_f * 0.250000 * pow(std::max(sc[0], 1e-12), -0.750000) *
-          pow(sc[1], 0.500000) * sc[3];
+  dqdci = +k_f * 0.250000 * pow(std::max(sc[0], 1e-14), -0.750000) *
+          std::sqrt(std::max(sc[1], 1e-14)) * sc[3];
   J[0] -= dqdci;      // dwdot[O2]/d[O2]
   J[3] += -2 * dqdci; // dwdot[CO]/d[O2]
   J[4] += 2 * dqdci;  // dwdot[CO2]/d[O2]
   // d()/d[H2O]
-  dqdci = +k_f * pow(sc[0], 0.250000) * 0.500000 *
-          pow(std::max(sc[1], 1e-12), -0.500000) * sc[3];
+  dqdci = +k_f * pow(std::max(sc[0], 1e-14), 0.250000) * 0.500000 *
+          pow(std::max(sc[1], 1e-14), -0.500000) * sc[3];
   J[7] -= dqdci;       // dwdot[O2]/d[H2O]
   J[10] += -2 * dqdci; // dwdot[CO]/d[H2O]
   J[11] += 2 * dqdci;  // dwdot[CO2]/d[H2O]
   // d()/d[CO]
-  dqdci = +k_f * pow(sc[0], 0.250000) * pow(sc[1], 0.500000);
+  dqdci = +k_f * pow(std::max(sc[0], 1e-14), 0.250000) *
+          std::sqrt(std::max(sc[1], 1e-14));
   J[21] -= dqdci;      // dwdot[O2]/d[CO]
   J[24] += -2 * dqdci; // dwdot[CO]/d[CO]
   J[25] += 2 * dqdci;  // dwdot[CO2]/d[CO]
@@ -2407,19 +2408,20 @@ aJacobian(
   wdot[3] -= 2 * q; // CO
   wdot[4] += 2 * q; // CO2
   // d()/d[O2]
-  dqdci = +k_f * 0.250000 * pow(std::max(sc[0], 1e-12), -0.750000) *
-          pow(sc[1], 0.500000) * sc[3];
+  dqdci = +k_f * 0.250000 * pow(std::max(sc[0], 1e-14), -0.750000) *
+          std::sqrt(std::max(sc[1], 1e-14)) * sc[3];
   J[0] -= dqdci;      // dwdot[O2]/d[O2]
   J[3] += -2 * dqdci; // dwdot[CO]/d[O2]
   J[4] += 2 * dqdci;  // dwdot[CO2]/d[O2]
   // d()/d[H2O]
-  dqdci = +k_f * pow(sc[0], 0.250000) * 0.500000 *
-          pow(std::max(sc[1], 1e-12), -0.500000) * sc[3];
+  dqdci = +k_f * pow(std::max(sc[0], 1e-14), 0.250000) * 0.500000 *
+          pow(std::max(sc[1], 1e-14), -0.500000) * sc[3];
   J[7] -= dqdci;       // dwdot[O2]/d[H2O]
   J[10] += -2 * dqdci; // dwdot[CO]/d[H2O]
   J[11] += 2 * dqdci;  // dwdot[CO2]/d[H2O]
   // d()/d[CO]
-  dqdci = +k_f * pow(sc[0], 0.250000) * pow(sc[1], 0.500000);
+  dqdci = +k_f * pow(std::max(sc[0], 1e-14), 0.250000) *
+          std::sqrt(std::max(sc[1], 1e-14));
   J[21] -= dqdci;      // dwdot[O2]/d[CO]
   J[24] += -2 * dqdci; // dwdot[CO]/d[CO]
   J[25] += 2 * dqdci;  // dwdot[CO2]/d[CO]

--- a/Support/Mechanism/Models/chem-CH4-2step/mechanism.H
+++ b/Support/Mechanism/Models/chem-CH4-2step/mechanism.H
@@ -1787,7 +1787,8 @@ comp_qfqr(
   qr[0] = 0.0;
 
   // reaction 1: 2 CO + O2 => 2 CO2
-  qf[1] = pow(sc[0], 0.250000) * pow(sc[1], 0.500000) * sc[3];
+  qf[1] = pow(std::max(sc[0], 1e-14), 0.250000) *
+          std::sqrt(std::max(sc[1], 1e-14)) * sc[3];
   qr[1] = 0.0;
 
   // reaction 2: 2 CO2 => 2 CO + O2
@@ -1872,8 +1873,8 @@ productionRate(amrex::Real* wdot, const amrex::Real* sc, const amrex::Real T)
   {
     // reaction 1:  2 CO + O2 => 2 CO2
     const amrex::Real k_f = 6296094821.39524 * exp(-(20128.6666321888) * invT);
-    const amrex::Real qf =
-      k_f * (pow(sc[0], 0.250000) * pow(sc[1], 0.500000) * sc[3]);
+    const amrex::Real qf = k_f * (pow(std::max(sc[0], 1e-14), 0.250000) *
+                                  std::sqrt(std::max(sc[1], 1e-14)) * sc[3]);
     const amrex::Real qr = 0.0;
     const amrex::Real qdot = qf - qr;
     wdot[0] -= qdot;
@@ -2195,7 +2196,8 @@ aJacobian_precond(
   // reaction 1: 2 CO + O2 => 2 CO2
   // a non-third-body and non-pressure-fall-off reaction
   // forward
-  phi_f = pow(sc[0], 0.250000) * pow(sc[1], 0.500000) * sc[3];
+  phi_f = pow(std::max(sc[0], 1e-14), 0.250000) *
+          std::sqrt(std::max(sc[1], 1e-14)) * sc[3];
   k_f = 6296094821.39524 * exp(-(20128.6666321888) * invT);
   dlnkfdT = (20128.6666321888) * invT2;
   // rate of progress
@@ -2397,7 +2399,8 @@ aJacobian(
   // reaction 1: 2 CO + O2 => 2 CO2
   // a non-third-body and non-pressure-fall-off reaction
   // forward
-  phi_f = pow(sc[0], 0.250000) * pow(sc[1], 0.500000) * sc[3];
+  phi_f = pow(std::max(sc[0], 1e-14), 0.250000) *
+          std::sqrt(std::max(sc[1], 1e-14)) * sc[3];
   k_f = 6296094821.39524 * exp(-(20128.6666321888) * invT);
   dlnkfdT = (20128.6666321888) * invT2;
   // rate of progress

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -1440,6 +1440,7 @@ def dphase_space(mechanism, species_info, reagents, r, reaction_orders, syms):
         else:
             order = coefficient
         if symbol not in species_info.qssa_species_list:
+            sc_cutoff = "1e-14"
             if symbol == r:
                 if order > 1:
                     phi += [f"{order:f}"]
@@ -1452,15 +1453,18 @@ def dphase_space(mechanism, species_info, reagents, r, reaction_orders, syms):
                                 [f"sc[{species_info.ordered_idx_map[symbol]}]"]
                                 * int(exponent)
                             )
+                        elif exponent == 0.5:
+                            idx = species_info.ordered_idx_map[symbol]
+                            conc = f"std::sqrt(std::max(sc[{idx}], {sc_cutoff}))"
                         else:
                             idx = species_info.ordered_idx_map[symbol]
-                            conc = f"pow(sc[{idx}],{exponent:f})"
+                            conc = f"pow(std::max(sc[{idx}], {sc_cutoff}),{exponent:f})"
                     phi += [conc]
                 elif order < 1:
                     phi += [f"{order:f}"]
                     exponent = order - 1.0
                     idx = species_info.ordered_idx_map[symbol]
-                    conc = f"pow(std::max(sc[{idx}], 1e-12),{exponent:f})"
+                    conc = f"pow(std::max(sc[{idx}], {sc_cutoff}),{exponent:f})"
                     phi += [conc]
             else:
                 if order == 1.0:
@@ -1470,9 +1474,13 @@ def dphase_space(mechanism, species_info, reagents, r, reaction_orders, syms):
                         conc = "*".join(
                             [f"sc[{species_info.ordered_idx_map[symbol]}]"] * int(order)
                         )
+                    elif order == 0.5:
+                        conc = (
+                            f"std::sqrt(std::max(sc[{species_info.ordered_idx_map[symbol]}], {sc_cutoff}))"
+                        )
                     else:
                         conc = (
-                            f"pow(sc[{species_info.ordered_idx_map[symbol]}],"
+                            f"pow(std::max(sc[{species_info.ordered_idx_map[symbol]}], {sc_cutoff}),"
                             f" {order:f})"
                         )
                 phi += [conc]

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -1440,7 +1440,6 @@ def dphase_space(mechanism, species_info, reagents, r, reaction_orders, syms):
         else:
             order = coefficient
         if symbol not in species_info.qssa_species_list:
-            sc_cutoff = "1e-14"
             if symbol == r:
                 if order > 1:
                     phi += [f"{order:f}"]
@@ -1455,16 +1454,24 @@ def dphase_space(mechanism, species_info, reagents, r, reaction_orders, syms):
                             )
                         elif exponent == 0.5:
                             idx = species_info.ordered_idx_map[symbol]
-                            conc = f"std::sqrt(std::max(sc[{idx}], {sc_cutoff}))"
+                            conc = (
+                                f"std::sqrt(std::max(sc[{idx}], {cu.sc_cutoff(0.5)}))"
+                            )
                         else:
                             idx = species_info.ordered_idx_map[symbol]
-                            conc = f"pow(std::max(sc[{idx}], {sc_cutoff}),{exponent:f})"
+                            conc = (
+                                f"pow(std::max(sc[{idx}],"
+                                f" {cu.sc_cutoff(exponent)}),{exponent:f})"
+                            )
                     phi += [conc]
                 elif order < 1:
                     phi += [f"{order:f}"]
                     exponent = order - 1.0
                     idx = species_info.ordered_idx_map[symbol]
-                    conc = f"pow(std::max(sc[{idx}], {sc_cutoff}),{exponent:f})"
+                    conc = (
+                        f"pow(std::max(sc[{idx}],"
+                        f" {cu.sc_cutoff(exponent)}),{exponent:f})"
+                    )
                     phi += [conc]
             else:
                 if order == 1.0:
@@ -1477,12 +1484,12 @@ def dphase_space(mechanism, species_info, reagents, r, reaction_orders, syms):
                     elif order == 0.5:
                         conc = (
                             f"std::sqrt(std::max(sc[{species_info.ordered_idx_map[symbol]}],"
-                            f" {sc_cutoff}))"
+                            f" {cu.sc_cutoff(0.5)}))"
                         )
                     else:
                         conc = (
                             f"pow(std::max(sc[{species_info.ordered_idx_map[symbol]}],"
-                            f" {sc_cutoff}), {order:f})"
+                            f" {cu.sc_cutoff(order)}), {order:f})"
                         )
                 phi += [conc]
         # Symbol is in qssa_species_list

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -1476,12 +1476,13 @@ def dphase_space(mechanism, species_info, reagents, r, reaction_orders, syms):
                         )
                     elif order == 0.5:
                         conc = (
-                            f"std::sqrt(std::max(sc[{species_info.ordered_idx_map[symbol]}], {sc_cutoff}))"
+                            f"std::sqrt(std::max(sc[{species_info.ordered_idx_map[symbol]}],"
+                            f" {sc_cutoff}))"
                         )
                     else:
                         conc = (
-                            f"pow(std::max(sc[{species_info.ordered_idx_map[symbol]}], {sc_cutoff}),"
-                            f" {order:f})"
+                            f"pow(std::max(sc[{species_info.ordered_idx_map[symbol]}],"
+                            f" {sc_cutoff}), {order:f})"
                         )
                 phi += [conc]
         # Symbol is in qssa_species_list

--- a/Support/ceptr/ceptr/utilities.py
+++ b/Support/ceptr/ceptr/utilities.py
@@ -221,9 +221,11 @@ def fkc_conv_inv(self, mechanism, reaction, syms=None):
                 conversion_smp *= syms.refC_smp
         else:
             if dim.is_integer():
-                conversion = "*".join([f"refC"] * int(dim))
+                conversion = "*".join(["refC"] * int(dim))
             else:
-                conversion = "*".join([f"pow(std::max(refC, {sc_cutoff}), {abs(dim):f})"])
+                conversion = "*".join(
+                    [f"pow(std::max(refC, {sc_cutoff}), {abs(dim):f})"]
+                )
             if record_symbolic_operations:
                 conversion_smp *= syms.refC_smp**dim
 
@@ -254,7 +256,7 @@ def kc_conv(mechanism, reaction):
                 conversion = "*".join(["(refC * refC)"])
             else:
                 if dim.is_integer():
-                    conversion = "*".join([f"refC"] * int(dim))
+                    conversion = "*".join(["refC"] * int(dim))
                 else:
                     conversion = "*".join([f"pow(std::max(refC, {sc_cutoff}),{dim:f})"])
     else:
@@ -262,9 +264,11 @@ def kc_conv(mechanism, reaction):
             conversion = "*".join(["refCinv"])
         else:
             if dim.is_integer():
-                conversion = "*".join([f"refCinv"] * int(dim))
+                conversion = "*".join(["refCinv"] * int(dim))
             else:
-                conversion = "*".join([f"pow(std::max(refCinv, {sc_cutoff}),{abs(dim):f})"])
+                conversion = "*".join(
+                    [f"pow(std::max(refCinv, {sc_cutoff}),{abs(dim):f})"]
+                )
 
     return conversion
 


### PR DESCRIPTION
When doing fractional powers, make sure the concentrations are not negative.

Todo
- [x] regen qss mechs
- [x] remove the fixme on the sqrt (what's up with that @malihass?)

This is related to https://github.com/AMReX-Combustion/PeleLMeX/discussions/287