### PR TITLE
enable COMP=clang for TPL

### DIFF
--- a/ThirdParty/GNUmakefile
+++ b/ThirdParty/GNUmakefile
@@ -29,7 +29,7 @@ else
       CCOMPILER = pgicc
       CXXCOMPILER = pgiCC
     else
-      ifeq ($(lowercase_hcomp),$(filter $(lowercase_hcomp),llvm))
+      ifeq ($(lowercase_hcomp),$(filter $(lowercase_hcomp),llvm clang clang++))
         CCOMPILER = clang
         CXXCOMPILER = clang++
       else
@@ -67,7 +67,7 @@ INSTALL_PREFIX=$(PWD)/INSTALL/$(tp_suffix)
 
 ifeq ($(PELE_USE_KLU),TRUE)
   KLUSuffix   := .KLU
-  KLU_DEFINES=-DENABLE_KLU:BOOL=ON -DKLU_INCLUDE_DIR=${INSTALL_PREFIX}/include -DKLU_LIBRARY_DIR=${INSTALL_PREFIX}/lib 
+  KLU_DEFINES=-DENABLE_KLU:BOOL=ON -DKLU_INCLUDE_DIR=${INSTALL_PREFIX}/include -DKLU_LIBRARY_DIR=${INSTALL_PREFIX}/lib
   SS_BUILD_PREFIX=$(PWD)/BUILD/SUITESPARSE
 
   SS_DIST_DIR=$(SS_BUILD_PREFIX)/dist

--- a/ThirdParty/GNUmakefile
+++ b/ThirdParty/GNUmakefile
@@ -21,7 +21,7 @@ ifeq ($(lowercase_hcomp),$(filter $(lowercase_hcomp),gcc gnu g++ mpicc mpicxx))
     CXXCOMPILER = g++
   endif
 else
-  ifeq ($(lowercase_hcomp),$(filter $(lowercase_hcomp),intel))
+  ifeq ($(lowercase_hcomp),$(filter $(lowercase_hcomp),intel-classic))
     CCOMPILER = icc
     CXXCOMPILER = icpc
   else
@@ -45,7 +45,11 @@ else
                CCOMPILER = icx
                CXXCOMPILER = icpx
 	    else
-             $(error Unknown COMP setting)
+              ifeq ($(lowercase_hcomp),$(filter $(lowercase_hcomp),intel))
+                $(error for intel, specify COMP as intel-classic or intel-llvm)
+              else
+                $(error Unknown COMP setting)
+              endif
 	    endif
 	  endif
         endif


### PR DESCRIPTION
The AMReX GNUmake system interprets `COMP=llvm` and `COMP=clang` equivalently, so we should too for `TPL`.