### PR TITLE
Simplify ceptr python code

### DIFF
--- a/Support/ceptr/ceptr/converter.py
+++ b/Support/ceptr/ceptr/converter.py
@@ -178,6 +178,7 @@ class Converter:
                 " ",
                 all_species.weight,
             )
+        self.species_info.set_low_high_temperatures(self.mechanism)
 
     def writer(self):
         """Write out the C++ files."""

--- a/Support/ceptr/ceptr/inputs.py
+++ b/Support/ceptr/ceptr/inputs.py
@@ -1,7 +1,5 @@
 """Classes for toml input files."""
 
-import sys
-
 import toml
 
 
@@ -37,13 +35,13 @@ class Parameter:
         elif value is None:
             self.value = value
         else:
-            sys.exit(
+            raise TypeError(
                 f"Type does not match for {self.name} ({self.typer} is not"
                 f" {type(value)})"
             )
 
         if (self.choices is not None) and (value not in self.choices):
-            sys.exit(
+            raise ValueError(
                 f"Value {value} is not part of the available choices {self.choices}"
             )
 

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -1,7 +1,6 @@
 """Write jacobian functions."""
 
 import copy
-import sys
 from collections import Counter, OrderedDict
 from math import isclose
 
@@ -193,8 +192,6 @@ def ajac(
             cw.writer(fstream, "const amrex::Real log10e = 1.0/log(10.0);")
 
             for orig_idx, _ in reaction_info.idxmap.items():
-                # if orig_idx == 35:
-                #     exit()
                 reaction = mechanism.reaction(orig_idx)
 
                 cw.writer(
@@ -618,11 +615,10 @@ def ajac_reaction_d(
         elif is_lindemann:
             pass
         else:
-            print(
+            raise ValueError(
                 f"Unrecognized reaction rate type {reaction.rate.type},"
                 f" {reaction.rate.sub_type} for reaction: {reaction.equation}"
             )
-            sys.exit(1)
 
     has_alpha = False
     corr_s = ""
@@ -882,8 +878,7 @@ def ajac_reaction_d(
         #
         if is_sri:
             cw.writer(fstream, cw.comment("SRI form"))
-            print("FIXME: sri not supported in _ajac_reaction yet")
-            sys.exit(1)
+            raise NotImplementedError("FIXME: sri not supported in _ajac_reaction yet")
         elif is_troe:
             cw.writer(fstream, cw.comment("Troe form"))
             troe = reaction.rate.falloff_coeffs
@@ -1372,12 +1367,10 @@ def denhancement_d(mechanism, species_info, reaction, kid, cons_p):
     third_body = reaction.third_body is not None
     falloff = reaction.rate.type == "falloff"
     if not third_body and not falloff:
-        print("denhancement_d called for a reaction without a third body")
-        sys.exit(1)
+        raise ValueError("denhancement_d called for a reaction without a third body")
 
     if not reaction.third_body:
-        print("FIXME")
-        sys.exit(1)
+        raise NotImplementedError("FIXME")
         species, coefficient = third_body
         if species == "<mixture>":
             if cons_p:

--- a/Support/ceptr/ceptr/production.py
+++ b/Support/ceptr/ceptr/production.py
@@ -1,6 +1,5 @@
 """Production functions."""
 
-import sys
 from math import isclose
 
 import symengine as sme
@@ -22,9 +21,7 @@ def production_rate(
     n_qss_species = species_info.n_qssa_species
     n_reactions = mechanism.n_reactions
 
-    if len(reaction_info.index) != 7:
-        print("\n\nCheck this!!!\n")
-        sys.exit(1)
+    assert len(reaction_info.index) == 7
 
     itroe = reaction_info.index[0:2]
     isri = reaction_info.index[1:3]
@@ -243,11 +240,10 @@ def production_rate(
                 elif is_lindemann:
                     pass
                 else:
-                    print(
+                    raise ValueError(
                         f"Unrecognized reaction rate type {reaction.rate.type},"
                         f" {reaction.rate.sub_type} for reaction: {reaction.equation}"
                     )
-                    sys.exit(1)
 
             cw.writer(
                 fstream,
@@ -609,11 +605,10 @@ def production_rate(
                 elif is_lindemann:
                     pass
                 else:
-                    print(
+                    raise ValueError(
                         f"Unrecognized reaction rate type {reaction.rate.type},"
                         f" {reaction.rate.sub_type} for reaction: {reaction.equation}"
                     )
-                    sys.exit(1)
 
                 low_beta = syms.convert_number_to_int(low_beta)
 
@@ -811,7 +806,7 @@ def production_rate(
                             f" exp({-sri[1]:.15g} * invT)",
                         )
                         if syms is not None:
-                            sys.exit("Not done for now")
+                            raise NotImplementedError("Not done for now")
                     else:
                         cw.writer(
                             fstream,
@@ -819,22 +814,22 @@ def production_rate(
                             f" exp(-{sri[1]:.15g} * invT)",
                         )
                         if syms is not None:
-                            sys.exit("Not done for now")
+                            raise NotImplementedError("Not done for now")
                     if sri[2] > 1.0e-100:
                         cw.writer(fstream, f"   +  exp(logT / {sri[2]:.15g}) ")
                         if syms is not None:
-                            sys.exit("Not done for now")
+                            raise NotImplementedError("Not done for now")
                     else:
                         cw.writer(fstream, "   +  0. ")
                         if syms is not None:
-                            sys.exit("Not done for now")
+                            raise NotImplementedError("Not done for now")
                     cw.writer(
                         fstream,
                         f"   *  ({nsri} > 3 ? {sri[3]:.15g} *"
                         f" exp({sri[4]:.15g} * logT) : 1.0);",
                     )
                     if syms is not None:
-                        sys.exit("Not done for now")
+                        raise NotImplementedError("Not done for now")
                     cw.writer(fstream, "Corr = F * F_sri;")
                     cw.writer(
                         fstream,
@@ -932,11 +927,9 @@ def production_rate(
                 key=lambda v, dict_species=dict_species: dict_species[v[0]],
             )
             # Check for duplicates
-            if len(agents) != len(set(agents)):
-                message = f"Reaction {reaction} contains duplicate agents\n"
-                message += "This will create an issue for productionRate\n"
-                print(message)
-                sys.exit(1)
+            assert len(agents) == len(
+                set(agents)
+            ), f"Reaction {reaction} contains duplicate agents"
             # note that a species might appear as both reactant and product
             # a species might also appear twice or more on on each side
             # agents is a set that contains unique (symbol, coefficient)
@@ -1000,9 +993,7 @@ def production_rate_light(fstream, mechanism, species_info, reaction_info):
     n_species = species_info.n_species
     n_reactions = mechanism.n_reactions
 
-    if len(reaction_info.index) != 7:
-        print("\n\nCheck this!!!\n")
-        sys.exit(1)
+    assert len(reaction_info.index) == 7
 
     itroe = reaction_info.index[0:2]
     isri = reaction_info.index[1:3]
@@ -1179,11 +1170,10 @@ def production_rate_light(fstream, mechanism, species_info, reaction_info):
                 elif is_lindemann:
                     pass
                 else:
-                    print(
+                    raise ValueError(
                         f"Unrecognized reaction rate type {reaction.rate.type},"
                         f" {reaction.rate.sub_type} for reaction: {reaction.equation}"
                     )
-                    sys.exit(1)
 
             cw.writer(
                 fstream,
@@ -1398,11 +1388,9 @@ def production_rate_light(fstream, mechanism, species_info, reaction_info):
                 key=lambda v, dict_species=dict_species: dict_species[v[0]],
             )
             # Check for duplicates
-            if len(agents) != len(set(agents)):
-                message = f"Reaction {reaction} contains duplicate agents\n"
-                message += "This will create an issue for productionRate_light\n"
-                print(message)
-                sys.exit(1)
+            assert len(agents) == len(
+                set(agents)
+            ), f"Reaction {reaction} contains duplicate agents"
             # note that a species might appear as both reactant and product
             # a species might also appear twice or more on on each side
             # agents is a set that contains unique (symbol, coefficient)
@@ -1451,9 +1439,7 @@ def progress_rate_fr(fstream, mechanism, species_info, reaction_info):
     """Write progress rates."""
     n_reactions = mechanism.n_reactions
 
-    if len(reaction_info.index) != 7:
-        print("\n\nCheck this!!!\n")
-        sys.exit(1)
+    assert len(reaction_info.index) == 7
 
     cw.writer(fstream)
     cw.writer(fstream, cw.comment("compute the progress rate for each reaction"))
@@ -1523,12 +1509,10 @@ def enhancement_d_with_qss(mechanism, species_info, reaction, syms=None):
     third_body = reaction.third_body is not None
     falloff = reaction.rate.type == "falloff"
     if not third_body and not falloff:
-        print("enhancement_d called for a reaction without a third body")
-        sys.exit(1)
+        raise ValueError("enhancement_d called for a reaction without a third body")
 
     if not reaction.third_body:
-        print("FIXME EFFICIENCIES")
-        sys.exit(1)
+        raise NotImplementedError("FIXME EFFICIENCIES")
         species, coefficient = third_body
         if species == "<mixture>":
             if record_symbolic_operations:

--- a/Support/ceptr/ceptr/qssa.py
+++ b/Support/ceptr/ceptr/qssa.py
@@ -2,7 +2,6 @@
 
 import argparse
 import pathlib
-import sys
 import time
 
 import cantera as ct
@@ -28,9 +27,10 @@ def process_qss(fname, nqssa, visualize, method):
             False in f_non_qssa_species["species"]
             or True in f_non_qssa_species["species"]
         ):
-            print("Some species in non qssa list interpreted as Boolean.")
-            print("Use quotation marks to avoid this issue.")
-            sys.exit(1)
+            raise ValueError(
+                "Some species in non qssa list interpreted as Boolean."
+                "Use quotation marks to avoid this issue."
+            )
         non_qssa_species = f_non_qssa_species["species"]
     all_species = mechanism.species_names
     qssa_species = sorted(list(set(all_species) - set(non_qssa_species)))
@@ -69,8 +69,7 @@ def process_qss(fname, nqssa, visualize, method):
     )
 
     if cqr.qssa_coupling(qssa, qssa_species, forward_to_remove):
-        print("Failure to generate QSSA mechanism.")
-        sys.exit(1)
+        raise ValueError("Failure to generate QSSA mechanism.")
 
     qssa.update_user_header({"description": f"QSSA of {mechanism.name}"})
     qssa.update_user_data(

--- a/Support/ceptr/ceptr/qssa_converter.py
+++ b/Support/ceptr/ceptr/qssa_converter.py
@@ -1,7 +1,6 @@
 """QSSA functions needed for conversion."""
 
 import copy
-import sys
 from collections import Counter, OrderedDict, defaultdict
 from math import isclose
 
@@ -123,8 +122,7 @@ def qssa_validation(mechanism, species_info, reaction_info):
     # Check that QSSA species are all species used in the given mechanism
     for s in species_info.qssa_species_list:
         if s not in species_info.all_species_list:
-            text = "species " + s + " is not in the mechanism"
-            sys.exit(text)
+            raise ValueError(f"species {s} is not in the mechanism")
 
     # Check that QSSA species are consumed/produced at least once to
     # ensure theoretically valid QSSA option (There is more to it than
@@ -151,13 +149,11 @@ def qssa_validation(mechanism, species_info, reaction_info):
                     consumed += 1
 
         if consumed == 0 or produced == 0:
-            text = (
-                "Uh Oh! QSSA species "
-                + symbol
-                + " does not have a balanced consumption/production"
-                + "relationship in mechanism => bad QSSA choice"
+            raise ValueError(
+                f"Uh Oh! QSSA species {symbol}"
+                " does not have a balanced consumption/production"
+                "relationship in mechanism => bad QSSA choice"
             )
-            sys.exit(text)
 
 
 def qssa_coupling(mechanism, species_info, reaction_info):
@@ -184,11 +180,10 @@ def qssa_coupling(mechanism, species_info, reaction_info):
                             product == species_info.qssa_species_list[j]
                             for product, _ in reaction.products.items()
                         ):
-                            sys.exit(
-                                "Species "
-                                + species_info.qssa_species_list[j]
-                                + " appears as both prod and reacts. Check reaction "
-                                + reaction.equation
+                            raise ValueError(
+                                f"Species {species_info.qssa_species_list[j]} appears"
+                                " as both prod and reacts. Check reaction"
+                                f" {reaction.equation}"
                             )
 
                     # we know j is in reaction r. Options are
@@ -314,11 +309,10 @@ def qssa_coupling(mechanism, species_info, reaction_info):
                             product == species_info.qssa_species_list[j]
                             for product, _ in reaction.products.items()
                         ):
-                            sys.exit(
-                                "Species "
-                                + species_info.qssa_species_list[j]
-                                + " appears as both prod and reacts. Check reaction "
-                                + reaction.equation
+                            raise ValueError(
+                                f"Species {species_info.qssa_species_list[j]} appears"
+                                " as both prod and reacts. Check reaction"
+                                f" {reaction.equation}"
                             )
 
                     if reaction.reversible:
@@ -405,7 +399,7 @@ def qssa_coupling(mechanism, species_info, reaction_info):
     print("\n\n SC network for QSSA: ")
     print(species_info.qssa_info.scnet)
     if is_coupling:
-        sys.exit(
+        raise ValueError(
             "There is some quadratic coupling in mechanism."
             + "Here is the list of reactions to check: \n"
             + coupling_reactions
@@ -1438,9 +1432,7 @@ def qssa_coeff_functions(fstream, mechanism, species_info, reaction_info, syms):
                 special_first = False
             ispecial_qssa[1] = reaction_info.qssa_reactions.index(reac_id) + 1
 
-    if len(reaction_info.index) != 7:
-        print("\n\nCheck this!!!\n")
-        sys.exit(1)
+    assert len(reaction_info.index) == 7
 
     # qssa coefficients
     cw.writer(fstream)
@@ -1549,11 +1541,10 @@ def qssa_coeff_functions(fstream, mechanism, species_info, reaction_info, syms):
             elif is_lindemann:
                 pass
             else:
-                print(
+                raise ValueError(
                     f"Unrecognized reaction rate type {reaction.rate.type},"
                     f" {reaction.rate.sub_type} for reaction: {reaction.equation}"
                 )
-                sys.exit(1)
 
             beta = syms.convert_number_to_int(beta)
             low_beta = syms.convert_number_to_int(low_beta)
@@ -1969,9 +1960,7 @@ def qssa_component_functions(
                 special_first = False
             ispecial_qssa[1] = reaction_info.qssa_reactions.index(reac_id) + 1
 
-    if len(reaction_info.index) != 7:
-        print("\n\nCheck this!!!\n")
-        sys.exit(1)
+    assert len(reaction_info.index) == 7
 
     # k_f_qssa function
     cw.writer(fstream)
@@ -2046,11 +2035,10 @@ def qssa_component_functions(
             elif is_lindemann:
                 pass
             else:
-                print(
+                raise ValueError(
                     f"Unrecognized reaction rate type {reaction.rate.type},"
                     f" {reaction.rate.sub_type} for reaction: {reaction.equation}"
                 )
-                sys.exit(1)
 
         cw.writer(fstream, f"k_f[{index}] = {pef.m:.15g}")
         syms.kf_qss_smp_tmp[index] = pef.m
@@ -2195,16 +2183,6 @@ def qssa_component_functions(
             syms.sc_qss_smp[species_info.qssa_species_list.index(symbol)] = (
                 -numerator_smp / denominator_smp
             )
-            # print(f"Starting simplification of fraction for {symbol}...")
-            # times = time.time()
-            # syms.sc_qss_smp[
-            #    species_info.qssa_species_list.index(symbol)
-            # ] = smp.cancel(
-            #    syms.sc_qss_smp[species_info.qssa_species_list.index(symbol)]
-            # )
-            # timee = time.time()
-            # print(f"Time to simplify = {timee-times}")
-            # exit()
             cw.writer(fstream)
         # This case happens for dodecane_lu_qss
         if symbol in list(species_info.qssa_info.group.keys()):

--- a/Support/ceptr/ceptr/species_info.py
+++ b/Support/ceptr/ceptr/species_info.py
@@ -313,3 +313,12 @@ class SpeciesInfo:
 
         # Return a deepcopy to self
         self.wdot_df = wdot_df.copy(deep=True)
+
+    def set_low_high_temperatures(self, mechanism):
+        """Set low and high temperatures."""
+        self.low_temp = max(
+            mechanism.species(s).thermo.min_temp for s in self.nonqssa_species_list
+        )
+        self.high_temp = min(
+            mechanism.species(s).thermo.max_temp for s in self.nonqssa_species_list
+        )

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -87,7 +87,7 @@ class SymbolicMath:
         # temporary symbols that contain temperature dependence
 
         species_coeffs = cth.analyze_thermodynamics(mechanism, species_info, 0)
-        low_temp, high_temp, midpoints = species_coeffs
+        midpoints = species_coeffs
         self.midpointsList = []
         for mid_temp, _ in list(midpoints.items()):
             self.midpointsList.append(mid_temp)
@@ -145,7 +145,7 @@ class SymbolicMath:
 
             # temporary symbols that contain temperature dependence
             qss_species_coeffs = cth.analyze_thermodynamics(mechanism, species_info, 1)
-            low_temp, high_temp, midpoints = qss_species_coeffs
+            midpoints = qss_species_coeffs
             self.midpointsQSSList = []
             for mid_temp, _ in list(midpoints.items()):
                 self.midpointsQSSList.append(mid_temp)

--- a/Support/ceptr/ceptr/thermo.py
+++ b/Support/ceptr/ceptr/thermo.py
@@ -1,7 +1,6 @@
 """Thermodynamics functions."""
 
 import io
-import sys
 from collections import OrderedDict
 
 import ceptr.writer as cw
@@ -28,56 +27,26 @@ def thermo(fstream, mechanism, species_info, syms=None):
 
 def analyze_thermodynamics(mechanism, species_info, qss_flag):
     """Extract information from the thermodynamics model."""
-    low_temp = 0.0
-    high_temp = 1000000.0
-
     midpoints = OrderedDict()
 
-    if qss_flag:
-        for symbol in species_info.qssa_species_list:
-            species = mechanism.species(symbol)
-            model = species.thermo
+    spec_list = (
+        species_info.qssa_species_list
+        if qss_flag
+        else species_info.nonqssa_species_list
+    )
+    for symbol in spec_list:
+        species = mechanism.species(symbol)
+        model = species.thermo
 
-            if not model.n_coeffs == 15:
-                print("Unsupported thermo model.")
-                sys.exit(1)
+        assert model.n_coeffs == 15, "Unsupported thermo model."
 
-            lo_temp = model.min_temp
-            hi_temp = model.max_temp
-            if low_temp < lo_temp:
-                low_temp = lo_temp
-            if hi_temp < high_temp:
-                high_temp = hi_temp
-            mid = model.coeffs[0]
-            high_range = model.coeffs[1:8]
-            low_range = model.coeffs[8:15]
+        mid = model.coeffs[0]
+        high_range = model.coeffs[1:8]
+        low_range = model.coeffs[8:15]
 
-            midpoints.setdefault(mid, []).append((species, low_range, high_range))
+        midpoints.setdefault(mid, []).append((species, low_range, high_range))
 
-    else:
-        for symbol in species_info.nonqssa_species_list:
-            species = mechanism.species(symbol)
-            model = species.thermo
-
-            if not model.n_coeffs == 15:
-                print("Unsupported thermo model.")
-                sys.exit(1)
-
-            lo_temp = model.min_temp
-            hi_temp = model.max_temp
-            if low_temp < lo_temp:
-                low_temp = lo_temp
-            if hi_temp < high_temp:
-                high_temp = hi_temp
-            mid = model.coeffs[0]
-            high_range = model.coeffs[1:8]
-            low_range = model.coeffs[8:15]
-
-            midpoints.setdefault(mid, []).append((species, low_range, high_range))
-
-    species_info.low_temp = low_temp
-    species_info.high_temp = high_temp
-    return low_temp, high_temp, midpoints
+    return midpoints
 
 
 def generate_thermo_routine(
@@ -93,7 +62,7 @@ def generate_thermo_routine(
     inline=False,
 ):
     """Write a thermodynamics routine."""
-    low_temp, high_temp, midpoints = species_coeffs
+    midpoints = species_coeffs
 
     if not inline:
         cw.writer(
@@ -128,55 +97,32 @@ def generate_thermo_routine(
     if needs_log_temp:
         cw.writer(fstream, "const amrex::Real logT = log(T);")
 
-    # if name=="gibbs_qss":
-    #    print("name = ", name)
-    #    for mid_temp, species_list in list(midpoints.items()):
-    #        print("midpoints = ", mid_temp)
-    #    stop
-    # stop
     for mid_temp, species_list in list(midpoints.items()):
         lostream = io.StringIO()
         for species, low_range, _ in species_list:
-            if qss_flag:
-                idx = (
-                    species_info.ordered_idx_map[species.name] - species_info.n_species
-                )
-                cw.writer(lostream, cw.comment(f"species {idx}: {species.name}"))
-                cw.writer(
-                    lostream,
-                    (f"result += y[{idx}] * (" if inline else f"species[{idx}] ="),
-                )
-            else:
-                idx = species_info.ordered_idx_map[species.name]
-                cw.writer(
-                    lostream,
-                    cw.comment(f"species {idx}: {species.name}"),
-                )
-                cw.writer(
-                    lostream,
-                    (f"result += y[{idx}] * (" if inline else f"species[{idx}] ="),
-                )
+            index = (
+                species_info.ordered_idx_map[species.name] - species_info.n_species
+                if qss_flag
+                else species_info.ordered_idx_map[species.name]
+            )
+            cw.writer(lostream, cw.comment(f"species {index}: {species.name}"))
+            cw.writer(
+                lostream,
+                (f"result += y[{index}] * (" if inline else f"species[{index}] ="),
+            )
             if syms_g_rt:
-                index = species_info.ordered_idx_map[species.name]
                 syms.g_RT_smp_tmp[mid_temp]["m"][index] = expression_generator(
                     lostream, low_range, syms
                 )
             elif syms_g_rt_qss:
-                index = (
-                    species_info.ordered_idx_map[species.name] - species_info.n_species
-                )
                 syms.g_RT_qss_smp_tmp[mid_temp]["m"][index] = expression_generator(
                     lostream, low_range, syms
                 )
             elif syms_h_rt:
-                index = species_info.ordered_idx_map[species.name]
                 syms.h_RT_smp_tmp[mid_temp]["m"][index] = expression_generator(
                     lostream, low_range, syms
                 )
             elif syms_h_rt_qss:
-                index = (
-                    species_info.ordered_idx_map[species.name] - species_info.n_species
-                )
                 syms.h_RT_qss_smp_tmp[mid_temp]["m"][index] = expression_generator(
                     lostream, low_range, syms
                 )
@@ -191,49 +137,32 @@ def generate_thermo_routine(
 
         histream = io.StringIO()
         for species, _, high_range in species_list:
-            if qss_flag:
-                idx = (
-                    species_info.ordered_idx_map[species.name] - species_info.n_species
-                )
-                cw.writer(
-                    histream,
-                    cw.comment(f"species {idx}: {species.name}"),
-                )
-                cw.writer(
-                    histream,
-                    (f"result += y[{idx}] * (" if inline else f"species[{idx}] ="),
-                )
-            else:
-                idx = species_info.ordered_idx_map[species.name]
-                cw.writer(
-                    histream,
-                    cw.comment(f"species {idx}: {species.name}"),
-                )
-                cw.writer(
-                    histream,
-                    (f"result += y[{idx}] * (" if inline else f"species[{idx}] ="),
-                )
+            index = (
+                species_info.ordered_idx_map[species.name] - species_info.n_species
+                if qss_flag
+                else species_info.ordered_idx_map[species.name]
+            )
+            cw.writer(
+                histream,
+                cw.comment(f"species {index}: {species.name}"),
+            )
+            cw.writer(
+                histream,
+                (f"result += y[{index}] * (" if inline else f"species[{index}] ="),
+            )
             if syms_g_rt:
-                index = species_info.ordered_idx_map[species.name]
                 syms.g_RT_smp_tmp[mid_temp]["p"][index] = expression_generator(
                     histream, high_range, syms
                 )
             elif syms_g_rt_qss:
-                index = (
-                    species_info.ordered_idx_map[species.name] - species_info.n_species
-                )
                 syms.g_RT_qss_smp_tmp[mid_temp]["p"][index] = expression_generator(
                     histream, high_range, syms
                 )
             elif syms_h_rt:
-                index = species_info.ordered_idx_map[species.name]
                 syms.h_RT_smp_tmp[mid_temp]["p"][index] = expression_generator(
                     histream, high_range, syms
                 )
             elif syms_h_rt_qss:
-                index = (
-                    species_info.ordered_idx_map[species.name] - species_info.n_species
-                )
                 syms.h_RT_qss_smp_tmp[mid_temp]["p"][index] = expression_generator(
                     histream, high_range, syms
                 )

--- a/Support/ceptr/ceptr/thermo.py
+++ b/Support/ceptr/ceptr/thermo.py
@@ -222,22 +222,9 @@ def gibbs(fstream, species_info, species_coeffs, qss_flag, syms=None):
         name = "gibbs"
     cw.writer(fstream)
     cw.writer(fstream, cw.comment("compute the g/(RT) at the given temperature"))
-    if syms is None:
-        generate_thermo_routine(
-            fstream, species_info, name, gibbs_nasa, species_coeffs, qss_flag, 1, True
-        )
-    else:
-        generate_thermo_routine(
-            fstream,
-            species_info,
-            name,
-            gibbs_nasa,
-            species_coeffs,
-            qss_flag,
-            1,
-            True,
-            syms,
-        )
+    generate_thermo_routine(
+        fstream, species_info, name, gibbs_nasa, species_coeffs, qss_flag, 1, True, syms
+    )
 
 
 def helmholtz(fstream, species_info, species_coeffs):
@@ -283,28 +270,17 @@ def species_enthalpy(fstream, species_info, species_coeffs, qss_flag, syms=None)
         cw.comment("compute the h/(RT) at the given temperature (Eq 20)"),
     )
 
-    if syms is None:
-        generate_thermo_routine(
-            fstream,
-            species_info,
-            name,
-            enthalpy_nasa,
-            species_coeffs,
-            qss_flag,
-            1,
-        )
-    else:
-        generate_thermo_routine(
-            fstream,
-            species_info,
-            name,
-            enthalpy_nasa,
-            species_coeffs,
-            qss_flag,
-            1,
-            False,
-            syms,
-        )
+    generate_thermo_routine(
+        fstream,
+        species_info,
+        name,
+        enthalpy_nasa,
+        species_coeffs,
+        qss_flag,
+        1,
+        False,
+        syms,
+    )
 
 
 def species_entropy(fstream, species_info, species_coeffs):

--- a/Support/ceptr/ceptr/transport.py
+++ b/Support/ceptr/ceptr/transport.py
@@ -1,6 +1,5 @@
 """Transport routines."""
 
-import sys
 from collections import OrderedDict
 
 import numpy as np
@@ -57,8 +56,7 @@ def analyze_transport(mechanism, species_info):
         elif m1.geometry == "nonlinear":
             lin = 2
         else:
-            print("Unrecognized species geometry in transport")
-            sys.exit(1)
+            raise ValueError("Unrecognized species geometry in transport")
         eps = (m1.well_depth * cc.ureg.joule).to(cc.ureg.erg).m / cc.kb
         sig = (m1.diameter * cc.ureg.meter).to(cc.ureg.angstrom).m
         dip = (m1.dipole * cc.ureg.coulomb * cc.ureg.m).to(cc.ureg.debye).m
@@ -496,13 +494,9 @@ def diffcoefs(fstream, species_info, species_transport, ntfit):
     cofd = []
     for i, spec1 in enumerate(spec_ordered):
         cofd.append([])
-        if i != spec1.idx:
-            print("Problem in _diffcoefs computation")
-            sys.exit(1)
+        assert i == spec1.idx
         for j, spec2 in enumerate(spec_ordered[0 : i + 1]):
-            if j != spec2.idx:
-                print("Problem in _diffcoefs computation")
-                sys.exit(1)
+            assert j == spec2.idx
             # eq. (9)
             sigm = (
                 0.5
@@ -644,14 +638,10 @@ def thermaldiffratios(
     coftd = []
     k = -1
     for i, spec1 in enumerate(spec_ordered):
-        if i != spec1.idx:
-            print("Problem in _thermaldiffratios computation")
-            sys.exit(1)
+        assert i == spec1.idx
         if spec1.idx in light_spec_list:
             k = k + 1
-            if light_spec_list[k] != spec1.idx:
-                print("Problem in  _thermaldiffratios computation")
-                sys.exit(1)
+            assert light_spec_list[k] == spec1.idx
             coftd.append([])
             epsi = float(species_transport[spec1][1]) * cc.kb
             sigi = float(species_transport[spec1][2]) * a2cm
@@ -659,9 +649,7 @@ def thermaldiffratios(
             # eq. (12)
             poli_red = poli / sigi**3
             for j, spec2 in enumerate(spec_ordered):
-                if j != spec2.idx:
-                    print("Problem in _thermaldiffratios computation")
-                    sys.exit(1)
+                assert j == spec2.idx
                 # eq. (53)
                 wji = (spec2.weight - spec1.weight) / (spec1.weight + spec2.weight)
                 epsj = float(species_transport[spec2][1]) * cc.kb
@@ -1592,9 +1580,7 @@ def qinterp(x0, x, y):
 def get_cv_dr_species(mechanism, t, species):
     """Get the parameters of a thermo model."""
     model = mechanism.species(species.name).thermo
-    if not model.n_coeffs == 15:
-        print("Unsupported thermo model.")
-        sys.exit(1)
+    assert model.n_coeffs == 15, "Unsupported thermo model."
 
     mid = model.coeffs[0]
     high_range = model.coeffs[1:8]

--- a/Support/ceptr/ceptr/utilities.py
+++ b/Support/ceptr/ceptr/utilities.py
@@ -1,7 +1,6 @@
 """Utility functions used across ceptr."""
 
 import copy
-import sys
 from collections import Counter
 from math import isclose
 
@@ -398,12 +397,10 @@ def enhancement_d(mechanism, species_info, reaction, syms=None):
     third_body = reaction.third_body is not None
     falloff = reaction.rate.type == "falloff"
     if not third_body and not falloff:
-        print("enhancement_d called for a reaction without a third body")
-        sys.exit(1)
+        raise ValueError("enhancement_d called for a reaction without a third body")
 
     if not reaction.third_body:
-        print("FIXME EFFICIENCIES")
-        sys.exit(1)
+        raise NotImplementedError("FIXME EFFICIENCIES")
         species, coefficient = third_body
         if species == "<mixture>":
             if record_symbolic_operations:


### PR DESCRIPTION
- simplify a bunch of code
- remove `sys.exit` and replace with `raise` error. This is because the use of the `multiprocessing` (PR #437) does not like child processes just exiting via sys.exit. It can basically cause a hang in the main process. Also `raise` errors is just a better thing to be doing
- no diffs caused in the mech files