### PR TITLE
Max substep input for CVODE

### DIFF
--- a/Source/Reactions/ReactorCvode.H
+++ b/Source/Reactions/ReactorCvode.H
@@ -189,6 +189,7 @@ private:
   int max_fp_accel{2};
   int m_print_profiling{0};
   int m_cvode_maxorder{2};
+  int m_cvode_maxstep{10000};
   int m_solve_type{-1};
   int m_analytical_jacobian{-1};
   int m_precond_type{-1};

--- a/Source/Reactions/ReactorCvode.cpp
+++ b/Source/Reactions/ReactorCvode.cpp
@@ -28,6 +28,7 @@ ReactorCvode::init(int reactor_type, int /*ncells*/)
   // Query CVODE options
   amrex::ParmParse ppcv("cvode");
   ppcv.query("max_order", m_cvode_maxorder);
+  ppcv.query("max_substeps", m_cvode_maxstep);
   std::string linear_solve_type;
   ppcv.query("solve_type", linear_solve_type);
   std::string precondJFNK_type;
@@ -206,7 +207,7 @@ ReactorCvode::initCvode(
   if (utils::check_flag(&flag, "CVodeSetMaxNonlinIters", 1)) {
     return (1);
   }
-  flag = CVodeSetMaxNumSteps(a_cvode_mem, 100000);
+  flag = CVodeSetMaxNumSteps(a_cvode_mem, m_cvode_maxstep);
   if (utils::check_flag(&flag, "CVodeSetMaxNumSteps", 1)) {
     return (1);
   }


### PR DESCRIPTION
A short PR to add the ability to specify number of substeps for the chemistry integration in CVODE. Addresses #480 . Will also add a small PR to LMeX documentation for the flag, along with a suggestion of trying other solve_types before increasing from the default.