### PR TITLE
Add cray to compilers for make TPL

### DIFF
--- a/ThirdParty/GNUmakefile
+++ b/ThirdParty/GNUmakefile
@@ -48,7 +48,12 @@ else
               ifeq ($(lowercase_hcomp),$(filter $(lowercase_hcomp),intel))
                 $(error for intel, specify COMP as intel-classic or intel-llvm)
               else
-                $(error Unknown COMP setting)
+                ifeq ($(lowercase_hcomp),$(filter $(lowercase_hcomp),cray))
+                   CCOMPILER = craycc
+                   CXXCOMPILER = craycxx
+                else
+                  $(error Unknown COMP setting)
+                endif
               endif
 	    endif
 	  endif


### PR DESCRIPTION
AMReX gmake system supports cray compilers but we do not for building third party libraries, so this PR adds that to the ThirdParty GNUmakefile. Not sure if I missed any other changes would be needed. Seems to work on Kestrel. 