### PR TITLE
update Factory to allow for chained inheritance

### DIFF
--- a/Source/Factory.H
+++ b/Source/Factory.H
@@ -92,11 +92,13 @@ struct Factory
   }
 
   //! Class to handle registration of subclass for runtime selection
-  template <class T>
-  struct Register : public Base
+  template <class T, class DeriveFrom = Base>
+  struct Register : public DeriveFrom
   {
     friend T;
     static bool registered;
+
+    static_assert(std::is_base_of_v<Base, DeriveFrom> == true);
 
     static bool add_sub_type()
     {
@@ -155,9 +157,9 @@ private:
 };
 
 template <class Base, class... Args>
-template <class T>
-bool Factory<Base, Args...>::Register<T>::registered =
-  Factory<Base, Args...>::Register<T>::add_sub_type();
+template <class T, class DeriveFrom>
+bool Factory<Base, Args...>::Register<T, DeriveFrom>::registered =
+  Factory<Base, Args...>::Register<T, DeriveFrom>::add_sub_type();
 
 } // namespace pele::physics
 #endif /* FACTORY_H */


### PR DESCRIPTION
Right now you can use Factory if you have two classes B and C that derive from A. This change makes it so that if you have class D that derives from B, you can also generate it with the same Factory.