### PR TITLE
Fix default viscosity_mu_ref value in Sutherland model

### DIFF
--- a/Source/Transport/TransportParams.H
+++ b/Source/Transport/TransportParams.H
@@ -69,7 +69,7 @@ template <typename EOSType>
 struct TransParm<EOSType, SutherlandTransport>
 {
   amrex::Real Prandtl_number{0.7};
-  amrex::Real viscosity_mu_ref{17.16};
+  amrex::Real viscosity_mu_ref{17.16e-5};
   amrex::Real viscosity_T_ref{273.15};
   amrex::Real viscosity_S{110.4};
   amrex::Real const_bulk_viscosity{0.0};

--- a/Testing/Exec/TranEval/inputs.2d_Sutherland
+++ b/Testing/Exec/TranEval/inputs.2d_Sutherland
@@ -1,5 +1,5 @@
 transport.Prandtl_number       = 0.7
-transport.viscosity_mu_ref     = 17.16
+transport.viscosity_mu_ref     = 17.16e-5
 transport.viscosity_T_ref      = 273.15
 transport.viscosity_S          = 110.4
 transport.const_bulk_viscosity = 0.0


### PR DESCRIPTION
**Changes Made**

I have corrected the default value of viscosity_mu_ref in the Sutherland transport model. The original value was 17.16, and I have changed it to 17.16e-5.

```
struct TransParm<EOSType, SutherlandTransport>
{
  amrex::Real Prandtl_number{0.7};
  amrex::Real viscosity_mu_ref{17.16e-5};  // Corrected value
  amrex::Real viscosity_T_ref{273.15};
  amrex::Real viscosity_S{110.4};
  amrex::Real const_bulk_viscosity{0.0};
  amrex::Real const_diffusivity{1.0};
  bool use_soret = false;
};
```

**Justification**

The reference viscosity value (viscosity_mu_ref) for air at standard temperature (273.15 K) is 17.16 µPa·s according to the [literature](https://doc.comsol.com/5.5/doc/com.comsol.help.cfd/cfd_ug_fluidflow_high_mach.08.27.html). In the CGS system, this value should be expressed as 17.16e-5 Poise (P), since 1 Pa·s = 10 Poise. The original default value of 17.16 is incorrect in this context as it does not account for this unit conversion.