### PR TITLE
Chemical mask implementation

### DIFF
--- a/Source/Reactions/ReactorArkode.H
+++ b/Source/Reactions/ReactorArkode.H
@@ -129,23 +129,23 @@ public:
   }
 
   void unflatten(
-      const amrex::Box& box,
-      const int ncells,
-      amrex::Array4<amrex::Real> const& rhoY,
-      amrex::Array4<amrex::Real> const& temperature,
-      amrex::Array4<amrex::Real> const& rhoE,
-      amrex::Array4<amrex::Real> const& frcEExt,
-      amrex::Array4<amrex::Real> const& FC_in,
-	  amrex::Array4<int> const& mask,
-      amrex::Real* y_vect,
-      amrex::Real* vect_energy,
-      long int* FCunt,
-      amrex::Real dt)
-    {
-      flatten_ops.unflatten(
-        box, ncells, m_reactor_type, m_clean_init_massfrac, rhoY, temperature,
-        rhoE, frcEExt, FC_in, mask, y_vect, vect_energy, FCunt, dt);
-    }
+    const amrex::Box& box,
+    const int ncells,
+    amrex::Array4<amrex::Real> const& rhoY,
+    amrex::Array4<amrex::Real> const& temperature,
+    amrex::Array4<amrex::Real> const& rhoE,
+    amrex::Array4<amrex::Real> const& frcEExt,
+    amrex::Array4<amrex::Real> const& FC_in,
+    amrex::Array4<int> const& mask,
+    amrex::Real* y_vect,
+    amrex::Real* vect_energy,
+    long int* FCunt,
+    amrex::Real dt)
+  {
+    flatten_ops.unflatten(
+      box, ncells, m_reactor_type, m_clean_init_massfrac, rhoY, temperature,
+      rhoE, frcEExt, FC_in, mask, y_vect, vect_energy, FCunt, dt);
+  }
 
 private:
   amrex::Real relTol{1e-6};

--- a/Source/Reactions/ReactorArkode.H
+++ b/Source/Reactions/ReactorArkode.H
@@ -128,6 +128,25 @@ public:
       rhoE, frcEExt, FC_in, y_vect, vect_energy, FCunt, dt);
   }
 
+  void unflatten(
+      const amrex::Box& box,
+      const int ncells,
+      amrex::Array4<amrex::Real> const& rhoY,
+      amrex::Array4<amrex::Real> const& temperature,
+      amrex::Array4<amrex::Real> const& rhoE,
+      amrex::Array4<amrex::Real> const& frcEExt,
+      amrex::Array4<amrex::Real> const& FC_in,
+	  amrex::Array4<int> const& mask,
+      amrex::Real* y_vect,
+      amrex::Real* vect_energy,
+      long int* FCunt,
+      amrex::Real dt)
+    {
+      flatten_ops.unflatten(
+        box, ncells, m_reactor_type, m_clean_init_massfrac, rhoY, temperature,
+        rhoE, frcEExt, FC_in, mask, y_vect, vect_energy, FCunt, dt);
+    }
+
 private:
   amrex::Real relTol{1e-6};
   amrex::Real absTol{1e-10};

--- a/Source/Reactions/ReactorArkode.cpp
+++ b/Source/Reactions/ReactorArkode.cpp
@@ -135,7 +135,7 @@ ReactorArkode::react(
   amrex::Array4<amrex::Real> const& rEner_in,
   amrex::Array4<amrex::Real> const& rEner_src_in,
   amrex::Array4<amrex::Real> const& FC_in,
-  amrex::Array4<int> const& /*mask*/,
+  amrex::Array4<int> const& mask,
   amrex::Real& dt_react,
   amrex::Real& time
 #ifdef AMREX_USE_GPU
@@ -239,7 +239,7 @@ ReactorArkode::react(
   amrex::Gpu::DeviceVector<long int> v_nfe(ncells, nfe);
   long int* d_nfe = v_nfe.data();
   unflatten(
-    box, ncells, rY_in, T_in, rEner_in, rEner_src_in, FC_in, yvec_d,
+    box, ncells, rY_in, T_in, rEner_in, rEner_src_in, FC_in, mask,yvec_d,
     user_data->rhoe_init, d_nfe, dt_react);
 
   N_VDestroy(y);

--- a/Source/Reactions/ReactorArkode.cpp
+++ b/Source/Reactions/ReactorArkode.cpp
@@ -449,8 +449,8 @@ ReactorArkode::print_final_stats(void* arkode_mem)
   }
 
 #ifdef AMREX_USE_OMP
-  amrex::Print() << "\nFinal Statistics: " << "(thread:" << omp_get_thread_num()
-                 << ", ";
+  amrex::Print() << "\nFinal Statistics: "
+                 << "(thread:" << omp_get_thread_num() << ", ";
   amrex::Print() << "arkodeMem:" << arkode_mem << ")\n";
 #else
   amrex::Print() << "\nFinal Statistics:\n";

--- a/Source/Reactions/ReactorArkode.cpp
+++ b/Source/Reactions/ReactorArkode.cpp
@@ -239,7 +239,7 @@ ReactorArkode::react(
   amrex::Gpu::DeviceVector<long int> v_nfe(ncells, nfe);
   long int* d_nfe = v_nfe.data();
   unflatten(
-    box, ncells, rY_in, T_in, rEner_in, rEner_src_in, FC_in, mask,yvec_d,
+    box, ncells, rY_in, T_in, rEner_in, rEner_src_in, FC_in, mask, yvec_d,
     user_data->rhoe_init, d_nfe, dt_react);
 
   N_VDestroy(y);
@@ -449,8 +449,8 @@ ReactorArkode::print_final_stats(void* arkode_mem)
   }
 
 #ifdef AMREX_USE_OMP
-  amrex::Print() << "\nFinal Statistics: "
-                 << "(thread:" << omp_get_thread_num() << ", ";
+  amrex::Print() << "\nFinal Statistics: " << "(thread:" << omp_get_thread_num()
+                 << ", ";
   amrex::Print() << "arkodeMem:" << arkode_mem << ")\n";
 #else
   amrex::Print() << "\nFinal Statistics:\n";

--- a/Source/Reactions/ReactorBDF.cpp
+++ b/Source/Reactions/ReactorBDF.cpp
@@ -319,7 +319,7 @@ ReactorBDF::react(
   amrex::Array4<amrex::Real> const& rEner_in,
   amrex::Array4<amrex::Real> const& rEner_src_in,
   amrex::Array4<amrex::Real> const& FC_in,
-  amrex::Array4<int> const& /*mask*/,
+  amrex::Array4<int> const& mask,
   amrex::Real& dt_react,
   amrex::Real& time
 #ifdef AMREX_USE_GPU
@@ -355,6 +355,7 @@ ReactorBDF::react(
   int* d_nsteps = v_nsteps.data();
 
   amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+	  if(mask(i,j,k)!=-1){
     amrex::Real soln[NUM_SPECIES + 1] = {0.0};
     amrex::Real soln_n[NUM_SPECIES + 1] = {0.0};   // at time level n
     amrex::Real soln_nm1[NUM_SPECIES + 1] = {0.0}; // at time level n-1
@@ -475,7 +476,7 @@ ReactorBDF::react(
       amrex::Abort("Wrong reactor type. Choose between 1 (e) or 2 (h).");
     }
     T_in(i, j, k, 0) = temp;
-    FC_in(i, j, k, 0) = captured_nsubsteps;
+    FC_in(i, j, k, 0) = captured_nsubsteps;}
   });
 
 #ifdef MOD_REACTOR

--- a/Source/Reactions/ReactorCvode.H
+++ b/Source/Reactions/ReactorCvode.H
@@ -158,7 +158,7 @@ public:
     amrex::Real* y_vect,
     amrex::Real* vect_energy,
     long int* FCunt,
-    amrex::Real dt) 
+    amrex::Real dt)
   {
     flatten_ops.unflatten(
       box, ncells, m_reactor_type, m_clean_init_massfrac, rhoY, temperature,

--- a/Source/Reactions/ReactorCvode.H
+++ b/Source/Reactions/ReactorCvode.H
@@ -146,6 +146,25 @@ public:
       rhoE, frcEExt, FC_in, y_vect, vect_energy, FCunt, dt);
   }
 
+  void unflatten(
+    const amrex::Box& box,
+    const int ncells,
+    amrex::Array4<amrex::Real> const& rhoY,
+    amrex::Array4<amrex::Real> const& temperature,
+    amrex::Array4<amrex::Real> const& rhoE,
+    amrex::Array4<amrex::Real> const& frcEExt,
+    amrex::Array4<amrex::Real> const& FC_in,
+    amrex::Array4<int> const& mask,
+    amrex::Real* y_vect,
+    amrex::Real* vect_energy,
+    long int* FCunt,
+    amrex::Real dt) 
+  {
+    flatten_ops.unflatten(
+      box, ncells, m_reactor_type, m_clean_init_massfrac, rhoY, temperature,
+      rhoE, frcEExt, FC_in, mask, y_vect, vect_energy, FCunt, dt);
+  }
+
 private:
   void checkCvodeOptions(
     const std::string& a_solve_type_str,

--- a/Source/Reactions/ReactorCvode.cpp
+++ b/Source/Reactions/ReactorCvode.cpp
@@ -1373,7 +1373,7 @@ ReactorCvode::react(
   amrex::Gpu::DeviceVector<long int> v_nfe(ncells, nfe);
   long int* d_nfe = v_nfe.data();
   unflatten(
-    box, ncells, rY_in, T_in, rEner_in, rEner_src_in, FC_in, yvec_d,
+    box, ncells, rY_in, T_in, rEner_in, rEner_src_in, FC_in,mask, yvec_d,
     udata->rhoe_init, d_nfe, dt_react);
 
   if (udata->verbose > 1) {

--- a/Source/Reactions/ReactorCvode.cpp
+++ b/Source/Reactions/ReactorCvode.cpp
@@ -1878,8 +1878,8 @@ ReactorCvode::print_final_stats(void* cvodemem, bool print_ls_stats) // NOLINT
   }
 
 #ifdef AMREX_USE_OMP
-  amrex::Print() << "\nFinal Statistics: " << "(thread:" << omp_get_thread_num()
-                 << ", ";
+  amrex::Print() << "\nFinal Statistics: "
+                 << "(thread:" << omp_get_thread_num() << ", ";
   amrex::Print() << "cvode_mem:" << cvodemem << ")\n";
 #else
   amrex::Print() << "\nFinal Statistics:\n";

--- a/Source/Reactions/ReactorCvode.cpp
+++ b/Source/Reactions/ReactorCvode.cpp
@@ -1373,7 +1373,7 @@ ReactorCvode::react(
   amrex::Gpu::DeviceVector<long int> v_nfe(ncells, nfe);
   long int* d_nfe = v_nfe.data();
   unflatten(
-    box, ncells, rY_in, T_in, rEner_in, rEner_src_in, FC_in,mask, yvec_d,
+    box, ncells, rY_in, T_in, rEner_in, rEner_src_in, FC_in, mask, yvec_d,
     udata->rhoe_init, d_nfe, dt_react);
 
   if (udata->verbose > 1) {
@@ -1878,8 +1878,8 @@ ReactorCvode::print_final_stats(void* cvodemem, bool print_ls_stats) // NOLINT
   }
 
 #ifdef AMREX_USE_OMP
-  amrex::Print() << "\nFinal Statistics: "
-                 << "(thread:" << omp_get_thread_num() << ", ";
+  amrex::Print() << "\nFinal Statistics: " << "(thread:" << omp_get_thread_num()
+                 << ", ";
   amrex::Print() << "cvode_mem:" << cvodemem << ")\n";
 #else
   amrex::Print() << "\nFinal Statistics:\n";

--- a/Source/Reactions/ReactorCvodeUtils.H
+++ b/Source/Reactions/ReactorCvodeUtils.H
@@ -318,7 +318,7 @@ fKernelDenseAJchem(
   amrex::Real temp_pt = u_curr[NUM_SPECIES];
 
   const int consP = reactor_type == ReactorTypes::h_reactor_type;
-  amrex::GpuArray<amrex::Real, neqs * neqs> Jmat_pt = {0.0};
+  amrex::GpuArray<amrex::Real, neqs* neqs> Jmat_pt = {0.0};
   auto eos = pele::physics::PhysicsType::eos();
   eos.RTY2JAC(rho_pt, temp_pt, massfrac.arr, Jmat_pt.arr, consP);
 

--- a/Source/Reactions/ReactorCvodeUtils.H
+++ b/Source/Reactions/ReactorCvodeUtils.H
@@ -269,7 +269,7 @@ fKernelComputeAJchem(
   amrex::Real temp_pt = u_curr[NUM_SPECIES];
 
   const int consP = reactor_type == ReactorTypes::h_reactor_type;
-  amrex::GpuArray<amrex::Real, neqs * neqs> Jmat_pt = {0.0};
+  amrex::GpuArray<amrex::Real, neqs* neqs> Jmat_pt = {0.0};
   auto eos = pele::physics::PhysicsType::eos();
   eos.RTY2JAC(rho_pt, temp_pt, massfrac.arr, Jmat_pt.arr, consP);
 

--- a/Source/Reactions/ReactorCvodeUtils.H
+++ b/Source/Reactions/ReactorCvodeUtils.H
@@ -269,7 +269,7 @@ fKernelComputeAJchem(
   amrex::Real temp_pt = u_curr[NUM_SPECIES];
 
   const int consP = reactor_type == ReactorTypes::h_reactor_type;
-  amrex::GpuArray<amrex::Real, neqs* neqs> Jmat_pt = {0.0};
+  amrex::GpuArray<amrex::Real, neqs * neqs> Jmat_pt = {0.0};
   auto eos = pele::physics::PhysicsType::eos();
   eos.RTY2JAC(rho_pt, temp_pt, massfrac.arr, Jmat_pt.arr, consP);
 
@@ -318,7 +318,7 @@ fKernelDenseAJchem(
   amrex::Real temp_pt = u_curr[NUM_SPECIES];
 
   const int consP = reactor_type == ReactorTypes::h_reactor_type;
-  amrex::GpuArray<amrex::Real, neqs* neqs> Jmat_pt = {0.0};
+  amrex::GpuArray<amrex::Real, neqs * neqs> Jmat_pt = {0.0};
   auto eos = pele::physics::PhysicsType::eos();
   eos.RTY2JAC(rho_pt, temp_pt, massfrac.arr, Jmat_pt.arr, consP);
 

--- a/Source/Reactions/ReactorRK64.cpp
+++ b/Source/Reactions/ReactorRK64.cpp
@@ -171,7 +171,7 @@ ReactorRK64::react(
   amrex::Array4<amrex::Real> const& rEner_in,
   amrex::Array4<amrex::Real> const& rEner_src_in,
   amrex::Array4<amrex::Real> const& FC_in,
-  amrex::Array4<int> const& /*mask*/,
+  amrex::Array4<int> const& mask,
   amrex::Real& dt_react,
   amrex::Real& time
 #ifdef AMREX_USE_GPU
@@ -246,6 +246,8 @@ ReactorRK64::react(
       rYsrc_ext[sp] = rYsrc_in(i, j, k, sp);
     }
 
+    if(mask(i,j,k)!= -1){
+
     int nsteps = 0;
     amrex::Real change_factor;
     while (current_time < time_out) {
@@ -287,6 +289,7 @@ ReactorRK64::react(
       dt_rk = amrex::min<amrex::Real>(dt_rk, time_out - current_time);
     }
 
+
     // copy data back
     int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
     d_nsteps[icell] = nsteps;
@@ -312,6 +315,11 @@ ReactorRK64::react(
     }
     T_in(i, j, k, 0) = temp;
     FC_in(i, j, k, 0) = nsteps;
+    }
+    else
+    {
+    	FC_in(i, j, k, 0) =0;
+    }
   });
 
 #ifdef MOD_REACTOR

--- a/Source/Reactions/ReactorRK64.cpp
+++ b/Source/Reactions/ReactorRK64.cpp
@@ -246,79 +246,76 @@ ReactorRK64::react(
       rYsrc_ext[sp] = rYsrc_in(i, j, k, sp);
     }
 
-    if(mask(i,j,k)!= -1){
+    if (mask(i, j, k) != -1) {
 
-    int nsteps = 0;
-    amrex::Real change_factor;
-    while (current_time < time_out) {
-      for (amrex::Real& sp : error_reg) {
-        sp = 0.0;
-      }
-      for (int stage = 0; stage < rkp.nstages_rk64; stage++) {
-        utils::fKernelSpec<Ordering>(
-          0, 1, current_time - time_init, captured_reactor_type, soln_reg, ydot,
-          rhoe_init, rhoesrc_ext, rYsrc_ext);
-
-        for (int sp = 0; sp < neq; sp++) {
-          error_reg[sp] += rkp.err_rk64[stage] * dt_rk * ydot[sp];
-          soln_reg[sp] =
-            carryover_reg[sp] + rkp.alpha_rk64[stage] * dt_rk * ydot[sp];
-          carryover_reg[sp] =
-            soln_reg[sp] + rkp.beta_rk64[stage] * dt_rk * ydot[sp];
+      int nsteps = 0;
+      amrex::Real change_factor;
+      while (current_time < time_out) {
+        for (amrex::Real& sp : error_reg) {
+          sp = 0.0;
         }
+        for (int stage = 0; stage < rkp.nstages_rk64; stage++) {
+          utils::fKernelSpec<Ordering>(
+            0, 1, current_time - time_init, captured_reactor_type, soln_reg,
+            ydot, rhoe_init, rhoesrc_ext, rYsrc_ext);
+
+          for (int sp = 0; sp < neq; sp++) {
+            error_reg[sp] += rkp.err_rk64[stage] * dt_rk * ydot[sp];
+            soln_reg[sp] =
+              carryover_reg[sp] + rkp.alpha_rk64[stage] * dt_rk * ydot[sp];
+            carryover_reg[sp] =
+              soln_reg[sp] + rkp.beta_rk64[stage] * dt_rk * ydot[sp];
+          }
+        }
+
+        current_time += dt_rk;
+        nsteps++;
+
+        amrex::Real max_err = tinyval;
+        for (amrex::Real sp : error_reg) {
+          max_err = fabs(sp) > max_err ? fabs(sp) : max_err;
+        }
+
+        if (max_err < captured_abstol) {
+          change_factor =
+            rkp.betaerr_rk64 * pow((captured_abstol / max_err), rkp.exp1_rk64);
+          dt_rk = amrex::min<amrex::Real>(dt_rk_max, dt_rk * change_factor);
+        } else {
+          change_factor =
+            rkp.betaerr_rk64 * pow((captured_abstol / max_err), rkp.exp2_rk64);
+          dt_rk = amrex::max<amrex::Real>(dt_rk_min, dt_rk * change_factor);
+        }
+        // Don't overstep the integration time
+        dt_rk = amrex::min<amrex::Real>(dt_rk, time_out - current_time);
       }
 
-      current_time += dt_rk;
-      nsteps++;
-
-      amrex::Real max_err = tinyval;
-      for (amrex::Real sp : error_reg) {
-        max_err = fabs(sp) > max_err ? fabs(sp) : max_err;
+      // copy data back
+      int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
+      d_nsteps[icell] = nsteps;
+      rho = 0.0;
+      for (int sp = 0; sp < NUM_SPECIES; sp++) {
+        rY_in(i, j, k, sp) = soln_reg[sp];
+        rho += rY_in(i, j, k, sp);
       }
+      rho_inv = 1.0 / rho;
+      for (int sp = 0; sp < NUM_SPECIES; sp++) {
+        mass_frac[sp] = rY_in(i, j, k, sp) * rho_inv;
+      }
+      temp = soln_reg[NUM_SPECIES];
+      rEner_in(i, j, k, 0) = rhoe_init[0] + dt_react * rhoesrc_ext[0];
+      Enrg_loc = rEner_in(i, j, k, 0) * rho_inv;
 
-      if (max_err < captured_abstol) {
-        change_factor =
-          rkp.betaerr_rk64 * pow((captured_abstol / max_err), rkp.exp1_rk64);
-        dt_rk = amrex::min<amrex::Real>(dt_rk_max, dt_rk * change_factor);
+      if (captured_reactor_type == ReactorTypes::e_reactor_type) {
+        eos.REY2T(rho, Enrg_loc, mass_frac, temp);
+      } else if (captured_reactor_type == ReactorTypes::h_reactor_type) {
+        eos.RHY2T(rho, Enrg_loc, mass_frac, temp);
       } else {
-        change_factor =
-          rkp.betaerr_rk64 * pow((captured_abstol / max_err), rkp.exp2_rk64);
-        dt_rk = amrex::max<amrex::Real>(dt_rk_min, dt_rk * change_factor);
+        amrex::Abort("Wrong reactor type. Choose between 1 (e) or 2 (h).");
       }
-      // Don't overstep the integration time
-      dt_rk = amrex::min<amrex::Real>(dt_rk, time_out - current_time);
-    }
-
-
-    // copy data back
-    int icell = (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
-    d_nsteps[icell] = nsteps;
-    rho = 0.0;
-    for (int sp = 0; sp < NUM_SPECIES; sp++) {
-      rY_in(i, j, k, sp) = soln_reg[sp];
-      rho += rY_in(i, j, k, sp);
-    }
-    rho_inv = 1.0 / rho;
-    for (int sp = 0; sp < NUM_SPECIES; sp++) {
-      mass_frac[sp] = rY_in(i, j, k, sp) * rho_inv;
-    }
-    temp = soln_reg[NUM_SPECIES];
-    rEner_in(i, j, k, 0) = rhoe_init[0] + dt_react * rhoesrc_ext[0];
-    Enrg_loc = rEner_in(i, j, k, 0) * rho_inv;
-
-    if (captured_reactor_type == ReactorTypes::e_reactor_type) {
-      eos.REY2T(rho, Enrg_loc, mass_frac, temp);
-    } else if (captured_reactor_type == ReactorTypes::h_reactor_type) {
-      eos.RHY2T(rho, Enrg_loc, mass_frac, temp);
+      T_in(i, j, k, 0) = temp;
+      FC_in(i, j, k, 0) = nsteps;
     } else {
-      amrex::Abort("Wrong reactor type. Choose between 1 (e) or 2 (h).");
-    }
-    T_in(i, j, k, 0) = temp;
-    FC_in(i, j, k, 0) = nsteps;
-    }
-    else
-    {
-    	FC_in(i, j, k, 0) =0;
+      FC_in(i, j, k, 0) = 0;
     }
   });
 

--- a/Source/Reactions/ReactorUtils.H
+++ b/Source/Reactions/ReactorUtils.H
@@ -356,6 +356,36 @@ public:
         dt);
     });
   }
+
+  void unflatten(
+      const amrex::Box& box,
+      const int ncells,
+      const int reactor_type,
+      const bool clean_init_massfrac,
+      amrex::Array4<amrex::Real> const& rhoY,
+      amrex::Array4<amrex::Real> const& temperature,
+      amrex::Array4<amrex::Real> const& rhoE,
+      amrex::Array4<amrex::Real> const& frcEExt,
+      amrex::Array4<amrex::Real> const& FC_in,
+	  amrex::Array4<int> const& mask,
+      amrex::Real* y_vect,
+      amrex::Real* vect_energy,
+      long int* FCunt,
+      amrex::Real dt)
+    {
+      BL_PROFILE("Pele::unflatten()");
+      const auto len = amrex::length(box);
+      const auto lo = amrex::lbound(box);
+      amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        const int icell =
+          (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
+        if(mask(i,j,k)!=-1){
+        box_unflatten<OrderType>(
+          icell, i, j, k, ncells, reactor_type, clean_init_massfrac, rhoY,
+          temperature, rhoE, frcEExt, FC_in, y_vect, vect_energy, FCunt[icell],
+          dt);}
+      });
+    }
 };
 
 template <typename OrderType>

--- a/Source/Reactions/ReactorUtils.H
+++ b/Source/Reactions/ReactorUtils.H
@@ -358,34 +358,35 @@ public:
   }
 
   void unflatten(
-      const amrex::Box& box,
-      const int ncells,
-      const int reactor_type,
-      const bool clean_init_massfrac,
-      amrex::Array4<amrex::Real> const& rhoY,
-      amrex::Array4<amrex::Real> const& temperature,
-      amrex::Array4<amrex::Real> const& rhoE,
-      amrex::Array4<amrex::Real> const& frcEExt,
-      amrex::Array4<amrex::Real> const& FC_in,
-	  amrex::Array4<int> const& mask,
-      amrex::Real* y_vect,
-      amrex::Real* vect_energy,
-      long int* FCunt,
-      amrex::Real dt)
-    {
-      BL_PROFILE("Pele::unflatten()");
-      const auto len = amrex::length(box);
-      const auto lo = amrex::lbound(box);
-      amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-        const int icell =
-          (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
-        if(mask(i,j,k)!=-1){
+    const amrex::Box& box,
+    const int ncells,
+    const int reactor_type,
+    const bool clean_init_massfrac,
+    amrex::Array4<amrex::Real> const& rhoY,
+    amrex::Array4<amrex::Real> const& temperature,
+    amrex::Array4<amrex::Real> const& rhoE,
+    amrex::Array4<amrex::Real> const& frcEExt,
+    amrex::Array4<amrex::Real> const& FC_in,
+    amrex::Array4<int> const& mask,
+    amrex::Real* y_vect,
+    amrex::Real* vect_energy,
+    long int* FCunt,
+    amrex::Real dt)
+  {
+    BL_PROFILE("Pele::unflatten()");
+    const auto len = amrex::length(box);
+    const auto lo = amrex::lbound(box);
+    amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+      const int icell =
+        (k - lo.z) * len.x * len.y + (j - lo.y) * len.x + (i - lo.x);
+      if (mask(i, j, k) != -1) {
         box_unflatten<OrderType>(
           icell, i, j, k, ncells, reactor_type, clean_init_massfrac, rhoY,
           temperature, rhoE, frcEExt, FC_in, y_vect, vect_energy, FCunt[icell],
-          dt);}
-      });
-    }
+          dt);
+      }
+    });
+  }
 };
 
 template <typename OrderType>


### PR DESCRIPTION
Chemistry mask implementation.

Updated Arkode, Cvode, RK64, and BDF chem integrators to mask chemical reactions inside a user-specified box region. Verified code change on PMF case for Clang serial, MPI, CUDA, and HIP.