### PR TITLE
peleparams: common data container for PMF, transport (others in future)

### DIFF
--- a/Source/PeleParamsGeneric.H
+++ b/Source/PeleParamsGeneric.H
@@ -1,0 +1,118 @@
+#ifndef PELEPARAMSGENERIC_H
+#define PELEPARAMSGENERIC_H
+
+#include <AMReX_Gpu.H>
+#include "Factory.H"
+
+namespace pele::physics {
+
+// ParmType: Generic parameters to be copied from host to device
+// Template for HostOnlyParm: Data kept only by Host
+template <typename ParmType>
+struct HostOnlyParm
+{
+};
+
+// Forward Declaration of PeleParams
+template <typename ParmType, typename BaseParmType = ParmType>
+class PeleParams;
+
+// Template for initializer/destructor functions
+template <typename ParmType, typename BaseParmType = ParmType>
+struct InitParm
+{
+  static void host_initialize(PeleParams<ParmType, BaseParmType>* /*parm_in*/)
+  {
+  }
+
+  static void host_deallocate(PeleParams<ParmType, BaseParmType>* /*parm_in*/)
+  {
+  }
+};
+
+// Define generic interface
+// This gets a bit complicated to handle the case of base and derived ParmType
+// classes
+template <typename BaseParmType>
+class PeleParamsGeneric : public Factory<PeleParamsGeneric<BaseParmType>>
+{
+public:
+  static std::string base_identifier() { return "pele_params_base_generic"; }
+
+  virtual void initialize() = 0;
+  virtual void device_allocate() = 0;
+  virtual void sync_to_device() = 0;
+  virtual void deallocate() = 0;
+  virtual BaseParmType& host_parm() = 0;
+  virtual const BaseParmType* device_parm() = 0;
+  virtual HostOnlyParm<BaseParmType>& host_only_parm() = 0;
+};
+
+// Template for class that allocates/deallocates a generic ParmType
+// For most use cases ParmType doesn't have inheritance to worry about
+// and uses the default BaseParmType = ParmType defined in the forward
+// declaration above
+template <typename ParmType, typename BaseParmType>
+class PeleParams : public PeleParamsGeneric<BaseParmType>
+{
+
+  friend struct InitParm<ParmType, BaseParmType>;
+
+public:
+  static_assert(std::is_base_of_v<BaseParmType, ParmType>);
+
+  PeleParams() = default;
+
+  ~PeleParams() override = default;
+
+  void initialize() override
+  {
+    InitParm<ParmType, BaseParmType>::host_initialize(this);
+    device_allocate();
+  }
+
+  void device_allocate() override
+  {
+    if (!m_device_allocated) {
+      m_d_parm = (ParmType*)amrex::The_Device_Arena()->alloc(sizeof(m_h_parm));
+      m_device_allocated = true;
+      sync_to_device();
+    }
+  }
+
+  void sync_to_device() override
+  {
+    if (!m_device_allocated) {
+      amrex::Abort("Device params not allocated yet");
+    } else {
+      amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, &m_h_parm, &m_h_parm + 1, m_d_parm);
+    }
+  }
+
+  void deallocate() override
+  {
+    InitParm<ParmType, BaseParmType>::host_deallocate(this);
+    if (m_device_allocated) {
+      amrex::The_Device_Arena()->free(m_d_parm);
+    }
+  }
+
+  BaseParmType& host_parm() override { return m_h_parm; }
+
+  const BaseParmType* device_parm() override { return m_d_parm; }
+
+  HostOnlyParm<BaseParmType>& host_only_parm() override
+  {
+    return m_host_only_parm;
+  }
+
+private:
+  HostOnlyParm<BaseParmType> m_host_only_parm;
+  ParmType m_h_parm;
+  ParmType* m_d_parm;
+  bool m_device_allocated{false};
+};
+
+} // namespace pele::physics
+#endif

--- a/Source/Transport/TransportParams.H
+++ b/Source/Transport/TransportParams.H
@@ -4,9 +4,11 @@
 #include <AMReX_REAL.H>
 #include <AMReX_ParmParse.H>
 #include "TransportTypes.H"
+#include "PeleParamsGeneric.H"
 #include "EOS.H"
 
-namespace pele::physics::transport {
+namespace pele::physics {
+namespace transport {
 
 struct ConstTransport;
 struct SimpleTransport;
@@ -15,12 +17,6 @@ struct SutherlandTransport;
 template <typename EOSType, typename TransportType>
 struct TransParm
 {
-};
-
-template <typename EOSType, typename TransportType>
-struct InitTransParm
-{
-  void operator()(TransParm<EOSType, TransportType> /*tparm*/) {}
 };
 
 template <typename EOSType>
@@ -35,37 +31,6 @@ struct TransParm<EOSType, ConstTransport>
 };
 
 template <typename EOSType>
-struct InitTransParm<EOSType, ConstTransport>
-{
-  void operator()(TransParm<EOSType, ConstTransport>* tparm)
-  {
-    amrex::ParmParse pp("transport");
-    pp.query("const_viscosity", tparm->const_viscosity);
-    pp.query("const_bulk_viscosity", tparm->const_bulk_viscosity);
-    pp.query("const_conductivity", tparm->const_conductivity);
-    pp.query("const_diffusivity", tparm->const_diffusivity);
-    pp.query(
-      "const_thermal_diffusion_ratio", tparm->const_thermal_diffusion_ratio);
-    if (std::abs(tparm->const_thermal_diffusion_ratio) > 1e-24) {
-      tparm->use_soret = true;
-    }
-    std::string units = "CGS";
-    pp.query("units", units);
-    if (units == "MKS") {
-      // If input in MKS, convert to CGS
-      tparm->const_viscosity *= amrex::Real(1.0e1);
-      tparm->const_bulk_viscosity *= amrex::Real(1.0e1);
-      tparm->const_diffusivity *= amrex::Real(1.0e1);
-      tparm->const_conductivity *= amrex::Real(1.0e5);
-    } else if (units != "CGS") {
-      amrex::Abort(
-        "Unable to initialize transport using unknown units " + units +
-        ". Use CGS (def) or MKS");
-    }
-  }
-};
-
-template <typename EOSType>
 struct TransParm<EOSType, SutherlandTransport>
 {
   amrex::Real Prandtl_number{0.7};
@@ -75,21 +40,6 @@ struct TransParm<EOSType, SutherlandTransport>
   amrex::Real const_bulk_viscosity{0.0};
   amrex::Real const_diffusivity{1.0};
   bool use_soret = false;
-};
-
-template <typename EOSType>
-struct InitTransParm<EOSType, SutherlandTransport>
-{
-  void operator()(TransParm<EOSType, SutherlandTransport>* tparm)
-  {
-    amrex::ParmParse pp("transport");
-    pp.query("Prandtl_number", tparm->Prandtl_number);
-    pp.query("viscosity_mu_ref", tparm->viscosity_mu_ref);
-    pp.query("viscosity_T_ref", tparm->viscosity_T_ref);
-    pp.query("viscosity_S", tparm->viscosity_S);
-    pp.query("const_bulk_viscosity", tparm->const_bulk_viscosity);
-    pp.query("const_diffusivity", tparm->const_diffusivity);
-  }
 };
 
 template <typename EOSType>
@@ -111,34 +61,6 @@ struct TransParm<EOSType, SimpleTransport>
   amrex::GpuArray<int, 3> liteSpec = {0};
   amrex::GpuArray<amrex::Real, NUM_SPECIES* NUM_FIT* 3> fittdrat = {0.0};
   amrex::GpuArray<int, NUM_SPECIES> nlin = {0};
-};
-
-template <typename EOSType>
-struct InitTransParm<EOSType, SimpleTransport>
-{
-  void operator()(TransParm<EOSType, SimpleTransport>* tparm)
-  {
-    egtransetWT(tparm->wt.data());
-    egtransetEPS(tparm->eps.data());
-    egtransetSIG(tparm->sig.data());
-    egtransetDIP(tparm->dip.data());
-    egtransetPOL(tparm->pol.data());
-    egtransetZROT(tparm->zrot.data());
-    egtransetNLIN(tparm->nlin.data());
-    egtransetCOFETA(tparm->fitmu.data());
-    egtransetCOFLAM(tparm->fitlam.data());
-    egtransetCOFD(tparm->fitdbin.data());
-    amrex::ParmParse pp("transport");
-    pp.query("use_soret", tparm->use_soret);
-    if (tparm->use_soret) {
-      egtransetNLITE(&tparm->numLite);
-      egtransetKTDIF(tparm->liteSpec.data());
-      egtransetCOFTD(tparm->fittdrat.data());
-    }
-    for (int i = 0; i < NUM_SPECIES; ++i) {
-      tparm->iwt[i] = 1. / tparm->wt[i];
-    }
-  }
 };
 
 template <>
@@ -173,11 +95,122 @@ struct TransParm<eos::SRK, SimpleTransport>
   amrex::GpuArray<amrex::Real, NUM_SPECIES> omega = {0.0};
 };
 
-template <>
-struct InitTransParm<eos::SRK, SimpleTransport>
+} // namespace transport
+
+template <typename EOSType>
+struct InitParm<transport::TransParm<EOSType, transport::ConstTransport>>
 {
-  void operator()(TransParm<eos::SRK, SimpleTransport>* tparm)
+  static void host_initialize(
+    PeleParams<transport::TransParm<EOSType, transport::ConstTransport>>*
+      parm_in)
   {
+    transport::TransParm<EOSType, transport::ConstTransport>* tparm =
+      &(parm_in->m_h_parm);
+    amrex::ParmParse pp("transport");
+    pp.query("const_viscosity", tparm->const_viscosity);
+    pp.query("const_bulk_viscosity", tparm->const_bulk_viscosity);
+    pp.query("const_conductivity", tparm->const_conductivity);
+    pp.query("const_diffusivity", tparm->const_diffusivity);
+    pp.query(
+      "const_thermal_diffusion_ratio", tparm->const_thermal_diffusion_ratio);
+    if (std::abs(tparm->const_thermal_diffusion_ratio) > 1e-24) {
+      tparm->use_soret = true;
+    }
+    std::string units = "CGS";
+    pp.query("units", units);
+    if (units == "MKS") {
+      // If input in MKS, convert to CGS
+      tparm->const_viscosity *= amrex::Real(1.0e1);
+      tparm->const_bulk_viscosity *= amrex::Real(1.0e1);
+      tparm->const_diffusivity *= amrex::Real(1.0e1);
+      tparm->const_conductivity *= amrex::Real(1.0e5);
+    } else if (units != "CGS") {
+      amrex::Abort(
+        "Unable to initialize transport using unknown units " + units +
+        ". Use CGS (def) or MKS");
+    }
+  }
+
+  static void host_deallocate(
+    PeleParams<transport::TransParm<EOSType, transport::ConstTransport>>*
+    /*parm_in*/)
+  {
+  }
+};
+
+template <typename EOSType>
+struct InitParm<transport::TransParm<EOSType, transport::SutherlandTransport>>
+{
+
+  static void host_initialize(
+    PeleParams<transport::TransParm<EOSType, transport::SutherlandTransport>>*
+      parm_in)
+  {
+    transport::TransParm<EOSType, transport::SutherlandTransport>* tparm =
+      &(parm_in->m_h_parm);
+    amrex::ParmParse pp("transport");
+    pp.query("Prandtl_number", tparm->Prandtl_number);
+    pp.query("viscosity_mu_ref", tparm->viscosity_mu_ref);
+    pp.query("viscosity_T_ref", tparm->viscosity_T_ref);
+    pp.query("viscosity_S", tparm->viscosity_S);
+    pp.query("const_bulk_viscosity", tparm->const_bulk_viscosity);
+    pp.query("const_diffusivity", tparm->const_diffusivity);
+  }
+
+  static void host_deallocate(
+    PeleParams<transport::TransParm<EOSType, transport::SutherlandTransport>>*
+    /*parm_in*/)
+  {
+  }
+};
+
+template <typename EOSType>
+struct InitParm<transport::TransParm<EOSType, transport::SimpleTransport>>
+{
+  static void host_initialize(
+    PeleParams<transport::TransParm<EOSType, transport::SimpleTransport>>*
+      parm_in)
+  {
+    transport::TransParm<EOSType, transport::SimpleTransport>* tparm =
+      &(parm_in->m_h_parm);
+    egtransetWT(tparm->wt.data());
+    egtransetEPS(tparm->eps.data());
+    egtransetSIG(tparm->sig.data());
+    egtransetDIP(tparm->dip.data());
+    egtransetPOL(tparm->pol.data());
+    egtransetZROT(tparm->zrot.data());
+    egtransetNLIN(tparm->nlin.data());
+    egtransetCOFETA(tparm->fitmu.data());
+    egtransetCOFLAM(tparm->fitlam.data());
+    egtransetCOFD(tparm->fitdbin.data());
+    amrex::ParmParse pp("transport");
+    pp.query("use_soret", tparm->use_soret);
+    if (tparm->use_soret) {
+      egtransetNLITE(&tparm->numLite);
+      egtransetKTDIF(tparm->liteSpec.data());
+      egtransetCOFTD(tparm->fittdrat.data());
+    }
+    for (int i = 0; i < NUM_SPECIES; ++i) {
+      tparm->iwt[i] = 1. / tparm->wt[i];
+    }
+  }
+
+  static void host_deallocate(
+    PeleParams<transport::TransParm<EOSType, transport::SimpleTransport>>*
+    /*parm_in*/)
+  {
+  }
+};
+
+template <>
+struct InitParm<transport::TransParm<eos::SRK, transport::SimpleTransport>>
+{
+  static void host_initialize(
+    PeleParams<transport::TransParm<eos::SRK, transport::SimpleTransport>>*
+      parm_in)
+  {
+    transport::TransParm<eos::SRK, transport::SimpleTransport>* tparm =
+      &(parm_in->m_h_parm);
     egtransetWT(tparm->wt.data());
     egtransetEPS(tparm->eps.data());
     egtransetSIG(tparm->sig.data());
@@ -335,59 +368,13 @@ struct InitTransParm<eos::SRK, SimpleTransport>
       }
     }
   }
+
+  static void host_deallocate(
+    PeleParams<transport::TransParm<eos::SRK, transport::SimpleTransport>>*
+    /*parm_in*/)
+  {
+  }
 };
 
-template <typename TransportType>
-class TransportParams
-{
-public:
-  TransportParams() = default;
-
-  ~TransportParams() = default;
-
-  void allocate()
-  {
-    InitTransParm<EosType, TransportType>()(&m_h_trans_parm);
-    if (!m_device_allocated) {
-      m_d_trans_parm =
-        (TransParm<EosType, TransportType>*)amrex::The_Device_Arena()->alloc(
-          sizeof(m_h_trans_parm));
-      m_device_allocated = true;
-      sync_to_device();
-    }
-  }
-
-  void deallocate()
-  {
-    if (m_device_allocated) {
-      amrex::The_Device_Arena()->free(m_d_trans_parm);
-    }
-  }
-
-  void sync_to_device()
-  {
-    if (!m_device_allocated) {
-      amrex::Abort("Device params not allocated yet");
-    } else {
-      amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, &m_h_trans_parm, &m_h_trans_parm + 1,
-        m_d_trans_parm);
-    }
-  }
-
-  TransParm<EosType, TransportType>& host_trans_parm()
-  {
-    return m_h_trans_parm;
-  }
-  const TransParm<EosType, TransportType>* device_trans_parm()
-  {
-    return m_d_trans_parm;
-  }
-
-private:
-  TransParm<EosType, TransportType> m_h_trans_parm;
-  TransParm<EosType, TransportType>* m_d_trans_parm{nullptr};
-  bool m_device_allocated{false};
-};
-} // namespace pele::physics::transport
+} // namespace pele::physics
 #endif

--- a/Source/Utility/PMF/PMF.H
+++ b/Source/Utility/PMF/PMF.H
@@ -12,7 +12,7 @@ AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
 void
 pmf(
-  DataContainer const* pmf_data,
+  PmfData::DataContainer const* pmf_data,
   amrex::Real xlo,
   amrex::Real xhi,
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4>& y_vector)

--- a/Source/Utility/PMF/PMF.H
+++ b/Source/Utility/PMF/PMF.H
@@ -12,7 +12,7 @@ AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
 void
 pmf(
-  PmfData::DataContainer const* pmf_data,
+  DataContainer const* pmf_data,
   amrex::Real xlo,
   amrex::Real xhi,
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4>& y_vector)
@@ -122,7 +122,7 @@ pmf(
       if (loside != hiside) {
         dydx = (y2 - y1) / (x2 - x1);
       }
-      y_vector[j] = y1 + dydx * (xlo - x1);
+      y_vector[j] = y1 + dydx * (xmid - x1);
     }
   }
 }

--- a/Source/Utility/PMF/PMFData.H
+++ b/Source/Utility/PMF/PMFData.H
@@ -9,7 +9,7 @@
 
 // Define a class to hold/manage the PMF data,
 namespace pele::physics {
-namespace PMF {
+namespace PMF::PmfData {
 
 struct DataContainer
 {
@@ -19,19 +19,19 @@ struct DataContainer
   amrex::Real* pmf_X;
   amrex::Real* pmf_Y;
 };
-} // namespace PMF
+} // namespace PMF::PmfData
 
 template <>
-struct InitParm<PMF::DataContainer>
+struct InitParm<PMF::PmfData::DataContainer>
 {
 
   static void read_pmf(
     const std::string& fname,
     const int a_doAverage,
     const int a_verbose,
-    PMF::DataContainer& h_pmf_data);
+    PMF::PmfData::DataContainer& h_pmf_data);
 
-  static void host_initialize(PeleParams<PMF::DataContainer>* parm_in)
+  static void host_initialize(PeleParams<PMF::PmfData::DataContainer>* parm_in)
   {
     amrex::ParmParse pp("pmf");
     std::string datafile;
@@ -46,7 +46,10 @@ struct InitParm<PMF::DataContainer>
     read_pmf(datafile, do_average, verbose, parm_in->m_h_parm);
   };
 
-  static void host_deallocate(PeleParams<PMF::DataContainer>* /*parm_in*/) {}
+  static void
+  host_deallocate(PeleParams<PMF::PmfData::DataContainer>* /*parm_in*/)
+  {
+  }
 };
 
 } // namespace pele::physics

--- a/Source/Utility/PMF/PMFData.H
+++ b/Source/Utility/PMF/PMFData.H
@@ -5,87 +5,49 @@
 #include <AMReX_GpuContainers.H>
 #include <AMReX_ParmParse.H>
 #include <mechanism.H>
+#include "PeleParamsGeneric.H"
 
 // Define a class to hold/manage the PMF data,
-namespace pele::physics::PMF {
+namespace pele::physics {
+namespace PMF {
 
-class PmfData
+struct DataContainer
 {
-public:
-  PmfData() = default;
+  int m_nPoint;
+  int m_nVar;
+  int m_doAverage = 0;
+  amrex::Real* pmf_X;
+  amrex::Real* pmf_Y;
+};
+} // namespace PMF
 
-  ~PmfData() = default;
+template <>
+struct InitParm<PMF::DataContainer>
+{
 
-  void initialize()
+  static void read_pmf(
+    const std::string& fname,
+    const int a_doAverage,
+    const int a_verbose,
+    PMF::DataContainer& h_pmf_data);
+
+  static void host_initialize(PeleParams<PMF::DataContainer>* parm_in)
   {
     amrex::ParmParse pp("pmf");
     std::string datafile;
-    pp.query("v", m_verbose);
+    int verbose;
+    pp.query("v", verbose);
     int do_average = 1;
     pp.query("do_cellAverage", do_average);
     if (!pp.contains("datafile")) {
       amrex::Abort("pmf.datafile is required when using pmf");
     }
     pp.get("datafile", datafile);
-    read_pmf(datafile, do_average, m_verbose);
-    allocate();
-  }
-
-  void read_pmf(const std::string& fname, int a_doAverage, int a_verbose);
-
-  struct DataContainer
-  {
-    int m_nPoint;
-    int m_nVar;
-    int m_doAverage = 0;
-    amrex::Real* pmf_X;
-    amrex::Real* pmf_Y;
+    read_pmf(datafile, do_average, verbose, parm_in->m_h_parm);
   };
 
-  void allocate()
-  {
-    if (!m_device_allocated) {
-      m_data_d = (DataContainer*)amrex::The_Arena()->alloc(sizeof(m_data_h));
-      m_device_allocated = true;
-      sync_to_device();
-    }
-  }
-
-  void deallocate()
-  {
-    if (m_host_allocated) {
-      amrex::The_Pinned_Arena()->free(m_data_h.pmf_X);
-      amrex::The_Pinned_Arena()->free(m_data_h.pmf_Y);
-    }
-    if (m_device_allocated) {
-      amrex::The_Arena()->free(m_data_d);
-    }
-  }
-
-  void sync_to_device()
-  {
-    if (!m_device_allocated) {
-      amrex::Abort("Device params not allocated yet");
-    } else {
-      amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, &m_data_h, &m_data_h + 1, m_data_d);
-    }
-  }
-
-  // Variables names
-  amrex::Vector<std::string> pmf_names;
-
-  // Accessors
-  DataContainer getHostData() { return m_data_h; }
-
-  DataContainer* getDeviceData() { return m_data_d; }
-
-private:
-  int m_verbose = 0;
-  DataContainer m_data_h;
-  DataContainer* m_data_d = nullptr;
-  bool m_device_allocated{false};
-  bool m_host_allocated{false};
+  static void host_deallocate(PeleParams<PMF::DataContainer>* /*parm_in*/) {}
 };
-} // namespace pele::physics::PMF
+
+} // namespace pele::physics
 #endif

--- a/Source/Utility/PMF/PMFData.cpp
+++ b/Source/Utility/PMF/PMFData.cpp
@@ -25,11 +25,11 @@ checkQuotes(const std::string& str)
 namespace pele::physics {
 
 void
-InitParm<PMF::DataContainer>::read_pmf(
+InitParm<PMF::PmfData::DataContainer>::read_pmf(
   const std::string& fname,
   const int a_doAverage,
   const int /*a_verbose*/,
-  PMF::DataContainer& h_pmf_data)
+  PMF::PmfData::DataContainer& h_pmf_data)
 {
   std::ifstream infile(fname);
   if (!infile.is_open()) {

--- a/Source/Utility/PMF/PMFData.cpp
+++ b/Source/Utility/PMF/PMFData.cpp
@@ -22,10 +22,14 @@ checkQuotes(const std::string& str)
   return (count % 2) == 0;
 }
 
-namespace pele::physics::PMF {
+namespace pele::physics {
 
 void
-PmfData::read_pmf(const std::string& fname, int a_doAverage, int /*a_verbose*/)
+InitParm<PMF::DataContainer>::read_pmf(
+  const std::string& fname,
+  const int a_doAverage,
+  const int /*a_verbose*/,
+  PMF::DataContainer& h_pmf_data)
 {
   std::ifstream infile(fname);
   if (!infile.is_open()) {
@@ -52,6 +56,7 @@ PmfData::read_pmf(const std::string& fname, int a_doAverage, int /*a_verbose*/)
     pos1 = pos2 + 1;
   }
 
+  amrex::Vector<std::string> pmf_names;
   pmf_names.resize(variable_count);
   pos1 = 0;
   for (int i = 0; i < variable_count; i++) {
@@ -75,27 +80,26 @@ PmfData::read_pmf(const std::string& fname, int a_doAverage, int /*a_verbose*/)
   }
   amrex::Print() << line_count << " data lines found in PMF file" << std::endl;
 
-  m_data_h.m_nPoint = line_count;
-  m_data_h.m_nVar = variable_count - 1;
+  h_pmf_data.m_nPoint = line_count;
+  h_pmf_data.m_nVar = variable_count - 1;
   const int sizeYvec = line_count * (variable_count - 1);
-  m_data_h.m_doAverage = a_doAverage;
-  m_data_h.pmf_X = (amrex::Real*)amrex::The_Pinned_Arena()->alloc(
+  h_pmf_data.m_doAverage = a_doAverage;
+  h_pmf_data.pmf_X = (amrex::Real*)amrex::The_Pinned_Arena()->alloc(
     line_count * sizeof(amrex::Real));
-  m_data_h.pmf_Y = (amrex::Real*)amrex::The_Pinned_Arena()->alloc(
+  h_pmf_data.pmf_Y = (amrex::Real*)amrex::The_Pinned_Arena()->alloc(
     sizeYvec * sizeof(amrex::Real));
-  m_host_allocated = true;
 
   iss.clear();
   iss.seekg(0, std::ios::beg);
   std::getline(iss, firstline);
   std::getline(iss, secondline);
-  for (int i = 0; i < m_data_h.m_nPoint; i++) {
+  for (int i = 0; i < h_pmf_data.m_nPoint; i++) {
     std::getline(iss, remaininglines);
     std::istringstream sinput(remaininglines);
-    sinput >> m_data_h.pmf_X[i];
-    for (int j = 0; j < m_data_h.m_nVar; j++) {
-      sinput >> m_data_h.pmf_Y[j * m_data_h.m_nPoint + i];
+    sinput >> h_pmf_data.pmf_X[i];
+    for (int j = 0; j < h_pmf_data.m_nVar; j++) {
+      sinput >> h_pmf_data.pmf_Y[j * h_pmf_data.m_nPoint + i];
     }
   }
 }
-} // namespace pele::physics::PMF
+} // namespace pele::physics

--- a/Testing/Exec/IgnitionDelay/main.cpp
+++ b/Testing/Exec/IgnitionDelay/main.cpp
@@ -47,7 +47,7 @@ main(int argc, char* argv[])
     amrex::Real strt_time = amrex::ParallelDescriptor::second();
     BL_PROFILE_VAR("main::main()", pmain);
 
-    // ~~~~ Init: Read input, initialize transport, geom, data
+    // ~~~~ Init: Read input, initialize geom, data
     // Parse the relevant inputs
     std::string fuel_name;
     std::string chem_integrator;
@@ -72,12 +72,6 @@ main(int argc, char* argv[])
     // Assign Fuel ID
     int fuel_idx;
     getFuelID(fuel_name, fuel_idx);
-
-    // Initialize transport
-    pele::physics::transport::TransportParams<
-      pele::physics::PhysicsType::transport_type>
-      trans_parms;
-    trans_parms.allocate();
 
     // Initialize reactor object inside OMP region, including tolerances
     BL_PROFILE_VAR("main::reactor_info()", reactInfo);
@@ -159,7 +153,6 @@ main(int argc, char* argv[])
     plotResult(do_plt, pltfile, finest_level, mf, geoms);
 
     // ~~~~ Finalize
-    trans_parms.deallocate();
     BL_PROFILE_VAR_STOP(pmain);
     amrex::Real run_time = amrex::ParallelDescriptor::second() - strt_time;
     amrex::ParallelDescriptor::ReduceRealMax(

--- a/Testing/Exec/PMFReader/data_K.H
+++ b/Testing/Exec/PMFReader/data_K.H
@@ -17,7 +17,7 @@ initdata(
   amrex::Array4<amrex::Real> const& state,
   const amrex::Real& standoff,
   amrex::GeometryData const& geomdata,
-  pele::physics::PMF::DataContainer const* pmf_data)
+  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
 {
   const amrex::Real* prob_lo = geomdata.ProbLo();
   const amrex::Real* prob_hi = geomdata.ProbHi();

--- a/Testing/Exec/PMFReader/data_K.H
+++ b/Testing/Exec/PMFReader/data_K.H
@@ -17,7 +17,7 @@ initdata(
   amrex::Array4<amrex::Real> const& state,
   const amrex::Real& standoff,
   amrex::GeometryData const& geomdata,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
+  pele::physics::PMF::DataContainer const* pmf_data)
 {
   const amrex::Real* prob_lo = geomdata.ProbLo();
   const amrex::Real* prob_hi = geomdata.ProbHi();

--- a/Testing/Exec/PMFReader/main.cpp
+++ b/Testing/Exec/PMFReader/main.cpp
@@ -32,7 +32,7 @@ main(int argc, char* argv[])
     BL_PROFILE_VAR("main::main()", pmain);
 
     // Init PMF
-    pele::physics::PMF::PmfData pmf_data;
+    pele::physics::PeleParams<pele::physics::PMF::DataContainer> pmf_data;
     pmf_data.initialize();
 
     // Get standoff
@@ -73,8 +73,7 @@ main(int argc, char* argv[])
 
     // Initialize data from PMF
     const auto geomdata = geom.data();
-    pele::physics::PMF::PmfData::DataContainer const* lpmfdata =
-      pmf_data.getDeviceData();
+    auto const* lpmfdata = pmf_data.device_parm();
     auto const& sma = stateMF.arrays();
     amrex::ParallelFor(
       stateMF, [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) noexcept {

--- a/Testing/Exec/PMFReader/main.cpp
+++ b/Testing/Exec/PMFReader/main.cpp
@@ -32,7 +32,8 @@ main(int argc, char* argv[])
     BL_PROFILE_VAR("main::main()", pmain);
 
     // Init PMF
-    pele::physics::PeleParams<pele::physics::PMF::DataContainer> pmf_data;
+    pele::physics::PeleParams<pele::physics::PMF::PmfData::DataContainer>
+      pmf_data;
     pmf_data.initialize();
 
     // Get standoff

--- a/Testing/Exec/ReactEval/main.cpp
+++ b/Testing/Exec/ReactEval/main.cpp
@@ -131,11 +131,6 @@ main(int argc, char* argv[])
 #endif
     }
 
-    pele::physics::transport::TransportParams<
-      pele::physics::PhysicsType::transport_type>
-      trans_parms;
-    trans_parms.allocate();
-
     /* Initialize reactor object inside OMP region, including tolerances */
     BL_PROFILE_VAR("main::reactor_info()", reactInfo);
     std::unique_ptr<pele::physics::reactions::ReactorBase> reactor =
@@ -718,8 +713,6 @@ main(int argc, char* argv[])
         0.0, isteps, refRatios);
       BL_PROFILE_VAR_STOP(PlotFile);
     }
-
-    trans_parms.deallocate();
 
     BL_PROFILE_VAR_STOP(pmain);
 

--- a/Testing/Exec/TranEval/main.cpp
+++ b/Testing/Exec/TranEval/main.cpp
@@ -18,10 +18,11 @@ main(int argc, char* argv[])
 
     amrex::ParmParse pp;
 
-    pele::physics::transport::TransportParams<
-      pele::physics::PhysicsType::transport_type>
+    pele::physics::PeleParams<pele::physics::transport::TransParm<
+      pele::physics::PhysicsType::eos_type,
+      pele::physics::PhysicsType::transport_type>>
       trans_parms;
-    trans_parms.allocate();
+    trans_parms.initialize();
 
     // Define geometry
     amrex::Array<int, AMREX_SPACEDIM> npts{AMREX_D_DECL(1, 1, 1)};
@@ -88,7 +89,7 @@ main(int argc, char* argv[])
     amrex::MultiFab chi(ba, dm, NUM_SPECIES, num_grow);
 
     // Get the transport data pointer
-    auto const* ltransparm = trans_parms.device_trans_parm();
+    auto const* ltransparm = trans_parms.device_parm();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())


### PR DESCRIPTION
Takes a piece from #492 to make reviewing easier.

PeleParams is a class template that allows copying arbitrary data structures from host to device, taking advantage of The_Pinned_Arena (simple data structures of fixed size can be copied directly without dealing with that though). An InitParm class must be defined with a function that populates the data structure (and cleans it up, if needed). There's some funky stuff to be able to use PeleParams to create derived versions of a base data structure, but for most use cases that can be transparently ignored. Written as a generalization of the old PMFData structure.

Will require minor downstream changes in LMeX/C.

Also implements bugfix in PMF interpolation from https://github.com/AMReX-Combustion/PeleC/pull/808