### PR TITLE
Simplify Make.package in mechanisms

### DIFF
--- a/Mechanisms/Aromatic_KrNara/Make.package
+++ b/Mechanisms/Aromatic_KrNara/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/BurkeDryer/Make.package
+++ b/Mechanisms/BurkeDryer/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/C1-C2-NO/Make.package
+++ b/Mechanisms/C1-C2-NO/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/C1-C2-NO_qss/Make.package
+++ b/Mechanisms/C1-C2-NO_qss/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/CH4_lean/Make.package
+++ b/Mechanisms/CH4_lean/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/CH4_lean_qss/Make.package
+++ b/Mechanisms/CH4_lean_qss/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/Davis/Make.package
+++ b/Mechanisms/Davis/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/FFCM1_Red/Make.package
+++ b/Mechanisms/FFCM1_Red/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/H2-CO-CO2-3spec/Make.package
+++ b/Mechanisms/H2-CO-CO2-3spec/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/HP_DME/Make.package
+++ b/Mechanisms/HP_DME/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/IonizedAir/Make.package
+++ b/Mechanisms/IonizedAir/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/JL4/Make.package
+++ b/Mechanisms/JL4/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/Kolla/Make.package
+++ b/Mechanisms/Kolla/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/LiDryer/Make.package
+++ b/Mechanisms/LiDryer/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/LuDME/Make.package
+++ b/Mechanisms/LuDME/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/LuEthylene/Make.package
+++ b/Mechanisms/LuEthylene/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/LuEthylene_qss/Make.package
+++ b/Mechanisms/LuEthylene_qss/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/NUIGalway/Make.package
+++ b/Mechanisms/NUIGalway/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/Null/Make.package
+++ b/Mechanisms/Null/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/SootReaction/Make.package
+++ b/Mechanisms/SootReaction/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/air/Make.package
+++ b/Mechanisms/air/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/alzeta/Make.package
+++ b/Mechanisms/alzeta/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/chem-CH4-2step/Make.package
+++ b/Mechanisms/chem-CH4-2step/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/chem-H/Make.package
+++ b/Mechanisms/chem-H/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/decane_3sp/Make.package
+++ b/Mechanisms/decane_3sp/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/dodecane_lu/Make.package
+++ b/Mechanisms/dodecane_lu/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/dodecane_lu_qss/Make.package
+++ b/Mechanisms/dodecane_lu_qss/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/dodecane_wang/Make.package
+++ b/Mechanisms/dodecane_wang/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/dodmethair_4sp/Make.package
+++ b/Mechanisms/dodmethair_4sp/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/drm19/Make.package
+++ b/Mechanisms/drm19/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/ethylene_af/Make.package
+++ b/Mechanisms/ethylene_af/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/grimech12/Make.package
+++ b/Mechanisms/grimech12/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/grimech30-noArN/Make.package
+++ b/Mechanisms/grimech30-noArN/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/grimech30/Make.package
+++ b/Mechanisms/grimech30/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/heptane_3sp/Make.package
+++ b/Mechanisms/heptane_3sp/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/heptane_fc/Make.package
+++ b/Mechanisms/heptane_fc/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/heptane_lu_88sk/Make.package
+++ b/Mechanisms/heptane_lu_88sk/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/heptane_lu_qss/Make.package
+++ b/Mechanisms/heptane_lu_qss/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/isooctane_lu/Make.package
+++ b/Mechanisms/isooctane_lu/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/methaneIons_diRenzo/Make.package
+++ b/Mechanisms/methaneIons_diRenzo/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/ndodecane_35/Make.package
+++ b/Mechanisms/ndodecane_35/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/nitrogens/Make.package
+++ b/Mechanisms/nitrogens/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/propane_fc/Make.package
+++ b/Mechanisms/propane_fc/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Mechanisms/sCO2/Make.package
+++ b/Mechanisms/sCO2/Make.package
@@ -1,9 +1,1 @@
-CEXE_headers+=mechanism.H
-
 CEXE_sources+=mechanism.cpp
-
-LIBRARIES +=
-
-INCLUDE_LOCATIONS += $(CHEM_DIR)
-
-VPATH_LOCATIONS +=  $(CHEM_DIR)/PMFs

--- a/Source/Utility/BlackBoxFunction/Table.H
+++ b/Source/Utility/BlackBoxFunction/Table.H
@@ -541,7 +541,8 @@ private:
         1.0 / (tf_data->grids[idx + 1] - tf_data->grids[idx]);
       dxinv[dim] = dx_inv;
       amrex::Real alpha = (tf_data->grids[idx + 1] - interpdata[dim]) * dx_inv;
-      alphas[dim] = std::min(std::max(alpha, 0.0), 1.0);
+      alphas[dim] =
+        std::min(std::max(alpha, amrex::Real(0.0)), amrex::Real(1.0));
       start += dimLen;
     }
   }


### PR DESCRIPTION
Get rid of a bunch of extraneous/deprecated stuff in the Make.package files for each mechanism.