### PR TITLE
Added functions to get nsteps after reading plot file

### DIFF
--- a/Source/Utility/PltFileManager/PltFileManager.H
+++ b/Source/Utility/PltFileManager/PltFileManager.H
@@ -32,6 +32,7 @@ public:
   amrex::Vector<std::string> getVariableList() { return m_vars; }
   int getNlev() const { return m_nlevels; }
   amrex::Real getTime() const { return m_time; }
+  int getNsteps() const { return m_nsteps; }
   const amrex::BoxArray& getGrid(int a_lev) { return m_grids[a_lev]; }
   const amrex::Geometry& getGeom(int a_lev) { return m_geoms[a_lev]; }
   int getRefRatio(int a_lev) { return m_refRatio[a_lev]; }
@@ -43,6 +44,7 @@ protected:
   amrex::Vector<std::string> m_vars; // list of variable in the plotfile
   int m_nlevels{0};                  // number of levels
   amrex::Real m_time{0.0};           // Simulation time
+  int m_nsteps;                      // Number of steps
   bool m_dataLoaded{false}; // Flag to check is the data has been read in
 
   // Geometry, grid and data containers

--- a/Source/Utility/PltFileManager/PltFileManager.cpp
+++ b/Source/Utility/PltFileManager/PltFileManager.cpp
@@ -122,7 +122,6 @@ PltFileManager::readGenericPlotfileHeader(const std::string& a_pltFileHeader)
   }
   GotoNextLine(is);
   is >> m_nsteps;
-  // GotoNextLine(is); // Skip nsteps line
   for (int lev = 0; lev < m_nlevels; ++lev) {
     GotoNextLine(is); // Skip dx line
   }

--- a/Source/Utility/PltFileManager/PltFileManager.cpp
+++ b/Source/Utility/PltFileManager/PltFileManager.cpp
@@ -121,7 +121,8 @@ PltFileManager::readGenericPlotfileHeader(const std::string& a_pltFileHeader)
     is >> Domains[lev];
   }
   GotoNextLine(is);
-  GotoNextLine(is); // Skip nsteps line
+  is >> m_nsteps;
+  // GotoNextLine(is); // Skip nsteps line
   for (int lev = 0; lev < m_nlevels; ++lev) {
     GotoNextLine(is); // Skip dx line
   }


### PR DESCRIPTION
Changed function to read nstep values from plot file headers.
Added a function to return the nstep values.
These changes will be used in PeleLMeX to restart from a plot file without (optionally) resetting time and nstep values to 0.