### PR TITLE
Unit conversions

### DIFF
--- a/Docs/sphinx/Utility.rst
+++ b/Docs/sphinx/Utility.rst
@@ -12,6 +12,7 @@ In addition to routines for evaluating chemical reactions, transport properties,
 * Turbulent inflows (``TurbInflow``) on domain boundaries from saved turbulence data
 * Plt file management (``PltFileManager``)
 * Output of runtime ``Diagnostics``
+* Basic ``Utilities``, including unit conversions
 
 This section provides relevant notes on using these utilities across the Pele family of codes. There may be additional subtleties based on the code-specific implementation of these capabilities, in which case it will be necessary to refer to the documentation of the code of interest.
 
@@ -146,3 +147,26 @@ discussed in PeleC milestone reports. An example call to the filtering operation
    les_filter.apply_filter(bxtmp, flux[i], filtered_flux[i], Density, NUM_STATE);
 
 The user must ensure that the correct number of grow cells is present in the Fab or MultiFab.
+
+Utilities
+=============================
+The utilities namespace contains unit conversions, which are particularly useful for PeleLM(eX) users working with mixed unit systems. The following aliases, defined in a file header, enable straightforward conversions between MKS and CGS units for use in equation of state (``eos``) function calls:
+
+::
+
+   namespace m2c = pele::physics::utilities::mks2cgs;
+   namespace c2m = pele::physics::utilities::cgs2mks;
+
+For example, users can call ``eos.PYT2R`` as follows:
+
+::
+
+   auto eos = pele::physics::PhysicsType::eos();
+   amrex::Real P_mean = 101325.0_rt; // Pressure in Pa (MKS)
+   amrex::Real massfrac[NUM_SPECIES]; // Mass fractions tracked by PeleLM(eX)
+   amrex::Real Temp = 300.0_rt; // Temp in K
+   amrex::Real rho_cgs = 0.0_rt; // Density in g/cm^3 (CGS)
+   
+   // Calculate density in CGS units, then convert to MKS
+   eos.PYT2R(m2c::P(P_mean), massfrac, Temp, rho_cgs);
+   amrex::Real rho = c2m::Rho(rho_cgs); // Convert eos density to MKS

--- a/Source/PelePhysics.H
+++ b/Source/PelePhysics.H
@@ -7,6 +7,7 @@
 #include "PelePhysicsConstraints.H"
 #include "EOS.H"
 #include "Transport.H"
+#include "Utilities.H"
 
 namespace pele::physics {
 

--- a/Source/Utility/Utilities/Make.package
+++ b/Source/Utility/Utilities/Make.package
@@ -1,0 +1,5 @@
+CEXE_headers += Utilities.H UnitConversions.H
+CEXE_sources += Utilities.cpp
+
+VPATH_LOCATIONS += $(PELE_PHYSICS_HOME)/Source/Utility/Utilities
+INCLUDE_LOCATIONS += $(PELE_PHYSICS_HOME)/Source/Utility/Utilities

--- a/Source/Utility/Utilities/Make.package
+++ b/Source/Utility/Utilities/Make.package
@@ -1,5 +1,4 @@
 CEXE_headers += Utilities.H UnitConversions.H
-CEXE_sources += Utilities.cpp
 
 VPATH_LOCATIONS += $(PELE_PHYSICS_HOME)/Source/Utility/Utilities
 INCLUDE_LOCATIONS += $(PELE_PHYSICS_HOME)/Source/Utility/Utilities

--- a/Source/Utility/Utilities/UnitConversions.H
+++ b/Source/Utility/Utilities/UnitConversions.H
@@ -6,238 +6,250 @@
 #include <AMReX_Utility.H>
 
 namespace pele::physics::utilities {
-
+namespace cgs2mks {
 // CGS to MKS conversions
-struct cgs2mks
+template <int n = 0>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+Length(const amrex::Real L_cgs)
 {
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Length(const amrex::Real L_cgs)
-  {
+  // Usage: Length(L_cgs) or Length<n>(L_cgs)
+  if constexpr (n == 0) {
     return L_cgs * 1.0e-2; // cm to m
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Length_Pow(const amrex::Real L_cgs, const amrex::Real n)
-  {
+  } else {
     return L_cgs * std::pow(1.0e-2, n); // cm^n to m^n
   }
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Mass(const amrex::Real M_cgs)
-  {
+template <int n = 0>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+Mass(const amrex::Real M_cgs)
+{
+  // Usage: Mass(M_cgs) or Mass<n>(M_cgs)
+  if constexpr (n == 0) {
     return M_cgs * 1.0e-3; // g to kg
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Mass_Pow(const amrex::Real M_cgs, const amrex::Real n)
-  {
+  } else {
     return M_cgs * std::pow(1.0e-3, n); // g^n to kg^n
   }
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Energy(const amrex::Real E_cgs)
-  {
-    return E_cgs * 1.0e-7; // erg to J
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Rho(const amrex::Real rho_cgs)
-  {
-    return rho_cgs * 1.0e3; // g/cm^3 to kg/m^3
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real U(const amrex::Real u_cgs)
-  {
-    return u_cgs * 1.0e-2; // cm/s to m/s
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real RhoU(const amrex::Real rhou_cgs)
-  {
-    return rhou_cgs * 1.0e1; // g/cm^2/s to kg/m^2/s
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real P(const amrex::Real p_cgs)
-  {
-    return p_cgs * 1.0e-1; // dyne/cm^2 to Pa
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real H(const amrex::Real h_cgs)
-  {
-    return h_cgs * 1.0e-4; // erg/g to J/kg
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real RhoH(const amrex::Real rhoh_cgs)
-  {
-    return rhoh_cgs * 1.0e1; // erg/cm^3 to J/m^3
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Nu(const amrex::Real nu_cgs)
-  {
-    return nu_cgs * 1.0e-4; // cm^2/s to m^2/s
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Mu(const amrex::Real mu_cgs)
-  {
-    return mu_cgs * 1.0e-1; // g/cm/s to kg/m/s
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Cp(const amrex::Real cp_cgs)
-  {
-    return cp_cgs * 1.0e-4; // erg/g/K to J/kg/K
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Alpha(const amrex::Real a_cgs)
-  {
-    return a_cgs * 1.0e-4; // cm^2/s to m^2/s
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Lambda(const amrex::Real l_cgs)
-  {
-    return l_cgs * 1.0e-5; // g/cm/s^3/K to W/m/K
-  }
-};
-
-// MKS to CGS conversions
-struct mks2cgs
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Energy(const amrex::Real E_cgs)
 {
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Length(const amrex::Real L_mks)
-  {
-    return L_mks * 1.0e2; // m to cm
-  }
+  return E_cgs * 1.0e-7; // erg to J
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Length_Pow(const amrex::Real L_mks, const amrex::Real n)
-  {
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Rho(const amrex::Real rho_cgs)
+{
+  return rho_cgs * 1.0e3; // g/cm^3 to kg/m^3
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+U(const amrex::Real u_cgs)
+{
+  return u_cgs * 1.0e-2; // cm/s to m/s
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+RhoU(const amrex::Real rhou_cgs)
+{
+  return rhou_cgs * 1.0e1; // g/cm^2/s to kg/m^2/s
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+P(const amrex::Real p_cgs)
+{
+  return p_cgs * 1.0e-1; // dyne/cm^2 to Pa
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+H(const amrex::Real h_cgs)
+{
+  return h_cgs * 1.0e-4; // erg/g to J/kg
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+RhoH(const amrex::Real rhoh_cgs)
+{
+  return rhoh_cgs * 1.0e1; // erg/cm^3 to J/m^3
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Nu(const amrex::Real nu_cgs)
+{
+  return nu_cgs * 1.0e-4; // cm^2/s to m^2/s
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Mu(const amrex::Real mu_cgs)
+{
+  return mu_cgs * 1.0e-1; // g/cm/s to kg/m/s
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Cp(const amrex::Real cp_cgs)
+{
+  return cp_cgs * 1.0e-4; // erg/g/K to J/kg/K
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Alpha(const amrex::Real a_cgs)
+{
+  return a_cgs * 1.0e-4; // cm^2/s to m^2/s
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Lambda(const amrex::Real l_cgs)
+{
+  return l_cgs * 1.0e-5; // g/cm/s^3/K to W/m/K
+}
+} // namespace cgs2mks
+
+namespace mks2cgs {
+// MKS to CGS conversions
+template <int n = 0>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+Length(const amrex::Real L_mks)
+{
+  // Usage: Length(L_mks) or Length<n>(L_mks)
+  if constexpr (n == 0) {
+    return L_mks * 1.0e2; // m to cm
+  } else {
     return L_mks * std::pow(1.0e2, n); // m^n to cm^n
   }
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Mass(const amrex::Real M_mks)
-  {
+template <int n = 0>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+Mass(const amrex::Real M_mks)
+{
+  // Usage: Mass(M_mks) or Mass<n>(M_mks)
+  if constexpr (n == 0) {
     return M_mks * 1.0e3; // kg to g
-  }
-
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Mass_Pow(const amrex::Real M_mks, const amrex::Real n)
-  {
+  } else {
     return M_mks * std::pow(1.0e3, n); // kg^n to g^n
   }
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Energy(const amrex::Real E_mks)
-  {
-    return E_mks * 1.0e7; // J to erg
-  }
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Energy(const amrex::Real E_mks)
+{
+  return E_mks * 1.0e7; // J to erg
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Rho(const amrex::Real Rho_mks)
-  {
-    return Rho_mks * 1.0e-3; // kg/m^3 to g/cm^3
-  }
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Rho(const amrex::Real Rho_mks)
+{
+  return Rho_mks * 1.0e-3; // kg/m^3 to g/cm^3
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real U(const amrex::Real u_mks)
-  {
-    return u_mks * 1.0e2; // m/s to cm/s
-  }
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+U(const amrex::Real u_mks)
+{
+  return u_mks * 1.0e2; // m/s to cm/s
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real RhoU(const amrex::Real Rhou_mks)
-  {
-    return Rhou_mks * 1.0e-1; // kg/m^2/s to g/cm^2/s
-  }
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+RhoU(const amrex::Real Rhou_mks)
+{
+  return Rhou_mks * 1.0e-1; // kg/m^2/s to g/cm^2/s
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real P(const amrex::Real p_mks)
-  {
-    return p_mks * 1.0e1; // Pa to dyne/cm^2
-  }
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+P(const amrex::Real p_mks)
+{
+  return p_mks * 1.0e1; // Pa to dyne/cm^2
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real H(const amrex::Real h_mks)
-  {
-    return h_mks * 1.0e4; // J/kg to erg/g
-  }
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+H(const amrex::Real h_mks)
+{
+  return h_mks * 1.0e4; // J/kg to erg/g
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real RhoH(const amrex::Real Rhoh_mks)
-  {
-    return Rhoh_mks * 1.0e1; // J/m^3 to erg/cm^3
-  }
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+RhoH(const amrex::Real Rhoh_mks)
+{
+  return Rhoh_mks * 1.0e1; // J/m^3 to erg/cm^3
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Nu(const amrex::Real Nu_mks)
-  {
-    return Nu_mks * 1.0e4; // m^2/s to cm^2/s
-  }
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Nu(const amrex::Real Nu_mks)
+{
+  return Nu_mks * 1.0e4; // m^2/s to cm^2/s
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Mu(const amrex::Real Mu_mks)
-  {
-    return Mu_mks * 1.0e1; // kg/m/s to g/cm/s
-  }
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Mu(const amrex::Real Mu_mks)
+{
+  return Mu_mks * 1.0e1; // kg/m/s to g/cm/s
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Cp(const amrex::Real cp_mks)
-  {
-    return cp_mks * 1.0e4; // J/kg/K to erg/g/K
-  }
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Cp(const amrex::Real cp_mks)
+{
+  return cp_mks * 1.0e4; // J/kg/K to erg/g/K
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Alpha(const amrex::Real a_mks)
-  {
-    return a_mks * 1.0e4; // m^2/s to cm^2/s
-  }
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Alpha(const amrex::Real a_mks)
+{
+  return a_mks * 1.0e4; // m^2/s to cm^2/s
+}
 
-  AMREX_GPU_HOST_DEVICE
-  AMREX_FORCE_INLINE
-  amrex::Real Lambda(const amrex::Real l_mks)
-  {
-    return l_mks * 1.0e5; // W/m/K to g/cm/s^3/K
-  }
-};
-
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Lambda(const amrex::Real l_mks)
+{
+  return l_mks * 1.0e5; // W/m/K to g/cm/s^3/K
+}
+} // namespace mks2cgs
 } // namespace pele::physics::utilities
 #endif

--- a/Source/Utility/Utilities/UnitConversions.H
+++ b/Source/Utility/Utilities/UnitConversions.H
@@ -5,204 +5,237 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Utility.H>
 
-namespace pele::physics::utilities{
+namespace pele::physics::utilities {
 
-  struct units{
-    // CGS to MKS conversions
-    
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_LENGTH(const amrex::Real L_cgs) {
-        return L_cgs * 1.0e-2;  // cm to m
-    }
+struct units
+{
+  // CGS to MKS conversions
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_LENGTH_POW(const amrex::Real L_cgs, amrex::Real n) {
-        return L_cgs * std::pow(1.0e-2, n);  // cm^n to m^n
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_LENGTH(const amrex::Real L_cgs)
+  {
+    return L_cgs * 1.0e-2; // cm to m
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_MASS(const amrex::Real M_cgs) {
-        return M_cgs * 1.0e-3;  // g to kg
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_LENGTH_POW(const amrex::Real L_cgs, amrex::Real n)
+  {
+    return L_cgs * std::pow(1.0e-2, n); // cm^n to m^n
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_MASS_POW(const amrex::Real M_cgs, amrex::Real n) {
-        return M_cgs * std::pow(1.0e-3, n);  // g^n to kg^n
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_MASS(const amrex::Real M_cgs)
+  {
+    return M_cgs * 1.0e-3; // g to kg
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_ENERGY(const amrex::Real E_cgs) {
-        return E_cgs * 1.0e-7;  // erg to J
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_MASS_POW(const amrex::Real M_cgs, amrex::Real n)
+  {
+    return M_cgs * std::pow(1.0e-3, n); // g^n to kg^n
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_RHO(const amrex::Real rho_cgs) {
-        return rho_cgs * 1.0e3;  // g/cm^3 to kg/m^3
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_ENERGY(const amrex::Real E_cgs)
+  {
+    return E_cgs * 1.0e-7; // erg to J
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_U(const amrex::Real u_cgs) {
-        return u_cgs * 1.0e-2;  // cm/s to m/s
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_RHO(const amrex::Real rho_cgs)
+  {
+    return rho_cgs * 1.0e3; // g/cm^3 to kg/m^3
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_RHOU(const amrex::Real rhou_cgs) {
-        return rhou_cgs * 1.0e1;  // g/cm^2/s to kg/m^2/s
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_U(const amrex::Real u_cgs)
+  {
+    return u_cgs * 1.0e-2; // cm/s to m/s
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_P(const amrex::Real p_cgs) {
-        return p_cgs * 1.0e-1;  // dyne/cm^2 to Pa
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_RHOU(const amrex::Real rhou_cgs)
+  {
+    return rhou_cgs * 1.0e1; // g/cm^2/s to kg/m^2/s
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_H(const amrex::Real h_cgs) {
-        return h_cgs * 1.0e-4;  // erg/g to J/kg
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_P(const amrex::Real p_cgs)
+  {
+    return p_cgs * 1.0e-1; // dyne/cm^2 to Pa
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_RHOH(const amrex::Real rhoh_cgs) {
-        return rhoh_cgs * 1.0e1;  // erg/cm^3 to J/m^3
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_H(const amrex::Real h_cgs)
+  {
+    return h_cgs * 1.0e-4; // erg/g to J/kg
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_NU(const amrex::Real nu_cgs) {
-        return nu_cgs * 1.0e-4;  // cm^2/s to m^2/s
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_RHOH(const amrex::Real rhoh_cgs)
+  {
+    return rhoh_cgs * 1.0e1; // erg/cm^3 to J/m^3
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_MU(const amrex::Real mu_cgs) {
-        return mu_cgs * 1.0e-1;  // g/cm/s to kg/m/s
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_NU(const amrex::Real nu_cgs)
+  {
+    return nu_cgs * 1.0e-4; // cm^2/s to m^2/s
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_Cp(const amrex::Real cp_cgs) {
-        return cp_cgs * 1.0e-4;  // erg/g/K to J/kg/K
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_MU(const amrex::Real mu_cgs)
+  {
+    return mu_cgs * 1.0e-1; // g/cm/s to kg/m/s
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_Alpha(const amrex::Real a_cgs) {
-        return a_cgs * 1.0e-4;  // cm^2/s to m^2/s
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_Cp(const amrex::Real cp_cgs)
+  {
+    return cp_cgs * 1.0e-4; // erg/g/K to J/kg/K
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real CGS2MKS_Lambda(const amrex::Real l_cgs) {
-        return l_cgs * 1.0e-5;  // g/cm/s^3/K to W/m/K  
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_Alpha(const amrex::Real a_cgs)
+  {
+    return a_cgs * 1.0e-4; // cm^2/s to m^2/s
+  }
 
-    // MKS to CGS conversions
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_LENGTH(const amrex::Real L_mks) {
-        return L_mks * 1.0e2;  // m to cm
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real CGS2MKS_Lambda(const amrex::Real l_cgs)
+  {
+    return l_cgs * 1.0e-5; // g/cm/s^3/K to W/m/K
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_LENGTH_POW(const amrex::Real L_mks, amrex::Real n) {
-        return L_mks * std::pow(1.0e2, n);  // m^n to cm^n
-    }
+  // MKS to CGS conversions
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_LENGTH(const amrex::Real L_mks)
+  {
+    return L_mks * 1.0e2; // m to cm
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_MASS(const amrex::Real M_mks) {
-        return M_mks * 1.0e3;  // kg to g
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_LENGTH_POW(const amrex::Real L_mks, amrex::Real n)
+  {
+    return L_mks * std::pow(1.0e2, n); // m^n to cm^n
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_MASS_POW(const amrex::Real M_mks, amrex::Real n) {
-        return M_mks * std::pow(1.0e3, n);  // kg^n to g^n
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_MASS(const amrex::Real M_mks)
+  {
+    return M_mks * 1.0e3; // kg to g
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_ENERGY(const amrex::Real E_mks) {
-        return E_mks * 1.0e7;  // J to erg
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_MASS_POW(const amrex::Real M_mks, amrex::Real n)
+  {
+    return M_mks * std::pow(1.0e3, n); // kg^n to g^n
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_RHO(const amrex::Real rho_mks) {
-        return rho_mks * 1.0e-3;  // kg/m^3 to g/cm^3
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_ENERGY(const amrex::Real E_mks)
+  {
+    return E_mks * 1.0e7; // J to erg
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_U(const amrex::Real u_mks) {
-        return u_mks * 1.0e2;  // m/s to cm/s
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_RHO(const amrex::Real rho_mks)
+  {
+    return rho_mks * 1.0e-3; // kg/m^3 to g/cm^3
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_RHOU(const amrex::Real rhou_mks) {
-        return rhou_mks * 1.0e-1;  // kg/m^2/s to g/cm^2/s
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_U(const amrex::Real u_mks)
+  {
+    return u_mks * 1.0e2; // m/s to cm/s
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_P(const amrex::Real p_mks) {
-        return p_mks * 1.0e1;  // Pa to dyne/cm^2
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_RHOU(const amrex::Real rhou_mks)
+  {
+    return rhou_mks * 1.0e-1; // kg/m^2/s to g/cm^2/s
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_H(const amrex::Real h_mks) {
-       return h_mks * 1.0e4;  // J/kg to erg/g
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_P(const amrex::Real p_mks)
+  {
+    return p_mks * 1.0e1; // Pa to dyne/cm^2
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_RHOH(const amrex::Real rhoh_mks) {
-        return rhoh_mks * 1.0e1;  // J/m^3 to erg/cm^3
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_H(const amrex::Real h_mks)
+  {
+    return h_mks * 1.0e4; // J/kg to erg/g
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_NU(const amrex::Real nu_mks) {
-        return nu_mks * 1.0e4;  // m^2/s to cm^2/s
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_RHOH(const amrex::Real rhoh_mks)
+  {
+    return rhoh_mks * 1.0e1; // J/m^3 to erg/cm^3
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_MU(const amrex::Real mu_mks) {
-        return mu_mks * 1.0e1;  // kg/m/s to g/cm/s
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_NU(const amrex::Real nu_mks)
+  {
+    return nu_mks * 1.0e4; // m^2/s to cm^2/s
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_Cp(const amrex::Real cp_mks) {
-        return cp_mks * 1.0e4;  // J/kg/K to erg/g/K
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_MU(const amrex::Real mu_mks)
+  {
+    return mu_mks * 1.0e1; // kg/m/s to g/cm/s
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_Alpha(const amrex::Real a_mks) {
-       return a_mks * 1.0e4;  // m^2/s to cm^2/s
-    }
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_Cp(const amrex::Real cp_mks)
+  {
+    return cp_mks * 1.0e4; // J/kg/K to erg/g/K
+  }
 
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::Real MKS2CGS_Lambda(const amrex::Real l_mks) {
-        return l_mks * 1.0e5;  // W/m/K to g/cm/s^3/K
-    }
-  };
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_Alpha(const amrex::Real a_mks)
+  {
+    return a_mks * 1.0e4; // m^2/s to cm^2/s
+  }
+
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
+  amrex::Real MKS2CGS_Lambda(const amrex::Real l_mks)
+  {
+    return l_mks * 1.0e5; // W/m/K to g/cm/s^3/K
+  }
+};
 
 } // namespace pele::physics::utilities
 #endif

--- a/Source/Utility/Utilities/UnitConversions.H
+++ b/Source/Utility/Utilities/UnitConversions.H
@@ -8,28 +8,36 @@
 namespace pele::physics::utilities {
 namespace cgs2mks {
 // CGS to MKS conversions
-template <int n = 0>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
 Length(const amrex::Real L_cgs)
 {
-  // Usage: Length(L_cgs) or Length<n>(L_cgs)
-  if constexpr (n == 0) {
-    return L_cgs * 1.0e-2; // cm to m
-  } else {
-    return L_cgs * std::pow(1.0e-2, n); // cm^n to m^n
-  }
+  return L_cgs * 1.0e-2; // cm to m
 }
 
-template <int n = 0>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Length(const amrex::Real L_cgs, const amrex::Real n)
+{
+  return L_cgs * std::pow(1.0e-2, n); // cm^n to m^n
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
 Mass(const amrex::Real M_cgs)
 {
-  // Usage: Mass(M_cgs) or Mass<n>(M_cgs)
-  if constexpr (n == 0) {
-    return M_cgs * 1.0e-3; // g to kg
-  } else {
-    return M_cgs * std::pow(1.0e-3, n); // g^n to kg^n
-  }
+  return M_cgs * 1.0e-3; // g to kg
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Mass(const amrex::Real M_cgs, const amrex::Real n)
+{
+  return M_cgs * std::pow(1.0e-3, n); // g^n to kg^n
 }
 
 AMREX_GPU_HOST_DEVICE
@@ -131,28 +139,36 @@ Lambda(const amrex::Real l_cgs)
 
 namespace mks2cgs {
 // MKS to CGS conversions
-template <int n = 0>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
 Length(const amrex::Real L_mks)
 {
-  // Usage: Length(L_mks) or Length<n>(L_mks)
-  if constexpr (n == 0) {
-    return L_mks * 1.0e2; // m to cm
-  } else {
-    return L_mks * std::pow(1.0e2, n); // m^n to cm^n
-  }
+  return L_mks * 1.0e2; // m to cm
 }
 
-template <int n = 0>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Length(const amrex::Real L_mks, const amrex::Real n)
+{
+  return L_mks * std::pow(1.0e2, n); // m^n to cm^n
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
 Mass(const amrex::Real M_mks)
 {
-  // Usage: Mass(M_mks) or Mass<n>(M_mks)
-  if constexpr (n == 0) {
-    return M_mks * 1.0e3; // kg to g
-  } else {
-    return M_mks * std::pow(1.0e3, n); // kg^n to g^n
-  }
+  return M_mks * 1.0e3; // kg to g
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+Mass(const amrex::Real M_mks, const amrex::Real n)
+{
+  return M_mks * std::pow(1.0e3, n); // kg^n to g^n
 }
 
 AMREX_GPU_HOST_DEVICE

--- a/Source/Utility/Utilities/UnitConversions.H
+++ b/Source/Utility/Utilities/UnitConversions.H
@@ -1,0 +1,208 @@
+#ifndef UNITCONVERSIONS_H
+#define UNITCONVERSIONS_H
+
+#include <AMReX.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Utility.H>
+
+namespace pele::physics::utilities{
+
+  struct units{
+    // CGS to MKS conversions
+    
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_LENGTH(const amrex::Real L_cgs) {
+        return L_cgs * 1.0e-2;  // cm to m
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_LENGTH_POW(const amrex::Real L_cgs, amrex::Real n) {
+        return L_cgs * std::pow(1.0e-2, n);  // cm^n to m^n
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_MASS(const amrex::Real M_cgs) {
+        return M_cgs * 1.0e-3;  // g to kg
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_MASS_POW(const amrex::Real M_cgs, amrex::Real n) {
+        return M_cgs * std::pow(1.0e-3, n);  // g^n to kg^n
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_ENERGY(const amrex::Real E_cgs) {
+        return E_cgs * 1.0e-7;  // erg to J
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_RHO(const amrex::Real rho_cgs) {
+        return rho_cgs * 1.0e3;  // g/cm^3 to kg/m^3
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_U(const amrex::Real u_cgs) {
+        return u_cgs * 1.0e-2;  // cm/s to m/s
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_RHOU(const amrex::Real rhou_cgs) {
+        return rhou_cgs * 1.0e1;  // g/cm^2/s to kg/m^2/s
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_P(const amrex::Real p_cgs) {
+        return p_cgs * 1.0e-1;  // dyne/cm^2 to Pa
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_H(const amrex::Real h_cgs) {
+        return h_cgs * 1.0e-4;  // erg/g to J/kg
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_RHOH(const amrex::Real rhoh_cgs) {
+        return rhoh_cgs * 1.0e1;  // erg/cm^3 to J/m^3
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_NU(const amrex::Real nu_cgs) {
+        return nu_cgs * 1.0e-4;  // cm^2/s to m^2/s
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_MU(const amrex::Real mu_cgs) {
+        return mu_cgs * 1.0e-1;  // g/cm/s to kg/m/s
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_Cp(const amrex::Real cp_cgs) {
+        return cp_cgs * 1.0e-4;  // erg/g/K to J/kg/K
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_Alpha(const amrex::Real a_cgs) {
+        return a_cgs * 1.0e-4;  // cm^2/s to m^2/s
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real CGS2MKS_Lambda(const amrex::Real l_cgs) {
+        return l_cgs * 1.0e-5;  // g/cm/s^3/K to W/m/K  
+    }
+
+    // MKS to CGS conversions
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_LENGTH(const amrex::Real L_mks) {
+        return L_mks * 1.0e2;  // m to cm
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_LENGTH_POW(const amrex::Real L_mks, amrex::Real n) {
+        return L_mks * std::pow(1.0e2, n);  // m^n to cm^n
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_MASS(const amrex::Real M_mks) {
+        return M_mks * 1.0e3;  // kg to g
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_MASS_POW(const amrex::Real M_mks, amrex::Real n) {
+        return M_mks * std::pow(1.0e3, n);  // kg^n to g^n
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_ENERGY(const amrex::Real E_mks) {
+        return E_mks * 1.0e7;  // J to erg
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_RHO(const amrex::Real rho_mks) {
+        return rho_mks * 1.0e-3;  // kg/m^3 to g/cm^3
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_U(const amrex::Real u_mks) {
+        return u_mks * 1.0e2;  // m/s to cm/s
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_RHOU(const amrex::Real rhou_mks) {
+        return rhou_mks * 1.0e-1;  // kg/m^2/s to g/cm^2/s
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_P(const amrex::Real p_mks) {
+        return p_mks * 1.0e1;  // Pa to dyne/cm^2
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_H(const amrex::Real h_mks) {
+       return h_mks * 1.0e4;  // J/kg to erg/g
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_RHOH(const amrex::Real rhoh_mks) {
+        return rhoh_mks * 1.0e1;  // J/m^3 to erg/cm^3
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_NU(const amrex::Real nu_mks) {
+        return nu_mks * 1.0e4;  // m^2/s to cm^2/s
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_MU(const amrex::Real mu_mks) {
+        return mu_mks * 1.0e1;  // kg/m/s to g/cm/s
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_Cp(const amrex::Real cp_mks) {
+        return cp_mks * 1.0e4;  // J/kg/K to erg/g/K
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_Alpha(const amrex::Real a_mks) {
+       return a_mks * 1.0e4;  // m^2/s to cm^2/s
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real MKS2CGS_Lambda(const amrex::Real l_mks) {
+        return l_mks * 1.0e5;  // W/m/K to g/cm/s^3/K
+    }
+  };
+
+} // namespace pele::physics::utilities
+#endif

--- a/Source/Utility/Utilities/UnitConversions.H
+++ b/Source/Utility/Utilities/UnitConversions.H
@@ -7,231 +7,233 @@
 
 namespace pele::physics::utilities {
 
-struct units
+// CGS to MKS conversions
+struct cgs2mks
 {
-  // CGS to MKS conversions
-
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_LENGTH(const amrex::Real L_cgs)
+  amrex::Real Length(const amrex::Real L_cgs)
   {
     return L_cgs * 1.0e-2; // cm to m
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_LENGTH_POW(const amrex::Real L_cgs, amrex::Real n)
+  amrex::Real Length_Pow(const amrex::Real L_cgs, const amrex::Real n)
   {
     return L_cgs * std::pow(1.0e-2, n); // cm^n to m^n
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_MASS(const amrex::Real M_cgs)
+  amrex::Real Mass(const amrex::Real M_cgs)
   {
     return M_cgs * 1.0e-3; // g to kg
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_MASS_POW(const amrex::Real M_cgs, amrex::Real n)
+  amrex::Real Mass_Pow(const amrex::Real M_cgs, const amrex::Real n)
   {
     return M_cgs * std::pow(1.0e-3, n); // g^n to kg^n
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_ENERGY(const amrex::Real E_cgs)
+  amrex::Real Energy(const amrex::Real E_cgs)
   {
     return E_cgs * 1.0e-7; // erg to J
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_RHO(const amrex::Real rho_cgs)
+  amrex::Real Rho(const amrex::Real rho_cgs)
   {
     return rho_cgs * 1.0e3; // g/cm^3 to kg/m^3
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_U(const amrex::Real u_cgs)
+  amrex::Real U(const amrex::Real u_cgs)
   {
     return u_cgs * 1.0e-2; // cm/s to m/s
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_RHOU(const amrex::Real rhou_cgs)
+  amrex::Real RhoU(const amrex::Real rhou_cgs)
   {
     return rhou_cgs * 1.0e1; // g/cm^2/s to kg/m^2/s
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_P(const amrex::Real p_cgs)
+  amrex::Real P(const amrex::Real p_cgs)
   {
     return p_cgs * 1.0e-1; // dyne/cm^2 to Pa
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_H(const amrex::Real h_cgs)
+  amrex::Real H(const amrex::Real h_cgs)
   {
     return h_cgs * 1.0e-4; // erg/g to J/kg
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_RHOH(const amrex::Real rhoh_cgs)
+  amrex::Real RhoH(const amrex::Real rhoh_cgs)
   {
     return rhoh_cgs * 1.0e1; // erg/cm^3 to J/m^3
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_NU(const amrex::Real nu_cgs)
+  amrex::Real Nu(const amrex::Real nu_cgs)
   {
     return nu_cgs * 1.0e-4; // cm^2/s to m^2/s
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_MU(const amrex::Real mu_cgs)
+  amrex::Real Mu(const amrex::Real mu_cgs)
   {
     return mu_cgs * 1.0e-1; // g/cm/s to kg/m/s
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_Cp(const amrex::Real cp_cgs)
+  amrex::Real Cp(const amrex::Real cp_cgs)
   {
     return cp_cgs * 1.0e-4; // erg/g/K to J/kg/K
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_Alpha(const amrex::Real a_cgs)
+  amrex::Real Alpha(const amrex::Real a_cgs)
   {
     return a_cgs * 1.0e-4; // cm^2/s to m^2/s
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real CGS2MKS_Lambda(const amrex::Real l_cgs)
+  amrex::Real Lambda(const amrex::Real l_cgs)
   {
     return l_cgs * 1.0e-5; // g/cm/s^3/K to W/m/K
   }
+};
 
-  // MKS to CGS conversions
+// MKS to CGS conversions
+struct mks2cgs
+{
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_LENGTH(const amrex::Real L_mks)
+  amrex::Real Length(const amrex::Real L_mks)
   {
     return L_mks * 1.0e2; // m to cm
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_LENGTH_POW(const amrex::Real L_mks, amrex::Real n)
+  amrex::Real Length_Pow(const amrex::Real L_mks, const amrex::Real n)
   {
     return L_mks * std::pow(1.0e2, n); // m^n to cm^n
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_MASS(const amrex::Real M_mks)
+  amrex::Real Mass(const amrex::Real M_mks)
   {
     return M_mks * 1.0e3; // kg to g
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_MASS_POW(const amrex::Real M_mks, amrex::Real n)
+  amrex::Real Mass_Pow(const amrex::Real M_mks, const amrex::Real n)
   {
     return M_mks * std::pow(1.0e3, n); // kg^n to g^n
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_ENERGY(const amrex::Real E_mks)
+  amrex::Real Energy(const amrex::Real E_mks)
   {
     return E_mks * 1.0e7; // J to erg
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_RHO(const amrex::Real rho_mks)
+  amrex::Real Rho(const amrex::Real Rho_mks)
   {
-    return rho_mks * 1.0e-3; // kg/m^3 to g/cm^3
+    return Rho_mks * 1.0e-3; // kg/m^3 to g/cm^3
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_U(const amrex::Real u_mks)
+  amrex::Real U(const amrex::Real u_mks)
   {
     return u_mks * 1.0e2; // m/s to cm/s
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_RHOU(const amrex::Real rhou_mks)
+  amrex::Real RhoU(const amrex::Real Rhou_mks)
   {
-    return rhou_mks * 1.0e-1; // kg/m^2/s to g/cm^2/s
+    return Rhou_mks * 1.0e-1; // kg/m^2/s to g/cm^2/s
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_P(const amrex::Real p_mks)
+  amrex::Real P(const amrex::Real p_mks)
   {
     return p_mks * 1.0e1; // Pa to dyne/cm^2
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_H(const amrex::Real h_mks)
+  amrex::Real H(const amrex::Real h_mks)
   {
     return h_mks * 1.0e4; // J/kg to erg/g
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_RHOH(const amrex::Real rhoh_mks)
+  amrex::Real RhoH(const amrex::Real Rhoh_mks)
   {
-    return rhoh_mks * 1.0e1; // J/m^3 to erg/cm^3
+    return Rhoh_mks * 1.0e1; // J/m^3 to erg/cm^3
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_NU(const amrex::Real nu_mks)
+  amrex::Real Nu(const amrex::Real Nu_mks)
   {
-    return nu_mks * 1.0e4; // m^2/s to cm^2/s
+    return Nu_mks * 1.0e4; // m^2/s to cm^2/s
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_MU(const amrex::Real mu_mks)
+  amrex::Real Mu(const amrex::Real Mu_mks)
   {
-    return mu_mks * 1.0e1; // kg/m/s to g/cm/s
+    return Mu_mks * 1.0e1; // kg/m/s to g/cm/s
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_Cp(const amrex::Real cp_mks)
+  amrex::Real Cp(const amrex::Real cp_mks)
   {
     return cp_mks * 1.0e4; // J/kg/K to erg/g/K
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_Alpha(const amrex::Real a_mks)
+  amrex::Real Alpha(const amrex::Real a_mks)
   {
     return a_mks * 1.0e4; // m^2/s to cm^2/s
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real MKS2CGS_Lambda(const amrex::Real l_mks)
+  amrex::Real Lambda(const amrex::Real l_mks)
   {
     return l_mks * 1.0e5; // W/m/K to g/cm/s^3/K
   }

--- a/Source/Utility/Utilities/Utilities.H
+++ b/Source/Utility/Utilities/Utilities.H
@@ -4,8 +4,7 @@
 #include "UnitConversions.H"
 namespace pele::physics {
 namespace utilities {
-struct cgs2mks;
-struct mks2cgs;
+
 } // namespace utilities
 } // namespace pele::physics
 

--- a/Source/Utility/Utilities/Utilities.H
+++ b/Source/Utility/Utilities/Utilities.H
@@ -2,10 +2,9 @@
 #define UTILITIES_H
 
 #include "UnitConversions.H"
-namespace pele::physics
-{
-namespace utilities{
-  struct units;
+namespace pele::physics {
+namespace utilities {
+struct units;
 } // namespace utilities
 } // namespace pele::physics
 

--- a/Source/Utility/Utilities/Utilities.H
+++ b/Source/Utility/Utilities/Utilities.H
@@ -1,0 +1,12 @@
+#ifndef UTILITIES_H
+#define UTILITIES_H
+
+#include "UnitConversions.H"
+namespace pele::physics
+{
+namespace utilities{
+  struct units;
+} // namespace utilities
+} // namespace pele::physics
+
+#endif

--- a/Source/Utility/Utilities/Utilities.H
+++ b/Source/Utility/Utilities/Utilities.H
@@ -4,7 +4,8 @@
 #include "UnitConversions.H"
 namespace pele::physics {
 namespace utilities {
-struct units;
+struct cgs2mks;
+struct mks2cgs;
 } // namespace utilities
 } // namespace pele::physics
 

--- a/Source/Utility/Utilities/Utilities.cpp
+++ b/Source/Utility/Utilities/Utilities.cpp
@@ -1,1 +1,0 @@
-#include "Utilities.H"

--- a/Source/Utility/Utilities/Utilities.cpp
+++ b/Source/Utility/Utilities/Utilities.cpp
@@ -1,0 +1,1 @@
+#include "Utilities.H"

--- a/Testing/Exec/Make.PelePhysics
+++ b/Testing/Exec/Make.PelePhysics
@@ -130,6 +130,7 @@ include $(UTILITY_HOME)/PMF/Make.package
 include $(UTILITY_HOME)/PltFileManager/Make.package
 include $(UTILITY_HOME)/TurbInflow/Make.package
 include $(UTILITY_HOME)/BlackBoxFunction/Make.package
+include $(UTILITY_HOME)/Utilities/Make.package
 
 Pdirs   := Base Boundary AmrCore
 


### PR DESCRIPTION
This pull request introduces a new namespace called `utilities`, which contains a struct for unit conversion functions. This will primarily benefit users of PeleLMeX when calling EOS functions from PelePhysics, as the units in PeleLMeX are in MKS.  The `unit` functions are return type `amrex::Real` for ease of passing into the EOS functions from PeleLMeX.  

You can test it out on a local case in PeleLMeX  by adding the following to the `Make.PeleLMeX` file:
```
PPdirs += Source/Utility/Utilities
```
The functions are called similar to the eos functions.  For example:
```
auto eos = pele::physics::PhysicsType::eos();
auto units = pele::physics::utilities::units();
eos.PYT2R(units.MKS2CGS_P(p), massfrac, T, rho_cgs);
rho = units.CGS2MKS_RHO(rho_cgs);
```

I look forward to your feedback.