### PR TITLE
Tidied up nested namespace in Utilities for clang-tidy

### DIFF
--- a/Source/PelePhysics.H
+++ b/Source/PelePhysics.H
@@ -7,7 +7,6 @@
 #include "PelePhysicsConstraints.H"
 #include "EOS.H"
 #include "Transport.H"
-#include "Utilities.H"
 
 namespace pele::physics {
 

--- a/Source/Utility/Utilities/Utilities.H
+++ b/Source/Utility/Utilities/Utilities.H
@@ -2,10 +2,8 @@
 #define UTILITIES_H
 
 #include "UnitConversions.H"
-namespace pele::physics {
-namespace utilities {
+namespace pele::physics::utilities {
 
-} // namespace utilities
-} // namespace pele::physics
+} // namespace pele::physics::utilities
 
 #endif


### PR DESCRIPTION
The most recent commit failed to pass the clang-tidy test in PeleLMeX.  This PR should fix the problem.  Also, I removed Utilities.H from PelePhysics.H per @baperry2's request.  To include unit conversions in PeleLMeX or C we'll need to add Utilities.H to the associated PeleLMeX.H (or PeleC.H) headers as is done with the other utilities.  This works in my local PeleLMeX branch.