### PR TITLE
update cantera to 3.1 to get fix for occasional issue with qss conversion

### DIFF
--- a/Support/ceptr/pyproject.toml
+++ b/Support/ceptr/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Marc Henry de Frahan <marc.henrydefrahan@nrel.gov>", "Lucas Esclapez
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
-Cantera = ">=3.0.0"
+Cantera = ">=3.1.0"
 Pint = "^0.23"
 PyYAML = "^6.0.1"
 networkx = "^2.8.8"


### PR DESCRIPTION
The Cantera fix for yaml file handling that resolves #514 has been incorporated into Cantera release 3.1 so we can now close the issue by updating the Cantera version specification.