### PR TITLE
widen tolerance for grid checking in turb_box inflow generator

### DIFF
--- a/Support/TurbInflowGenerator/turb_box.cpp
+++ b/Support/TurbInflowGenerator/turb_box.cpp
@@ -73,11 +73,11 @@ readHIT(HITData* a_data)
   if (not std::is_sorted(xarray.begin(), xarray.end())) {
     amrex::Abort("Error: non ascending x-coordinate array.");
   }
-  if (std::abs(xarray[0] - 0.5 * xdiff[0]) > 1e-14 * xdiff[0]) {
+  if (std::abs(xarray[0] - 0.5 * xdiff[0]) > 1e-12 * xdiff[0]) {
     amrex::Abort("Error: domain must start at 0");
   }
   for (const amrex::Real& xd : xdiff) {
-    if (std::abs(xd - xdiff[0]) / xdiff[0] > 1e-14) {
+    if (std::abs(xd - xdiff[0]) / xdiff[0] > 1e-12) {
       amrex::Abort("Error: grid must be uniformly spaced");
     }
   }


### PR DESCRIPTION
Grids that are actually uniform are raising an error because the current tolerance `1-e14` can be a bit to tight for determining what constitutes equal with floating point precision in the relevant calculations. Therefore, widen the tolerance to `1e-12`