### PR TITLE
Allow 0 or negative turb conv vel in turbinflow

### DIFF
--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -72,7 +72,6 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
         tp[n].nplane > 3, "need at least 4 turb planes for 3 point "
                           "interpolation stencil + 1 extra");
       pp.query("turb_conv_vel", tp[n].turb_conv_vel);
-      AMREX_ALWAYS_ASSERT(tp[n].turb_conv_vel > 0);
 
       // Set other stuff
       std::string turb_header = tp[n].m_turb_file + "/HDR";


### PR DESCRIPTION
There's no need to enforce postive turbulent convective velocity. Users may want a frozen inflow condition or even to march through an inflow file in reverse.