### PR TITLE
Spray simplifications: Use PelePhysics unit conversions and EOS calls

### DIFF
--- a/Source/Spray/SprayFuelData.H
+++ b/Source/Spray/SprayFuelData.H
@@ -101,18 +101,6 @@ struct GasPhaseVals
       fluid_Y_dot[n] = 0.;
     }
   }
-
-  AMREX_GPU_DEVICE AMREX_FORCE_INLINE void define()
-  {
-    SprayUnits SPU;
-    mw_mix = 0.;
-    for (int n = 0; n < NUM_SPECIES; ++n) {
-      mw_mix += Y_fluid[n] / mw[n];
-    }
-    p_fluid =
-      rho_fluid * pele::physics::Constants::RU * mw_mix * T_fluid * SPU.ru_conv;
-    mw_mix = 1. / mw_mix;
-  }
 };
 
 // Structure containing values for the liquid sprays

--- a/Source/Spray/SprayFuelData.H
+++ b/Source/Spray/SprayFuelData.H
@@ -2,6 +2,7 @@
 #define SPRAYFUELDATA_H
 
 #include "PelePhysics.H"
+#include "UnitConversions.H"
 #include <AMReX_RealVect.H>
 
 // Spray flags and indices
@@ -38,32 +39,35 @@ enum splash_breakup {
   splash_wet_splash
 };
 
+using m2c = pele::physics::utilities::mks2cgs;
+
 // Units for sprays
 struct SprayUnits
 {
 #ifdef PELELM_USE_SPRAY
   // For converting CGS to MKS
-  amrex::Real ru_conv = 1.E-7;
-  amrex::Real eng_conv = 1.E-4;
-  amrex::Real rho_conv = 1.E3;
-  amrex::Real mass_conv = 1.E-3;
-  amrex::Real rhod_conv = 0.1; // rho D conversion
-  amrex::Real mu_conv = 0.1;
-  amrex::Real lambda_conv = 1.E-5;
-  amrex::Real pres_conv = 0.1;
-  amrex::Real len_conv = 0.01;
+  static constexpr amrex::Real ru_conv = m2c::Energy(1.0);
+  static constexpr amrex::Real eng_conv = m2c::H(1.0);
+  static constexpr amrex::Real rho_conv = m2c::Rho(1.0);
+  static constexpr amrex::Real mass_conv = m2c::Mass(1.0);
+  static constexpr amrex::Real rhod_conv =
+    m2c::Rho(1.0) * m2c::Alpha(1.0); // rho D conversion
+  static constexpr amrex::Real mu_conv = m2c::Mu(1.0);
+  static constexpr amrex::Real lambda_conv = m2c::Lambda(1.0);
+  static constexpr amrex::Real pres_conv = m2c::P(1.0);
+  static constexpr amrex::Real len_conv = m2c::Length(1.0);
 #else
-  amrex::Real ru_conv = 1.;
-  amrex::Real eng_conv = 1.;
-  amrex::Real rho_conv = 1.;
-  amrex::Real mass_conv = 1.;
-  amrex::Real rhod_conv = 1.;
-  amrex::Real mu_conv = 1.;
-  amrex::Real lambda_conv = 1.;
-  amrex::Real pres_conv = 1.;
-  amrex::Real len_conv = 1.;
+  static constexpr amrex::Real ru_conv = 1.;
+  static constexpr amrex::Real eng_conv = 1.;
+  static constexpr amrex::Real rho_conv = 1.;
+  static constexpr amrex::Real mass_conv = 1.;
+  static constexpr amrex::Real rhod_conv = 1.;
+  static constexpr amrex::Real mu_conv = 1.;
+  static constexpr amrex::Real lambda_conv = 1.;
+  static constexpr amrex::Real pres_conv = 1.;
+  static constexpr amrex::Real len_conv = 1.;
 #endif
-  amrex::Real min_mass = 1.E-13 * mass_conv;
+  static constexpr amrex::Real min_mass = 1.E-13 * mass_conv;
 };
 
 // Structure that contains the interpolated gas phase state

--- a/Source/Spray/SprayFuelData.H
+++ b/Source/Spray/SprayFuelData.H
@@ -39,7 +39,7 @@ enum splash_breakup {
   splash_wet_splash
 };
 
-using m2c = pele::physics::utilities::mks2cgs;
+namespace m2c = pele::physics::utilities::mks2cgs;
 
 // Units for sprays
 struct SprayUnits

--- a/Source/Spray/SprayFuelData.H
+++ b/Source/Spray/SprayFuelData.H
@@ -39,23 +39,23 @@ enum splash_breakup {
   splash_wet_splash
 };
 
-namespace m2c = pele::physics::utilities::mks2cgs;
+namespace c2m = pele::physics::utilities::cgs2mks;
 
 // Units for sprays
 struct SprayUnits
 {
 #ifdef PELELM_USE_SPRAY
   // For converting CGS to MKS
-  static constexpr amrex::Real ru_conv = m2c::Energy(1.0);
-  static constexpr amrex::Real eng_conv = m2c::H(1.0);
-  static constexpr amrex::Real rho_conv = m2c::Rho(1.0);
-  static constexpr amrex::Real mass_conv = m2c::Mass(1.0);
+  static constexpr amrex::Real ru_conv = c2m::Energy(1.0);
+  static constexpr amrex::Real eng_conv = c2m::H(1.0);
+  static constexpr amrex::Real rho_conv = c2m::Rho(1.0);
+  static constexpr amrex::Real mass_conv = c2m::Mass(1.0);
   static constexpr amrex::Real rhod_conv =
-    m2c::Rho(1.0) * m2c::Alpha(1.0); // rho D conversion
-  static constexpr amrex::Real mu_conv = m2c::Mu(1.0);
-  static constexpr amrex::Real lambda_conv = m2c::Lambda(1.0);
-  static constexpr amrex::Real pres_conv = m2c::P(1.0);
-  static constexpr amrex::Real len_conv = m2c::Length(1.0);
+    c2m::Rho(1.0) * c2m::Alpha(1.0); // rho D conversion
+  static constexpr amrex::Real mu_conv = c2m::Mu(1.0);
+  static constexpr amrex::Real lambda_conv = c2m::Lambda(1.0);
+  static constexpr amrex::Real pres_conv = c2m::P(1.0);
+  static constexpr amrex::Real len_conv = c2m::Length(1.0);
 #else
   static constexpr amrex::Real ru_conv = 1.;
   static constexpr amrex::Real eng_conv = 1.;

--- a/Source/Spray/SprayInterpolation.H
+++ b/Source/Spray/SprayInterpolation.H
@@ -108,9 +108,8 @@ InterpolateGasPhase(
   const amrex::IntVect* indx_array,
   const amrex::Real* weights)
 {
-#ifndef PELELM_USE_SPRAY
   auto eos = pele::physics::PhysicsType::eos();
-#else
+#ifdef PELELM_USE_SPRAY
   amrex::ignore_unused(engarr);
 #endif
   amrex::GpuArray<amrex::Real, NUM_SPECIES> mass_frac;
@@ -151,6 +150,13 @@ InterpolateGasPhase(
       gpv.T_fluid += cw * T_i;
     }
   }
+
+  // Fill in some other data with EOS calls
+  eos.Y2WBAR(gpv.Y_fluid.data(), gpv.mw_mix);
+  eos.RTY2P(
+    SprayUnits::rho_conv * gpv.rho_fluid, gpv.T_fluid, gpv.Y_fluid.data(),
+    gpv.p_fluid);
+  gpv.p_fluid *= SprayUnits::pres_conv;
 }
 
 // Slightly modified from MFIX code

--- a/Source/Spray/SprayInterpolation.H
+++ b/Source/Spray/SprayInterpolation.H
@@ -153,8 +153,10 @@ InterpolateGasPhase(
 
   // Fill in some other data with EOS calls
   eos.Y2WBAR(gpv.Y_fluid.data(), gpv.mw_mix);
+  gpv.mw_mix *= SprayUnits::mass_conv;
+
   eos.RTY2P(
-    SprayUnits::rho_conv * gpv.rho_fluid, gpv.T_fluid, gpv.Y_fluid.data(),
+    gpv.rho_fluid / SprayUnits::rho_conv, gpv.T_fluid, gpv.Y_fluid.data(),
     gpv.p_fluid);
   gpv.p_fluid *= SprayUnits::pres_conv;
 }

--- a/Source/Spray/SprayParticles.cpp
+++ b/Source/Spray/SprayParticles.cpp
@@ -387,7 +387,6 @@ SprayParticleContainer::updateParticles(
               gpv, state_box, rhoarr, rhoYarr, Tarr, momarr, engarr,
               indx_array.data(), weights.data());
             // Solve for avg mw and pressure at droplet location
-            gpv.define();
             fdat->calcBoilT(gpv, cBoilT.data());
             if (is_film) {
               calculateFilmSource(

--- a/Source/Utility/Utilities/UnitConversions.H
+++ b/Source/Utility/Utilities/UnitConversions.H
@@ -10,7 +10,7 @@ namespace cgs2mks {
 // CGS to MKS conversions
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Length(const amrex::Real L_cgs)
 {
   return L_cgs * 1.0e-2; // cm to m
@@ -26,7 +26,7 @@ Length(const amrex::Real L_cgs, const amrex::Real n)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Mass(const amrex::Real M_cgs)
 {
   return M_cgs * 1.0e-3; // g to kg
@@ -42,7 +42,7 @@ Mass(const amrex::Real M_cgs, const amrex::Real n)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Energy(const amrex::Real E_cgs)
 {
   return E_cgs * 1.0e-7; // erg to J
@@ -50,7 +50,7 @@ Energy(const amrex::Real E_cgs)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Rho(const amrex::Real rho_cgs)
 {
   return rho_cgs * 1.0e3; // g/cm^3 to kg/m^3
@@ -58,7 +58,7 @@ Rho(const amrex::Real rho_cgs)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 U(const amrex::Real u_cgs)
 {
   return u_cgs * 1.0e-2; // cm/s to m/s
@@ -66,7 +66,7 @@ U(const amrex::Real u_cgs)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 RhoU(const amrex::Real rhou_cgs)
 {
   return rhou_cgs * 1.0e1; // g/cm^2/s to kg/m^2/s
@@ -74,7 +74,7 @@ RhoU(const amrex::Real rhou_cgs)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 P(const amrex::Real p_cgs)
 {
   return p_cgs * 1.0e-1; // dyne/cm^2 to Pa
@@ -82,7 +82,7 @@ P(const amrex::Real p_cgs)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 H(const amrex::Real h_cgs)
 {
   return h_cgs * 1.0e-4; // erg/g to J/kg
@@ -90,7 +90,7 @@ H(const amrex::Real h_cgs)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 RhoH(const amrex::Real rhoh_cgs)
 {
   return rhoh_cgs * 1.0e1; // erg/cm^3 to J/m^3
@@ -98,7 +98,7 @@ RhoH(const amrex::Real rhoh_cgs)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Nu(const amrex::Real nu_cgs)
 {
   return nu_cgs * 1.0e-4; // cm^2/s to m^2/s
@@ -106,7 +106,7 @@ Nu(const amrex::Real nu_cgs)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Mu(const amrex::Real mu_cgs)
 {
   return mu_cgs * 1.0e-1; // g/cm/s to kg/m/s
@@ -114,7 +114,7 @@ Mu(const amrex::Real mu_cgs)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Cp(const amrex::Real cp_cgs)
 {
   return cp_cgs * 1.0e-4; // erg/g/K to J/kg/K
@@ -122,7 +122,7 @@ Cp(const amrex::Real cp_cgs)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Alpha(const amrex::Real a_cgs)
 {
   return a_cgs * 1.0e-4; // cm^2/s to m^2/s
@@ -130,7 +130,7 @@ Alpha(const amrex::Real a_cgs)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Lambda(const amrex::Real l_cgs)
 {
   return l_cgs * 1.0e-5; // g/cm/s^3/K to W/m/K
@@ -141,7 +141,7 @@ namespace mks2cgs {
 // MKS to CGS conversions
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Length(const amrex::Real L_mks)
 {
   return L_mks * 1.0e2; // m to cm
@@ -157,7 +157,7 @@ Length(const amrex::Real L_mks, const amrex::Real n)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Mass(const amrex::Real M_mks)
 {
   return M_mks * 1.0e3; // kg to g
@@ -173,7 +173,7 @@ Mass(const amrex::Real M_mks, const amrex::Real n)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Energy(const amrex::Real E_mks)
 {
   return E_mks * 1.0e7; // J to erg
@@ -181,7 +181,7 @@ Energy(const amrex::Real E_mks)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Rho(const amrex::Real Rho_mks)
 {
   return Rho_mks * 1.0e-3; // kg/m^3 to g/cm^3
@@ -189,7 +189,7 @@ Rho(const amrex::Real Rho_mks)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 U(const amrex::Real u_mks)
 {
   return u_mks * 1.0e2; // m/s to cm/s
@@ -197,7 +197,7 @@ U(const amrex::Real u_mks)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 RhoU(const amrex::Real Rhou_mks)
 {
   return Rhou_mks * 1.0e-1; // kg/m^2/s to g/cm^2/s
@@ -205,7 +205,7 @@ RhoU(const amrex::Real Rhou_mks)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 P(const amrex::Real p_mks)
 {
   return p_mks * 1.0e1; // Pa to dyne/cm^2
@@ -213,7 +213,7 @@ P(const amrex::Real p_mks)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 H(const amrex::Real h_mks)
 {
   return h_mks * 1.0e4; // J/kg to erg/g
@@ -221,7 +221,7 @@ H(const amrex::Real h_mks)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 RhoH(const amrex::Real Rhoh_mks)
 {
   return Rhoh_mks * 1.0e1; // J/m^3 to erg/cm^3
@@ -229,7 +229,7 @@ RhoH(const amrex::Real Rhoh_mks)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Nu(const amrex::Real Nu_mks)
 {
   return Nu_mks * 1.0e4; // m^2/s to cm^2/s
@@ -237,7 +237,7 @@ Nu(const amrex::Real Nu_mks)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Mu(const amrex::Real Mu_mks)
 {
   return Mu_mks * 1.0e1; // kg/m/s to g/cm/s
@@ -245,7 +245,7 @@ Mu(const amrex::Real Mu_mks)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Cp(const amrex::Real cp_mks)
 {
   return cp_mks * 1.0e4; // J/kg/K to erg/g/K
@@ -253,7 +253,7 @@ Cp(const amrex::Real cp_mks)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Alpha(const amrex::Real a_mks)
 {
   return a_mks * 1.0e4; // m^2/s to cm^2/s
@@ -261,7 +261,7 @@ Alpha(const amrex::Real a_mks)
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
-amrex::Real
+constexpr amrex::Real
 Lambda(const amrex::Real l_mks)
 {
   return l_mks * 1.0e5; // W/m/K to g/cm/s^3/K


### PR DESCRIPTION
The `define` function of the GasPhaseVals struct manually computes mw_mix and pressure. We can use EOS calls for that instead. 

To do that, some unit conversions are necessary, which motivates improvements to the unit conversions stuff in Spray. Instead of redefining unit conversions we can use the m2c stuff in PelePhysics utilities. We can also make all of this `static` and `constexpr` so it can be used without instantiating the SprayUnits struct.

In order to do that, we need to make everything possible constexpr in the m2c and c2m stuff.

