### PR TITLE
Turbulent Forcings - Bug fix for high aspect ratio domains.

### DIFF
--- a/Source/Utility/TurbForcing/TurbForcing.cpp
+++ b/Source/Utility/TurbForcing/TurbForcing.cpp
@@ -477,9 +477,8 @@ TurbForcing::addTurbVelForces(
   AMREX_ALWAYS_ASSERT(m_turbforcing_initialized);
 
   if (a_incompressible != 0 && a_rho_incompressible <= 0.0) {
-    amrex::Abort(
-      "rho_incompressible must be greater than 0 when "
-      "incompressible\n");
+    amrex::Abort("rho_incompressible must be greater than 0 when "
+                 "incompressible\n");
   }
 
   constexpr amrex::Real Pi = 3.14159265358979323846264338327950288;
@@ -488,9 +487,19 @@ TurbForcing::addTurbVelForces(
   const amrex::Real* problo = geomdata.ProbLo();
   const amrex::Real* probhi = geomdata.ProbHi();
 
-  const amrex::Real Lx = probhi[0] - problo[0];
-  const amrex::Real Ly = probhi[1] - problo[1];
-  const amrex::Real Lz = probhi[2] - problo[2];
+  amrex::Real Lx = probhi[0] - problo[0];
+  amrex::Real Ly = probhi[1] - problo[1];
+  amrex::Real Lz = probhi[2] - problo[2];
+
+  // breaks sysmetry in high aspect ratio domains
+  // can be passed by the user as a flag or value
+  if (m_tfp.m_hack_lz > 0) {
+    if (m_tfp.m_hack_lz == 1) {
+      Lz = Lz / 2.0;
+    } else {
+      Lz = Lz / m_tfp.m_hack_lz;
+    }
+  }
 
   const int* f_lo = bx.loVect();
   const int* f_hi = bx.hiVect();

--- a/Source/Utility/TurbForcing/TurbForcing.cpp
+++ b/Source/Utility/TurbForcing/TurbForcing.cpp
@@ -477,8 +477,9 @@ TurbForcing::addTurbVelForces(
   AMREX_ALWAYS_ASSERT(m_turbforcing_initialized);
 
   if (a_incompressible != 0 && a_rho_incompressible <= 0.0) {
-    amrex::Abort("rho_incompressible must be greater than 0 when "
-                 "incompressible\n");
+    amrex::Abort(
+      "rho_incompressible must be greater than 0 when "
+      "incompressible\n");
   }
 
   constexpr amrex::Real Pi = 3.14159265358979323846264338327950288;


### PR DESCRIPTION
The implementation for breaking symmetry in high aspect ratio domains was not implemented in the addTurbVelForces despite being setup correctly. This PR just adds a small change to get it working.