### PR TITLE
Add downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,9 +1,6 @@
 name: Downstream CI (PeleLMeX clang-tidy)
 
 on:
-  workflow_dispatch:
-  push:
-    branches: [development]
   pull_request:
     branches: [development]
 

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -62,10 +62,8 @@ jobs:
           echo "CCACHE_MAXSIZE=100M" >> $GITHUB_ENV
           echo "CTCACHE_DIR=~/.cache/ctcache" >> $GITHUB_ENV
 
-      - name: Install ccache & clang-tidy cache wrapper
+      - name: Install Ccache
         run: |
-          sudo apt-get update
-          sudo apt-get install -y xz-utils curl clang clang++ cmake
           wget https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-linux-x86_64.tar.xz
           sudo curl https://raw.githubusercontent.com/matus-chochlik/ctcache/7fd516e91c17779cbc6fc18bd119313d9532dd90/clang-tidy-cache -Lo /usr/bin/clang-tidy-cache
           tar xvf ccache-4.8-linux-x86_64.tar.xz
@@ -73,7 +71,7 @@ jobs:
           sudo chmod +x /usr/bin/clang-tidy-cache
           mkdir -p ~/.cache/ctcache
 
-      - name: Cache (ccache & ctcache)
+      - name: Set Up Ccache
         uses: actions/cache@v4
         with:
           path: ~/.cache
@@ -96,7 +94,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
             ${{ github.workspace }}/PeleLMeX
 
-      - name: Check (build to run clang-tidy)
+      - name: Check
         working-directory: ${{ env.BUILD_DIR }}
         run: |
           cmake --build . --parallel ${{ env.NPROCS }} 2>&1 | tee -a clang-tidy-full-report.txt
@@ -107,18 +105,18 @@ jobs:
 
       - name: Ccache Report
         run: |
-          ls ~/.cache || true
-          ls ~/.cache/ccache || true
-          du -hs ~/.cache/ccache || true
-          ls ~/.cache/ctcache || true
-          du -hs ~/.cache/ctcache || true
-          ccache -s || true
+          ls ~/.cache
+          ls ~/.cache/ccache
+          du -hs ~/.cache/ccache
+          ls ~/.cache/ctcache
+          du -hs ~/.cache/ctcache
+          ccache -s
 
       - name: Full report
         working-directory: ${{ env.BUILD_DIR }}
         run: cat clang-tidy-full-report.txt
 
-      - name: Short report (fail on warnings)
+      - name: Short report 
         working-directory: ${{ env.BUILD_DIR }}
         run: |
           echo "::add-matcher::${{ github.workspace }}/PeleLMeX/.github/problem-matchers/gcc.json"

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Configure
         working-directory: PeleLMeX
         run: |
-          cmake -B"${BUILD_DIR}" \
+          cmake -B"${{ github.workspace }}/build-clang-tidy-lmex" \
           -DCMAKE_BUILD_TYPE:STRING=Release \
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
           -DCMAKE_CXX_COMPILER:STRING=clang++ \
@@ -271,7 +271,7 @@ jobs:
       - name: Configure
         working-directory: PeleC
         run: |
-          cmake -B"${BUILD_DIR}" \
+          cmake -B"${{ github.workspace }}/build-clang-tidy-c" \
           -DCMAKE_BUILD_TYPE:STRING=Release \
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
           -DCMAKE_CXX_COMPILER:STRING=clang++ \

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,12 +1,11 @@
 name: Downstream-CI
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - '**'
-  pull_request:
-    branches: [development]
+   workflow_dispatch:
+   push:
+     branches: [development]
+   pull_request:
+     branches: [development]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -6,6 +6,11 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}-downstream
+  cancel-in-progress: true
+
+
 jobs:
   PeleLMeX-clang-tidy:
     name: PeleLMeX clang-tidy

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -229,3 +229,50 @@ jobs:
           cat clang-tidy-warnings.txt
           export return=$(tail -n 1 clang-tidy-warnings.txt | awk '{print $2}')
           exit ${return}
+
+  PeleLMeX FlameSheet:
+    name: GNU@9.3 MPI Run [PeleLMeX-FS]
+    runs-on: ubuntu-latest
+    env:
+      {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    
+    steps:
+      - name: Checkout PelePhysics
+        uses: actions/checkout@v4
+        with:
+          path: pelephysics-pr
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Clone PeleLMeX
+        run: |
+          git clone --recursive --shallow-submodules --single-branch \
+            https://github.com/AMReX-Combustion/PeleLMeX.git
+
+      - name: Point PeleLMeX/Submodules/PelePhysics to this PR
+        working-directory: PeleLMeX
+        shell: bash
+        run: |
+          cd Submodules/PelePhysics
+          git fetch "$GITHUB_WORKSPACE/pelephysics-pr"
+          git checkout $(git -C "$GITHUB_WORKSPACE/pelephysics-pr" rev-parse HEAD)
+
+          echo "PelePhysics Submodule now points to:"
+          git rev-parse --short HEAD
+      
+      - name: System Dependencies
+        working-directory: PeleLMeX
+        run: .github/workflows/dependencies/dependencies_gcc10.sh
+      - name: Repo Dependencies
+        working-directory: PeleLMeX
+        run: Utils/CloneDeps.sh
+      - name: Build
+        working-directory: PeleLMeX/Exec/RegTests/FlameSheet/
+        run: |
+          make TPL COMP=gnu USE_MPI=TRUE
+          make -j 2 DIM=3 COMP=gnu USE_MPI=TRUE
+      - name: Run
+        working-directory: PeleLMeX/Exec/RegTests/FlameSheet/
+        run: |
+          mpirun -n 2 ./PeleLMeX3d.gnu.MPI.ex input.3d-regt amr.max_step=2 amr.plot_int=-1 amr.check_int=-1 amrex.abort_on_unused_inputs=1 amr.n_cell=32 32 64
+

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -230,7 +230,7 @@ jobs:
           export return=$(tail -n 1 clang-tidy-warnings.txt | awk '{print $2}')
           exit ${return}
 
-  PeleLMeX FlameSheet:
+  PeleLMeX-FlameSheet:
     name: GNU@9.3 MPI Run [PeleLMeX-FS]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -47,16 +47,12 @@ jobs:
         working-directory: PeleLMeX
         shell: bash
         run: |
-          # Allow use of file:// remotes for submodules
-          git config --global protocol.file.allow always
+          cd Submodules/PelePhysics
+          git fetch "$GITHUB_WORKSPACE/pelephysics-pr"
+          git checkout $(git -C "$GITHUB_WORKSPACE/pelephysics-pr" rev-parse HEAD)
 
-          # Point the submodule to the checked-out PR
-          git config -f .gitmodules submodule.Submodules/PelePhysics.url "file://$GITHUB_WORKSPACE/pelephysics-pr"
-          git submodule sync -- Submodules/PelePhysics
-          git submodule update --init --depth 1 -- Submodules/PelePhysics
-
-          echo "Submodule now points to:"
-          git -C Submodules/PelePhysics rev-parse --short HEAD
+          echo "PelePhysics Submodule now points to:"
+          git rev-parse --short HEAD
 
       - name: Setup
         run: |
@@ -143,6 +139,7 @@ jobs:
         with:
           path: pelephysics-pr
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Clone PeleC
         run: |
@@ -153,16 +150,12 @@ jobs:
         working-directory: PeleC
         shell: bash
         run: |
-          # Allow use of file:// remotes for submodules
-          git config --global protocol.file.allow always
+          cd Submodules/PelePhysics
+          git fetch "$GITHUB_WORKSPACE/pelephysics-pr"
+          git checkout $(git -C "$GITHUB_WORKSPACE/pelephysics-pr" rev-parse HEAD)
 
-          # Point the submodule to the checked-out PR
-          git config -f .gitmodules submodule.Submodules/PelePhysics.url "file://$GITHUB_WORKSPACE/pelephysics-pr"
-          git submodule sync -- Submodules/PelePhysics
-          git submodule update --init --depth 1 -- Submodules/PelePhysics
-
-          echo "Submodule now points to:"
-          git -C Submodules/PelePhysics rev-parse --short HEAD
+          echo "PelePhysics Submodule now points to:"
+          git rev-parse --short HEAD
 
       - name: Setup
         run: |

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -2,7 +2,10 @@ name: Downstream CI (PeleLMeX clang-tidy)
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  push:
+    branches: 
+      - '**'
+  pull_request:
     branches: [development]
 
 jobs:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -124,3 +124,109 @@ jobs:
           export return=$(tail -n 1 clang-tidy-warnings.txt | awk '{print $2}')
           exit ${return}
 
+  PeleC-clang-tidy:
+    name: PeleC clang-tidy
+    runs-on: ubuntu-24.04
+
+    env:
+      BUILD_DIR: ${{ github.workspace }}/build-clang-tidy-c
+
+    steps:
+      - name: Checkout PelePhysics
+        uses: actions/checkout@v4
+        with:
+          path: pelephysics-pr
+          fetch-depth: 0
+
+      - name: Clone PeleC
+        run: |
+          git clone --recursive --shallow-submodules --single-branch \
+            https://github.com/AMReX-Combustion/PeleC
+
+      - name: Point PeleC/Submodules/PelePhysics to this PR
+        working-directory: PeleC
+        shell: bash
+        run: |
+          # Allow use of file:// remotes for submodules
+          git config --global protocol.file.allow always
+
+          # Point the submodule to the checked-out PR
+          git config -f .gitmodules submodule.Submodules/PelePhysics.url "file://$GITHUB_WORKSPACE/pelephysics-pr"
+          git submodule sync -- Submodules/PelePhysics
+          git submodule update --init --depth 1 -- Submodules/PelePhysics
+
+          echo "Submodule now points to:"
+          git -C Submodules/PelePhysics rev-parse --short HEAD
+
+      - name: Setup
+        run: |
+          echo "NPROCS=$(nproc)" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESS=1" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESSLEVEL=10" >> $GITHUB_ENV
+          echo "CCACHE_LOGFILE=${{github.workspace}}/ccache.log.txt" >> $GITHUB_ENV
+          echo "CCACHE_EXTRAFILES=${{github.workspace}}/PeleC/.clang-tidy" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=100M" >> $GITHUB_ENV
+          echo "CTCACHE_DIR=~/.cache/ctcache" >> $GITHUB_ENV
+
+      - name: Install Ccache
+        run: |
+          wget https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-linux-x86_64.tar.xz
+          sudo curl https://raw.githubusercontent.com/matus-chochlik/ctcache/7fd516e91c17779cbc6fc18bd119313d9532dd90/clang-tidy-cache -Lo /usr/bin/clang-tidy-cache
+          tar xvf ccache-4.8-linux-x86_64.tar.xz
+          sudo cp -f ccache-4.8-linux-x86_64/ccache /usr/local/bin/
+          sudo chmod +x /usr/bin/clang-tidy-cache
+          mkdir -p ~/.cache/ctcache
+
+      - name: Set Up Ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache
+          key: ccache-${{github.workflow}}-${{github.job}}-git-${{github.sha}}
+          restore-keys: |
+               ccache-${{github.workflow}}-${{github.job}}-git-
+
+      - name: Configure
+        working-directory: PeleC
+        run: |
+          cmake -B"${BUILD_DIR}" \
+          -DCMAKE_BUILD_TYPE:STRING=Release \
+          -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+          -DCMAKE_CXX_COMPILER:STRING=clang++ \
+          -DCMAKE_C_COMPILER:STRING=clang \
+          -DPELE_ENABLE_MPI:BOOL=OFF \
+          -DPELE_ENABLE_FCOMPARE_FOR_TESTS:BOOL=OFF \
+          -DPELE_ENABLE_MASA:BOOL=OFF \
+          -DPELE_ENABLE_CLANG_TIDY:BOOL=ON \
+          -DPELE_EXCLUDE_BUILD_IN_CI:BOOL=ON \
+          -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
+          ${{github.workspace}}/PeleC
+
+      - name: Check
+        working-directory: ${{ env.BUILD_DIR }}
+        run: |
+          cmake --build . --parallel ${{ env.NPROCS }} 2>&1 | tee -a clang-tidy-full-report.txt
+          egrep "Warning:|Error:|warning:|error:" clang-tidy-full-report.txt \
+            | egrep -v "Submodules/amrex|Submodules/sundials|Submodules/AMReX-Hydro" \
+            | egrep -v "ld: warning:" | sort | uniq \
+            | awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > clang-tidy-warnings.txt
+
+      - name: Ccache Report
+        run: |
+          ls ~/.cache
+          ls ~/.cache/ccache
+          du -hs ~/.cache/ccache
+          ls ~/.cache/ctcache
+          du -hs ~/.cache/ctcache
+          ccache -s
+
+      - name: Full report
+        working-directory: ${{ env.BUILD_DIR }}
+        run: cat clang-tidy-full-report.txt
+
+      - name: Short report 
+        working-directory: ${{ env.BUILD_DIR }}
+        run: |
+          echo "::add-matcher::${{ github.workspace }}/PeleC/.github/problem-matchers/gcc.json"
+          cat clang-tidy-warnings.txt
+          export return=$(tail -n 1 clang-tidy-warnings.txt | awk '{print $2}')
+          exit ${return}

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,9 +1,9 @@
-name: Downstream CI (PeleLMeX clang-tidy)
+name: Downstream-CI
 
 on:
   workflow_dispatch:
   push:
-    branches: 
+    branches:
       - '**'
   pull_request:
     branches: [development]
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
 
     env:
-      BUILD_DIR: ${{ runner.workspace }}/build-clang-tidy
+      BUILD_DIR: ${{ github.workspace }}/build-clang-tidy
 
     steps:
       - name: Checkout PelePhysics
@@ -42,6 +42,7 @@ jobs:
         shell: bash
         run: |
           PR_ABS="$(cd "${GITHUB_WORKSPACE}/pelephysics-pr" && pwd)"
+          git config --global protocol.file.allow always    # allow file:// remote
           git config -f .gitmodules submodule.Submodules/PelePhysics.url "file://${PR_ABS}"
           git submodule sync -- Submodules/PelePhysics
           # Re-init that single submodule from the PR checkout
@@ -57,7 +58,6 @@ jobs:
           echo "CCACHE_COMPRESS=1" >> $GITHUB_ENV
           echo "CCACHE_COMPRESSLEVEL=10" >> $GITHUB_ENV
           echo "CCACHE_LOGFILE=${{github.workspace}}/ccache.log.txt" >> $GITHUB_ENV
-          # Point to PeleLMeX's .clang-tidy (workspace here is PelePhysics)
           echo "CCACHE_EXTRAFILES=${{github.workspace}}/PeleLMeX/.clang-tidy" >> $GITHUB_ENV
           echo "CCACHE_MAXSIZE=100M" >> $GITHUB_ENV
           echo "CTCACHE_DIR=~/.cache/ctcache" >> $GITHUB_ENV
@@ -121,7 +121,6 @@ jobs:
       - name: Short report (fail on warnings)
         working-directory: ${{ env.BUILD_DIR }}
         run: |
-          # Use absolute matcher path since we're not at repo root
           echo "::add-matcher::${{ github.workspace }}/PeleLMeX/.github/problem-matchers/gcc.json"
           cat clang-tidy-warnings.txt
           export return=$(tail -n 1 clang-tidy-warnings.txt | awk '{print $2}')

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -14,8 +14,53 @@ concurrency:
 
 
 jobs:
+  PeleLMeX-FlameSheet:
+    name: PeleLMeX GNU@9.3 MPI Run [FlameSheet]
+    runs-on: ubuntu-latest
+    env:
+      {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    
+    steps:
+      - name: Checkout PelePhysics
+        uses: actions/checkout@v4
+        with:
+          path: pelephysics-pr
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Clone PeleLMeX
+        run: |
+          git clone --recursive --shallow-submodules --single-branch \
+            https://github.com/AMReX-Combustion/PeleLMeX.git
+
+      - name: Point PeleLMeX/Submodules/PelePhysics to this PR
+        working-directory: PeleLMeX
+        shell: bash
+        run: |
+          cd Submodules/PelePhysics
+          git fetch "$GITHUB_WORKSPACE/pelephysics-pr"
+          git checkout $(git -C "$GITHUB_WORKSPACE/pelephysics-pr" rev-parse HEAD)
+
+          echo "PelePhysics Submodule now points to:"
+          git rev-parse --short HEAD
+      
+      - name: System Dependencies
+        working-directory: PeleLMeX
+        run: .github/workflows/dependencies/dependencies_gcc10.sh
+      
+      - name: Build
+        working-directory: PeleLMeX/Exec/RegTests/FlameSheet/
+        run: |
+          make TPL COMP=gnu USE_MPI=TRUE
+          make -j 2 DIM=2 COMP=gnu USE_MPI=TRUE
+      - name: Run
+        working-directory: PeleLMeX/Exec/RegTests/FlameSheet/
+        run: |
+          mpirun -n 2 ./PeleLMeX2d.gnu.MPI.ex input.2d-regt amr.max_step=2 amr.plot_int=-1 amr.check_int=-1 amrex.abort_on_unused_inputs=1 amr.n_cell=32 64
+
   PeleLMeX-clang-tidy:
     name: PeleLMeX clang-tidy
+    needs: PeleLMeX-FlameSheet
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -229,50 +274,4 @@ jobs:
           cat clang-tidy-warnings.txt
           export return=$(tail -n 1 clang-tidy-warnings.txt | awk '{print $2}')
           exit ${return}
-
-  PeleLMeX-FlameSheet:
-    name: GNU@9.3 MPI Run [PeleLMeX-FS]
-    runs-on: ubuntu-latest
-    env:
-      {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
-    
-    steps:
-      - name: Checkout PelePhysics
-        uses: actions/checkout@v4
-        with:
-          path: pelephysics-pr
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Clone PeleLMeX
-        run: |
-          git clone --recursive --shallow-submodules --single-branch \
-            https://github.com/AMReX-Combustion/PeleLMeX.git
-
-      - name: Point PeleLMeX/Submodules/PelePhysics to this PR
-        working-directory: PeleLMeX
-        shell: bash
-        run: |
-          cd Submodules/PelePhysics
-          git fetch "$GITHUB_WORKSPACE/pelephysics-pr"
-          git checkout $(git -C "$GITHUB_WORKSPACE/pelephysics-pr" rev-parse HEAD)
-
-          echo "PelePhysics Submodule now points to:"
-          git rev-parse --short HEAD
-      
-      - name: System Dependencies
-        working-directory: PeleLMeX
-        run: .github/workflows/dependencies/dependencies_gcc10.sh
-      - name: Repo Dependencies
-        working-directory: PeleLMeX
-        run: Utils/CloneDeps.sh
-      - name: Build
-        working-directory: PeleLMeX/Exec/RegTests/FlameSheet/
-        run: |
-          make TPL COMP=gnu USE_MPI=TRUE
-          make -j 2 DIM=3 COMP=gnu USE_MPI=TRUE
-      - name: Run
-        working-directory: PeleLMeX/Exec/RegTests/FlameSheet/
-        run: |
-          mpirun -n 2 ./PeleLMeX3d.gnu.MPI.ex input.3d-regt amr.max_step=2 amr.plot_int=-1 amr.check_int=-1 amrex.abort_on_unused_inputs=1 amr.n_cell=32 32 64
 

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   PeleLMeX-FlameSheet:
-    name: PeleLMeX GNU@9.3 MPI Run [FlameSheet]
+    name: PeleLMeX GNU MPI Run [FlameSheet]
     runs-on: ubuntu-latest
     env:
       {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
@@ -58,7 +58,7 @@ jobs:
           mpirun -n 2 ./PeleLMeX2d.gnu.MPI.ex input.2d-regt amr.max_step=2 amr.plot_int=-1 amr.check_int=-1 amrex.abort_on_unused_inputs=1 amr.n_cell=32 64 
 
   PeleC-PMF:
-    name: PeleC GNU@9.3 MPI Run [PMF]
+    name: PeleC GNU MPI Run [PMF]
     runs-on: ubuntu-latest
     env:
       {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
@@ -97,7 +97,6 @@ jobs:
 
           sudo apt-get install -y --no-install-recommends \
               build-essential    \
-              gcc-10 \
               libopenmpi-dev     \
               openmpi-bin
       
@@ -116,10 +115,6 @@ jobs:
     name: PeleLMeX clang-tidy
     needs: [PeleLMeX-FlameSheet, PeleC-PMF]
     runs-on: ubuntu-24.04
-
-    env:
-      BUILD_DIR: ${{ github.workspace }}/build-clang-tidy-lmex
-      use_eb: "OFF"
 
     steps:
       - name: Checkout PelePhysics
@@ -180,7 +175,7 @@ jobs:
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
           -DCMAKE_CXX_COMPILER:STRING=clang++ \
           -DCMAKE_C_COMPILER:STRING=clang \
-          -DPELE_ENABLE_EB:BOOL=${{ env.use_eb }} \
+          -DPELE_ENABLE_EB:BOOL=OFF \
           -DPELE_ENABLE_MPI:BOOL=OFF \
           -DPELE_ENABLE_FCOMPARE_FOR_TESTS:BOOL=OFF \
           -DPELE_ENABLE_CLANG_TIDY:BOOL=ON \
@@ -188,7 +183,7 @@ jobs:
           ${{ github.workspace }}/PeleLMeX
 
       - name: Check
-        working-directory: ${{ env.BUILD_DIR }}
+        working-directory: ${{ github.workspace }}/build-clang-tidy-lmex
         run: |
           cmake --build . --parallel ${{ env.NPROCS }} 2>&1 | tee -a clang-tidy-full-report.txt
           egrep "Warning:|Error:|warning:|error:" clang-tidy-full-report.txt \
@@ -206,11 +201,11 @@ jobs:
           ccache -s
 
       - name: Full report
-        working-directory: ${{ env.BUILD_DIR }}
+        working-directory: ${{ github.workspace }}/build-clang-tidy-lmex
         run: cat clang-tidy-full-report.txt
 
       - name: Short report 
-        working-directory: ${{ env.BUILD_DIR }}
+        working-directory: ${{ github.workspace }}/build-clang-tidy-lmex
         run: |
           echo "::add-matcher::${{ github.workspace }}/PeleLMeX/.github/problem-matchers/gcc.json"
           cat clang-tidy-warnings.txt
@@ -221,9 +216,6 @@ jobs:
     name: PeleC clang-tidy
     needs: [PeleLMeX-FlameSheet, PeleC-PMF]
     runs-on: ubuntu-24.04
-
-    env:
-      BUILD_DIR: ${{ github.workspace }}/build-clang-tidy-c
 
     steps:
       - name: Checkout PelePhysics
@@ -293,7 +285,7 @@ jobs:
           ${{github.workspace}}/PeleC
 
       - name: Check
-        working-directory: ${{ env.BUILD_DIR }}
+        working-directory: ${{ github.workspace }}/build-clang-tidy-c
         run: |
           cmake --build . --parallel ${{ env.NPROCS }} 2>&1 | tee -a clang-tidy-full-report.txt
           egrep "Warning:|Error:|warning:|error:" clang-tidy-full-report.txt \
@@ -311,11 +303,11 @@ jobs:
           ccache -s
 
       - name: Full report
-        working-directory: ${{ env.BUILD_DIR }}
+        working-directory: ${{ github.workspace }}/build-clang-tidy-c
         run: cat clang-tidy-full-report.txt
 
       - name: Short report 
-        working-directory: ${{ env.BUILD_DIR }}
+        working-directory: ${{ github.workspace }}/build-clang-tidy-c
         run: |
           echo "::add-matcher::${{ github.workspace }}/PeleC/.github/problem-matchers/gcc.json"
           cat clang-tidy-warnings.txt

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,127 @@
+name: Downstream CI (PeleLMeX clang-tidy)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [development]
+  pull_request:
+    branches: [development]
+
+jobs:
+  PeleLMeX-clang-tidy:
+    name: PeleLMeX clang-tidy
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        enable_eb: [EB-OFF, EB-ON]
+        include:
+          - enable_eb: EB-OFF
+            use_eb: "OFF"
+          - enable_eb: EB-ON
+            use_eb: "ON"
+      fail-fast: false
+
+    env:
+      BUILD_DIR: ${{ runner.workspace }}/build-clang-tidy
+
+    steps:
+      - name: Checkout PelePhysics
+        uses: actions/checkout@v4
+        with:
+          path: pelephysics-pr
+          fetch-depth: 0
+
+      - name: Clone PeleLMeX
+        run: |
+          git clone --recursive --shallow-submodules --single-branch \
+            https://github.com/AMReX-Combustion/PeleLMeX.git
+
+      - name: Point PeleLMeX/Submodules/PelePhysics to this PR
+        working-directory: PeleLMeX
+        shell: bash
+        run: |
+          PR_ABS="$(cd "${GITHUB_WORKSPACE}/pelephysics-pr" && pwd)"
+          git config -f .gitmodules submodule.Submodules/PelePhysics.url "file://${PR_ABS}"
+          git submodule sync -- Submodules/PelePhysics
+          # Re-init that single submodule from the PR checkout
+          git submodule update --init --recursive --depth 1 -- Submodules/PelePhysics
+          # Init the rest (stays shallow)
+          git submodule update --init --recursive --depth 1
+          echo "PeleLMeX/Submodules/PelePhysics -> $(git -C Submodules/PelePhysics rev-parse --short HEAD)"
+          echo "PR checkout                    -> $(git -C "${PR_ABS}" rev-parse --short HEAD)"
+
+      - name: Setup
+        run: |
+          echo "NPROCS=$(nproc)" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESS=1" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESSLEVEL=10" >> $GITHUB_ENV
+          echo "CCACHE_LOGFILE=${{github.workspace}}/ccache.log.txt" >> $GITHUB_ENV
+          # Point to PeleLMeX's .clang-tidy (workspace here is PelePhysics)
+          echo "CCACHE_EXTRAFILES=${{github.workspace}}/PeleLMeX/.clang-tidy" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=100M" >> $GITHUB_ENV
+          echo "CTCACHE_DIR=~/.cache/ctcache" >> $GITHUB_ENV
+
+      - name: Install ccache & clang-tidy cache wrapper
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xz-utils curl clang clang++ cmake
+          wget https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-linux-x86_64.tar.xz
+          sudo curl https://raw.githubusercontent.com/matus-chochlik/ctcache/7fd516e91c17779cbc6fc18bd119313d9532dd90/clang-tidy-cache -Lo /usr/bin/clang-tidy-cache
+          tar xvf ccache-4.8-linux-x86_64.tar.xz
+          sudo cp -f ccache-4.8-linux-x86_64/ccache /usr/local/bin/
+          sudo chmod +x /usr/bin/clang-tidy-cache
+          mkdir -p ~/.cache/ctcache
+
+      - name: Cache (ccache & ctcache)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache
+          key: ccache-${{ github.workflow }}-${{ github.job }}-${{ matrix.enable_eb }}-git-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ github.workflow }}-${{ github.job }}-${{ matrix.enable_eb }}-git-
+
+      - name: Configure
+        working-directory: PeleLMeX
+        run: |
+          cmake -B"${BUILD_DIR}" \
+            -DCMAKE_BUILD_TYPE:STRING=Release \
+            -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+            -DCMAKE_CXX_COMPILER:STRING=clang++ \
+            -DCMAKE_C_COMPILER:STRING=clang \
+            -DPELE_ENABLE_EB:BOOL=${{ matrix.use_eb }} \
+            -DPELE_ENABLE_MPI:BOOL=OFF \
+            -DPELE_ENABLE_FCOMPARE_FOR_TESTS:BOOL=OFF \
+            -DPELE_ENABLE_CLANG_TIDY:BOOL=ON \
+            -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
+            ${{ github.workspace }}/PeleLMeX
+
+      - name: Check (build to run clang-tidy)
+        working-directory: ${{ env.BUILD_DIR }}
+        run: |
+          cmake --build . --parallel ${{ env.NPROCS }} 2>&1 | tee -a clang-tidy-full-report.txt
+          egrep "Warning:|Error:|warning:|error:" clang-tidy-full-report.txt \
+            | egrep -v "Submodules/amrex|Submodules/sundials|Submodules/AMReX-Hydro" \
+            | egrep -v "ld: warning:" | sort | uniq \
+            | awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > clang-tidy-warnings.txt
+
+      - name: Ccache Report
+        run: |
+          ls ~/.cache || true
+          ls ~/.cache/ccache || true
+          du -hs ~/.cache/ccache || true
+          ls ~/.cache/ctcache || true
+          du -hs ~/.cache/ctcache || true
+          ccache -s || true
+
+      - name: Full report
+        working-directory: ${{ env.BUILD_DIR }}
+        run: cat clang-tidy-full-report.txt
+
+      - name: Short report (fail on warnings)
+        working-directory: ${{ env.BUILD_DIR }}
+        run: |
+          # Use absolute matcher path since we're not at repo root
+          echo "::add-matcher::${{ github.workspace }}/PeleLMeX/.github/problem-matchers/gcc.json"
+          cat clang-tidy-warnings.txt
+          export return=$(tail -n 1 clang-tidy-warnings.txt | awk '{print $2}')
+          exit ${return}

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -12,7 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-
 jobs:
   PeleLMeX-FlameSheet:
     name: PeleLMeX GNU@9.3 MPI Run [FlameSheet]
@@ -331,4 +330,3 @@ jobs:
           cat clang-tidy-warnings.txt
           export return=$(tail -n 1 clang-tidy-warnings.txt | awk '{print $2}')
           exit ${return}
-

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           path: pelephysics-pr
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Clone PeleLMeX
         run: |

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,7 +1,8 @@
 name: Downstream CI (PeleLMeX clang-tidy)
 
 on:
-  pull_request:
+  workflow_dispatch:
+  pull_request_target:
     branches: [development]
 
 jobs:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
 
     env:
-      BUILD_DIR: ${{ github.workspace }}/build-clang-tidy
+      BUILD_DIR: ${{ github.workspace }}/build-clang-tidy-lmex
 
     steps:
       - name: Checkout PelePhysics
@@ -41,16 +41,16 @@ jobs:
         working-directory: PeleLMeX
         shell: bash
         run: |
-          PR_ABS="$(cd "${GITHUB_WORKSPACE}/pelephysics-pr" && pwd)"
-          git config --global protocol.file.allow always    # allow file:// remote
-          git config -f .gitmodules submodule.Submodules/PelePhysics.url "file://${PR_ABS}"
+          # Allow use of file:// remotes for submodules
+          git config --global protocol.file.allow always
+
+          # Point the submodule to the checked-out PR
+          git config -f .gitmodules submodule.Submodules/PelePhysics.url "file://$GITHUB_WORKSPACE/pelephysics-pr"
           git submodule sync -- Submodules/PelePhysics
-          # Re-init that single submodule from the PR checkout
-          git submodule update --init --recursive --depth 1 -- Submodules/PelePhysics
-          # Init the rest (stays shallow)
-          git submodule update --init --recursive --depth 1
-          echo "PeleLMeX/Submodules/PelePhysics -> $(git -C Submodules/PelePhysics rev-parse --short HEAD)"
-          echo "PR checkout                    -> $(git -C "${PR_ABS}" rev-parse --short HEAD)"
+          git submodule update --init --depth 1 -- Submodules/PelePhysics
+
+          echo "Submodule now points to:"
+          git -C Submodules/PelePhysics rev-parse --short HEAD
 
       - name: Setup
         run: |
@@ -83,16 +83,16 @@ jobs:
         working-directory: PeleLMeX
         run: |
           cmake -B"${BUILD_DIR}" \
-            -DCMAKE_BUILD_TYPE:STRING=Release \
-            -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-            -DCMAKE_CXX_COMPILER:STRING=clang++ \
-            -DCMAKE_C_COMPILER:STRING=clang \
-            -DPELE_ENABLE_EB:BOOL=${{ matrix.use_eb }} \
-            -DPELE_ENABLE_MPI:BOOL=OFF \
-            -DPELE_ENABLE_FCOMPARE_FOR_TESTS:BOOL=OFF \
-            -DPELE_ENABLE_CLANG_TIDY:BOOL=ON \
-            -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
-            ${{ github.workspace }}/PeleLMeX
+          -DCMAKE_BUILD_TYPE:STRING=Release \
+          -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+          -DCMAKE_CXX_COMPILER:STRING=clang++ \
+          -DCMAKE_C_COMPILER:STRING=clang \
+          -DPELE_ENABLE_EB:BOOL=${{ matrix.use_eb }} \
+          -DPELE_ENABLE_MPI:BOOL=OFF \
+          -DPELE_ENABLE_FCOMPARE_FOR_TESTS:BOOL=OFF \
+          -DPELE_ENABLE_CLANG_TIDY:BOOL=ON \
+          -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
+          ${{ github.workspace }}/PeleLMeX
 
       - name: Check
         working-directory: ${{ env.BUILD_DIR }}
@@ -123,3 +123,4 @@ jobs:
           cat clang-tidy-warnings.txt
           export return=$(tail -n 1 clang-tidy-warnings.txt | awk '{print $2}')
           exit ${return}
+

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,12 +1,10 @@
 name: Downstream-CI
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - '**'
-  pull_request:
-    branches: [development]
+  workflow_run:
+    workflows: ["PelePhysics-CI"]
+    types:
+      - completed
 
 jobs:
   PeleLMeX-clang-tidy:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,13 +1,15 @@
 name: Downstream-CI
 
 on:
-  workflow_run:
-    workflows: ["PelePhysics-CI"]
-    types:
-      - completed
+  workflow_dispatch:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches: [development]
 
 concurrency:
-  group: ${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}-downstream
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -117,18 +117,10 @@ jobs:
     name: PeleLMeX clang-tidy
     needs: [PeleLMeX-FlameSheet, PeleC-PMF]
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        enable_eb: [EB-OFF, EB-ON]
-        include:
-          - enable_eb: EB-OFF
-            use_eb: "OFF"
-          - enable_eb: EB-ON
-            use_eb: "ON"
-      fail-fast: false
 
     env:
       BUILD_DIR: ${{ github.workspace }}/build-clang-tidy-lmex
+      use_eb: "OFF"
 
     steps:
       - name: Checkout PelePhysics
@@ -177,9 +169,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache
-          key: ccache-${{ github.workflow }}-${{ github.job }}-${{ matrix.enable_eb }}-git-${{ github.sha }}
+          key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
           restore-keys: |
-            ccache-${{ github.workflow }}-${{ github.job }}-${{ matrix.enable_eb }}-git-
+            ccache-${{ github.workflow }}-${{ github.job }}-git-
 
       - name: Configure
         working-directory: PeleLMeX
@@ -189,7 +181,7 @@ jobs:
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
           -DCMAKE_CXX_COMPILER:STRING=clang++ \
           -DCMAKE_C_COMPILER:STRING=clang \
-          -DPELE_ENABLE_EB:BOOL=${{ matrix.use_eb }} \
+          -DPELE_ENABLE_EB:BOOL=${{ env.use_eb }} \
           -DPELE_ENABLE_MPI:BOOL=OFF \
           -DPELE_ENABLE_FCOMPARE_FOR_TESTS:BOOL=OFF \
           -DPELE_ENABLE_CLANG_TIDY:BOOL=ON \

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -53,14 +53,70 @@ jobs:
         run: |
           make TPL COMP=gnu USE_MPI=TRUE
           make -j 2 DIM=2 COMP=gnu USE_MPI=TRUE
+
       - name: Run
         working-directory: PeleLMeX/Exec/RegTests/FlameSheet/
         run: |
-          mpirun -n 2 ./PeleLMeX2d.gnu.MPI.ex input.2d-regt amr.max_step=2 amr.plot_int=-1 amr.check_int=-1 amrex.abort_on_unused_inputs=1 amr.n_cell=32 64
+          mpirun -n 2 ./PeleLMeX2d.gnu.MPI.ex input.2d-regt amr.max_step=2 amr.plot_int=-1 amr.check_int=-1 amrex.abort_on_unused_inputs=1 amr.n_cell=32 64 
+
+  PeleC-PMF:
+    name: PeleC GNU@9.3 MPI Run [PMF]
+    runs-on: ubuntu-latest
+    env:
+      {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    
+    steps:
+      - name: Checkout PelePhysics
+        uses: actions/checkout@v4
+        with:
+          path: pelephysics-pr
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Clone PeleC
+        run: |
+          git clone --recursive --shallow-submodules --single-branch \
+            https://github.com/AMReX-Combustion/PeleC.git
+
+      - name: Point PeleC/Submodules/PelePhysics to this PR
+        working-directory: PeleC
+        shell: bash
+        run: |
+          cd Submodules/PelePhysics
+          git fetch "$GITHUB_WORKSPACE/pelephysics-pr"
+          git checkout $(git -C "$GITHUB_WORKSPACE/pelephysics-pr" rev-parse HEAD)
+
+          echo "PelePhysics Submodule now points to:"
+          git rev-parse --short HEAD
+      
+      - name: System Dependencies
+        working-directory: PeleC
+        run: |
+          set -eu -o pipefail
+
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+
+          sudo apt-get install -y --no-install-recommends \
+              build-essential    \
+              gcc-10 \
+              libopenmpi-dev     \
+              openmpi-bin
+      
+      - name: Build
+        working-directory: PeleC/Exec/RegTests/PMF/
+        run: |
+          make TPL COMP=gnu USE_MPI=TRUE
+          make -j 2 DIM=3 COMP=gnu USE_MPI=TRUE
+
+      - name: Run
+        working-directory: PeleC/Exec/RegTests/PMF/
+        run: |
+          mpirun -n 2 ./PeleC3d.gnu.MPI.ex example.inp max_step=2 amr.plot_int=-1 amr.check_int=-1 amrex.abort_on_unused_inputs=0 amr.n_cell=8 8 128
 
   PeleLMeX-clang-tidy:
     name: PeleLMeX clang-tidy
-    needs: PeleLMeX-FlameSheet
+    needs: [PeleLMeX-FlameSheet, PeleC-PMF]
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -173,6 +229,7 @@ jobs:
 
   PeleC-clang-tidy:
     name: PeleC clang-tidy
+    needs: [PeleLMeX-FlameSheet, PeleC-PMF]
     runs-on: ubuntu-24.04
 
     env:

--- a/Source/Eos/EosParams.H
+++ b/Source/Eos/EosParams.H
@@ -122,7 +122,7 @@ struct InitParm<eos::EosParm<eos::Manifold>>
       }
     } else if (density_lookup_type_string == "log") {
       parm_in->m_h_parm.dens_lookup = eos::density_lookup_type::log;
-      parm_in->m_h_parm.idx_density = get_var_index("lnRHO", h_manf_data_in, 0);
+      parm_in->m_h_parm.idx_density = get_var_index("lnRHO", h_manf_data_in, false);
       if (parm_in->m_h_parm.idx_density < 0) {
         parm_in->m_h_parm.idx_density = get_var_index("logRHO", h_manf_data_in);
       }

--- a/Source/Eos/EosParams.H
+++ b/Source/Eos/EosParams.H
@@ -122,7 +122,8 @@ struct InitParm<eos::EosParm<eos::Manifold>>
       }
     } else if (density_lookup_type_string == "log") {
       parm_in->m_h_parm.dens_lookup = eos::density_lookup_type::log;
-      parm_in->m_h_parm.idx_density = get_var_index("lnRHO", h_manf_data_in, false);
+      parm_in->m_h_parm.idx_density =
+        get_var_index("lnRHO", h_manf_data_in, false);
       if (parm_in->m_h_parm.idx_density < 0) {
         parm_in->m_h_parm.idx_density = get_var_index("logRHO", h_manf_data_in);
       }


### PR DESCRIPTION
To avoid future headaches I'm proposing we add some downstream tests for LMeX and PeleC. I think the following should catch any potential issues from a PelePhysics PR:

- [x] clang-tidy for LMeX (EB-OFF only)
- [x] clang-tidy for PeleC 
- [x] FlameSheet for LMeX
- [x] PMF for PeleC
- [x]  Edit `workflow_dispatch` to only trigger for `development` branch

Let me know if you have any thoughts/suggestions @jrood-nrel , @marchdf and @baperry2.

When we are ready to merge, we'll want to edit the `workflow_dispatch` to read:
~~~
on:
  workflow_dispatch:
  push:
    branches: [development]
  pull_request:
    branches: [development]
~~~

I had to set the push branches to all to demonstrate the tests work as expected in this PR.