### PR TITLE
Unit conversion fix

### DIFF
--- a/Source/Utility/Utilities/UnitConversions.H
+++ b/Source/Utility/Utilities/UnitConversions.H
@@ -93,7 +93,7 @@ AMREX_FORCE_INLINE
 constexpr amrex::Real
 RhoH(const amrex::Real rhoh_cgs)
 {
-  return rhoh_cgs * 1.0e1; // erg/cm^3 to J/m^3
+  return rhoh_cgs * 1.0e-1; // erg/cm^3 to J/m^3
 }
 
 AMREX_GPU_HOST_DEVICE


### PR DESCRIPTION
While working on [PeleLMeX#556](https://github.com/AMReX-Combustion/PeleLMeX/pull/556), I noticed that the RhoH conversion is the same for c2m and m2c instead of being inverted (and is what causes my current version to crash). This fixes the issue, and I hope it hasn't caused issues elsewhere.