### PR TITLE
Generalize droplet mixture calculations

### DIFF
--- a/Docs/sphinx/Spray.rst
+++ b/Docs/sphinx/Spray.rst
@@ -22,6 +22,9 @@ Firstly, spray modeling relies on the following assumptions:
 
 * The radiation, Soret, and Dufour effects are neglected
 
+Secondly, accurate spray modeling requires accurate thermophysical and transport properties for both the gas and liquid phases. The gas phase properties are computed using information from the mechanism files in `PelePhysics` while the liquid-phase properties are provided by the user. 
+The required inputs and the forms of the component-level and mixture-level liquid-phase properties are discussed in detail in the :ref:`Liquid Spray Properties <SprayLiquidProperties>` section.
+
 The evaporation models follow the work by Abramzon and Sirignano [#abram]_ and the multicomponent evaporation is based on work by Tonini. [#ton]_ Details regarding the energy balance are provided in Ge et al. [#Ge]_
 
 The subscript notation for this section is: :math:`d` relates to the liquid droplet, :math:`v` relates to the vapor state that is in equilibrium with the liquid and gas phase, :math:`L` relates to the liquid phase, and :math:`g` relates to the gas phase. The subscript :math:`r` relates to the reference state with which to approximate the thermophysical and transport properties. This reference state is assumed to be in the evaporating film that surrounds the droplet state and is approximated as
@@ -84,16 +87,7 @@ The procedure is as follows for updating the spray droplet:
       h_{L,n}(T_d) = h_{g,n}(T_d) - h_{g,n}(T^*) + h_{L,n}(T^*) - c_{p,L,n}(T^*) (T_d - T^*) \,.
 
 
-   and the saturation pressure using either the Clasius-Clapeyron relation
-
-
-   .. math::
-      p_{{\rm{sat}}, n} = p_{\rm{atm}} \exp\left(\frac{h_{L,n}(T_d) M_n}{\mathcal{R}} \left(\frac{1}{T^*_{b,n}} - \frac{1}{T_d}\right)\right)
-
-   or the Antoine curve fit
-
-   .. math::
-      p_{{\rm{sat}},n} = d 10^{a - b / (T_d + c)}
+   and the saturation pressure, :math:`p_{{\rm{sat}}, n}`, using one of the methods described in the :ref:`Liquid Spray Properties <SprayLiquidProperties>` section.
 
 #. Estimate the mass fractions in the vapor state using Raoult's law
 
@@ -245,7 +239,6 @@ The procedure is as follows for updating the spray droplet:
 
    For such cases, fully three-dimensional simulations are recommended.
 
-
    
 Spray Flags and Inputs
 ======================
@@ -254,17 +247,13 @@ Spray Flags and Inputs
 
 * Depending on the gas phase solver, spray solving functionality can be turned on in the input file using ``pelec.do_spray_particles = 1`` or ``peleLM.do_spray_particles = 1``.
 
-* The units for `PeleLM` and `PeleLMeX` are MKS while the units for `PeleC` are CGS. This is the same for the spray inputs. E.g. when running a spray simulation coupled with `PeleC`, the units for ``particles.fuel_cp`` must be in erg/g.
-
 * There are many required ``particles.`` flags in the input file. For demonstration purposes, 2 liquid species of ``NC7H16`` and ``NC10H22`` will be used.
 
   * The liquid fuel species names are specified using ``particles.fuel_species = NC7H16 NC10H22``. The number of fuel species listed must match ``SPRAY_FUEL_NUM``.
 
-  * Many values must be specified on a per-species basis. Following the current example, one would have to specify ``particles.NC7H16_crit_temp = 540.`` and ``particles.NC10H22_crit_temp = 617.`` to set a critical temperature of 540 K for ``NC7H16`` and 617 K for ``NC10H22``.
-
   * Although this is not required or typical, if the evaporated mass should contribute to a different gas phase species than what is modeled in the liquid phase, use ``particles.dep_fuel_species``. For example, if we wanted the evaporated mass from both liquid species to contribute to a different species called ``SP3``, we would put ``particles.dep_fuel_species = SP3 SP3``. All species specified must be present in the chemistry transport and thermodynamic data.
 
-* The following table lists other inputs related to ``particles.``, where ``SP`` will refer to a fuel species name
+* The following table lists other inputs related to ``particles.``
 
 .. table::
 
@@ -275,28 +264,6 @@ Spray Flags and Inputs
    +-----------------------+-------------------------------+-------------+-------------------+
    |``dep_fuel_species``   |Name of gas phase species to   |Yes          |Inputs to          |
    |                       |contribute                     |             |``fuel_species``   |
-   +-----------------------+-------------------------------+-------------+-------------------+
-   |``fuel_ref_temp``      |Liquid reference temperature   |Yes          |None               |
-   +-----------------------+-------------------------------+-------------+-------------------+
-   |``SP_crit_temp``       |Critical temperature           |Yes          |None               |
-   +-----------------------+-------------------------------+-------------+-------------------+
-   |``SP_boil_temp``       |Boiling temperature at         |Yes          |None               |
-   |                       |atmospheric pressure           |             |                   |
-   +-----------------------+-------------------------------+-------------+-------------------+
-   |``SP_cp``              |Liquid :math:`c_p` at reference|Yes          |None               |
-   |                       |temperature                    |             |                   |
-   +-----------------------+-------------------------------+-------------+-------------------+
-   |``SP_latent``          |Latent heat at reference       |Yes          |None               |
-   |                       |temperature                    |             |                   |
-   +-----------------------+-------------------------------+-------------+-------------------+
-   |``SP_rho``             |Liquid density                 |Yes          |None               |
-   |                       |                               |             |                   |
-   +-----------------------+-------------------------------+-------------+-------------------+
-   |``SP_lambda``          |Liquid thermal conductivity    |No           |0.                 |
-   |                       |(currently unused)             |             |                   |
-   +-----------------------+-------------------------------+-------------+-------------------+
-   |``SP_mu``              |Liquid dynamic viscosity       |No           |0.                 |
-   |                       |(currently unused)             |             |                   |
    +-----------------------+-------------------------------+-------------+-------------------+
    |``mom_transfer``       |Couple momentum with gas phase |No           |``1``              |
    |                       |                               |             |                   |
@@ -320,16 +287,61 @@ Spray Flags and Inputs
    +-----------------------+-------------------------------+-------------+-------------------+
 
 
+.. _SprayLiquidProperties:
+
+Liquid Spray Properties
+-----------------------
+
+* The units for `PeleLM` and `PeleLMeX` are MKS while the units for `PeleC` are CGS. This is the same for the spray inputs. E.g. when running a spray simulation coupled with `PeleC`, the units for ``particles.fuel_cp`` must be in erg/g.
+
+* There are many required ``particles.`` flags in the input file for liquid fuel properties. For demonstration purposes, 2 liquid species of ``NC7H16`` and ``NC10H22`` will be used.
+
+  * Many values must be specified on a per-species basis. Following the current example, one would have to specify ``particles.NC7H16_crit_temp = 540.`` and ``particles.NC10H22_crit_temp = 617.`` to set a critical temperature of 540 K for ``NC7H16`` and 617 K for ``NC10H22``.
+
+* The following table lists other inputs related to ``particles.``, where ``SP`` will refer to a fuel species name
+
+.. table::
+
+   +-----------------------+-------------------------------+-------------+-------------------+
+   |Input                  |Description                    |Required     |Default Value      |
+   +=======================+===============================+=============+===================+
+   |``fuel_ref_temp``      |Liquid reference temperature   |Yes          |None               |
+   +-----------------------+-------------------------------+-------------+-------------------+
+   |``SP_crit_temp``       |Critical temperature           |Yes          |None               |
+   +-----------------------+-------------------------------+-------------+-------------------+
+   |``SP_boil_temp``       |Boiling temperature at         |Yes          |None               |
+   |                       |atmospheric pressure           |             |                   |
+   +-----------------------+-------------------------------+-------------+-------------------+
+   |``SP_cp``              |Liquid :math:`c_p` at reference|Yes          |None               |
+   |                       |temperature                    |             |                   |
+   +-----------------------+-------------------------------+-------------+-------------------+
+   |``SP_latent``          |Latent heat at reference       |Yes          |None               |
+   |                       |temperature                    |             |                   |
+   +-----------------------+-------------------------------+-------------+-------------------+
+   |``SP_rho``             |Liquid density                 |Yes          |None               |
+   |                       |                               |             |                   |
+   +-----------------------+-------------------------------+-------------+-------------------+
+   |``SP_lambda``          |Liquid thermal conductivity    |No           |0.                 |
+   |                       |(currently unused)             |             |                   |
+   +-----------------------+-------------------------------+-------------+-------------------+
+   |``SP_mu``              |Liquid dynamic viscosity       |No           |0.                 |
+   |                       |(currently unused)             |             |                   |
+   +-----------------------+-------------------------------+-------------+-------------------+
+
+
 * If an Antoine fit for saturation pressure is used, it must be specified for individual species, ::
 
     particles.SP_psat = 4.07857 1501.268 -78.67 1.E5
 
-  where the numbers represent coefficients :math:`a`, :math:`b`, :math:`c`, and unit conversion :math:`d`, respectively in:
+  where the numbers represent coefficients :math:`a_n`, :math:`b_n`, :math:`c_n`, and unit conversion :math:`d_n`, respectively in:
 
   .. math::
-     p_{\rm{sat}}(T) = d 10^{a - b / (T + c)}
+     p_{\rm{sat},n}(T) = d_n 10^{a_n - b_n / (T + c_n)}.
+  
+  * If no fit is provided, the saturation pressure is estimated using the Clasius-Clapeyron relation
 
-  * If no fit is provided, the saturation pressure is estimated using the Clasius-Clapeyron relation; see
+      .. math::
+         p_{{\rm{sat}}, n} = p_{\rm{atm}} \exp\left(\frac{h_{L,n}(T_d) M_n}{\mathcal{R}} \left(\frac{1}{T^*_{b,n}} - \frac{1}{T_d}\right)\right)
 
 * Temperature based fits for liquid density, thermal conductivity, and dynamic viscosity can be used; these can be specified as ::
 
@@ -337,14 +349,15 @@ Spray Flags and Inputs
     particles.SP_lambda = 7.243 1.223 4.223E-8 8.224E-9
     particles.SP_mu = 7.243 1.223 4.223E-8 8.224E-9
 
-  where the numbers represent :math:`a`, :math:`b`, :math:`c`, and :math:`d`, respectively in:
+  where the numbers represent :math:`a_n`, :math:`b_n`, :math:`c_n`, and :math:`d_n`, respectively in:
 
   .. math::
-     \rho_L \,, \lambda_L = a + b T + c T^2 + d T^3
+     \rho_{L,n} \,, \lambda_{L,n} = a_n + b_n T + c_n T^2 + d_n T^3
 
-     \mu_L = a + b / T + c / T^2 + d / T^3
+     \mu_{L,n} = a_n + b_n / T + c_n / T^2 + d_n / T^3
 
-  If only a single value is provided, :math:`a` is assigned to that value and the other coefficients are set to zero, effectively using a constant value for the parameters.
+  If only a single value is provided, :math:`a_n` is assigned to that value and the other coefficients are set to zero, effectively using a constant value for the parameters.
+
 
 Spray Injection
 ---------------

--- a/Source/Spray/BreakupSplash/AhamedSplash.H
+++ b/Source/Spray/BreakupSplash/AhamedSplash.H
@@ -228,10 +228,10 @@ droplet_splashing(
     Y_part[spf] = p.rdata(SprayComps::pstateY + spf);
   }
   // TODO: Determine correct method for handling multi-component liquids
-  amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, cBoilT);
-  amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
-  amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
-  amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
+  const amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, cBoilT);
+  const amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
+  const amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
+  const amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
   amrex::Real Tstar = fdat.wall_T / Tboil;
   const amrex::Real dia_part = p.rdata(SprayComps::pstateDia);
   const amrex::Real pmass = M_PI / 6. * rho_part * std::pow(dia_part, 3);

--- a/Source/Spray/BreakupSplash/AhamedSplash.H
+++ b/Source/Spray/BreakupSplash/AhamedSplash.H
@@ -231,12 +231,13 @@ droplet_splashing(
   amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, T_part, cBoilT);
   amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
   amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
+  amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
   amrex::Real Tstar = fdat.wall_T / Tboil;
   const amrex::Real dia_part = p.rdata(SprayComps::pstateDia);
   const amrex::Real pmass = M_PI / 6. * rho_part * std::pow(dia_part, 3);
   // Weber number
   const amrex::Real We =
-    rho_part * dia_part * U0norm * U0norm / fdat.liqprops.sigma;
+    rho_part * dia_part * U0norm * U0norm / sigma_part;
   const amrex::Real Re_L = std::abs(U0norm) * dia_part * rho_part / mu_part;
   const amrex::Real Kv = std::sqrt(We * std::sqrt(Re_L));
   // Inclination of on-coming particle to surface in radians

--- a/Source/Spray/BreakupSplash/AhamedSplash.H
+++ b/Source/Spray/BreakupSplash/AhamedSplash.H
@@ -226,13 +226,14 @@ droplet_splashing(
   amrex::Real mu_part = 0.;
   amrex::Real rho_part = 0.;
   amrex::Real Y_part[SPRAY_FUEL_NUM] = {0.0};
-  // TODO: Determine correct method for handling multi-component liquids
-  amrex::Real Tboil = 0.;
   for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
     Y_part[spf] = p.rdata(SprayComps::pstateY + spf);
+  }
+  // TODO: Determine correct method for handling multi-component liquids
+  amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, T_part, cBoilT);
+  for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
     amrex::Real minT = amrex::min(T_part, cBoilT[spf]);
     mu_part += Y_part[spf] * fdat.liqprops.mu_i(minT, spf);
-    Tboil += Y_part[spf] * cBoilT[spf];
   }
   rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
   amrex::Real Tstar = fdat.wall_T / Tboil;

--- a/Source/Spray/BreakupSplash/AhamedSplash.H
+++ b/Source/Spray/BreakupSplash/AhamedSplash.H
@@ -228,7 +228,7 @@ droplet_splashing(
     Y_part[spf] = p.rdata(SprayComps::pstateY + spf);
   }
   // TODO: Determine correct method for handling multi-component liquids
-  amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, T_part, cBoilT);
+  amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, cBoilT);
   amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
   amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
   amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);

--- a/Source/Spray/BreakupSplash/AhamedSplash.H
+++ b/Source/Spray/BreakupSplash/AhamedSplash.H
@@ -231,7 +231,8 @@ droplet_splashing(
   const amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, cBoilT);
   const amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
   const amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
-  const amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
+  const amrex::Real sigma_part =
+    fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
   amrex::Real Tstar = fdat.wall_T / Tboil;
   const amrex::Real dia_part = p.rdata(SprayComps::pstateDia);
   const amrex::Real pmass = M_PI / 6. * rho_part * std::pow(dia_part, 3);

--- a/Source/Spray/BreakupSplash/AhamedSplash.H
+++ b/Source/Spray/BreakupSplash/AhamedSplash.H
@@ -236,8 +236,7 @@ droplet_splashing(
   const amrex::Real dia_part = p.rdata(SprayComps::pstateDia);
   const amrex::Real pmass = M_PI / 6. * rho_part * std::pow(dia_part, 3);
   // Weber number
-  const amrex::Real We =
-    rho_part * dia_part * U0norm * U0norm / sigma_part;
+  const amrex::Real We = rho_part * dia_part * U0norm * U0norm / sigma_part;
   const amrex::Real Re_L = std::abs(U0norm) * dia_part * rho_part / mu_part;
   const amrex::Real Kv = std::sqrt(We * std::sqrt(Re_L));
   // Inclination of on-coming particle to surface in radians

--- a/Source/Spray/BreakupSplash/AhamedSplash.H
+++ b/Source/Spray/BreakupSplash/AhamedSplash.H
@@ -223,19 +223,14 @@ droplet_splashing(
   amrex::Real U0tan = std::sqrt(U0mag * U0mag - U0norm * U0norm);
   amrex::Real T_part = p.rdata(SprayComps::pstateT);
   amrex::Real num_dens = p.rdata(SprayComps::pstateNumDens);
-  amrex::Real mu_part = 0.;
-  amrex::Real rho_part = 0.;
   amrex::Real Y_part[SPRAY_FUEL_NUM] = {0.0};
   for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
     Y_part[spf] = p.rdata(SprayComps::pstateY + spf);
   }
   // TODO: Determine correct method for handling multi-component liquids
   amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, T_part, cBoilT);
-  for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-    amrex::Real minT = amrex::min(T_part, cBoilT[spf]);
-    mu_part += Y_part[spf] * fdat.liqprops.mu_i(minT, spf);
-  }
-  rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
+  amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
+  amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
   amrex::Real Tstar = fdat.wall_T / Tboil;
   const amrex::Real dia_part = p.rdata(SprayComps::pstateDia);
   const amrex::Real pmass = M_PI / 6. * rho_part * std::pow(dia_part, 3);

--- a/Source/Spray/BreakupSplash/ReitzKHRT.H
+++ b/Source/Spray/BreakupSplash/ReitzKHRT.H
@@ -54,7 +54,8 @@ updateBreakupKHRT(
   // To prolong RT breakup, rt_time is set to -1 on injection. RT breakup can
   // then only occur after KH breakup happens at least once
   amrex::Real rt_time = p.rdata(SprayComps::pstateBM2);
-  const amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
+  const amrex::Real sigma_part =
+    fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
   amrex::Real rad_part = 0.5 * dia_part;
   if (rad_part < min_rad) {
     return;

--- a/Source/Spray/BreakupSplash/ReitzKHRT.H
+++ b/Source/Spray/BreakupSplash/ReitzKHRT.H
@@ -54,7 +54,7 @@ updateBreakupKHRT(
   // To prolong RT breakup, rt_time is set to -1 on injection. RT breakup can
   // then only occur after KH breakup happens at least once
   amrex::Real rt_time = p.rdata(SprayComps::pstateBM2);
-  amrex::Real sigma = fdat.liqprops.sigma;
+  amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
   amrex::Real rad_part = 0.5 * dia_part;
   if (rad_part < min_rad) {
     return;
@@ -72,8 +72,8 @@ updateBreakupKHRT(
   } else if (Reyn > 0.) {
     C_D = 24. / Reyn;
   }
-  amrex::Real We_g = gpv.rho_fluid * vel_sq * rad_part / sigma;
-  amrex::Real Z = mu_part / std::sqrt(rho_part * rad_part * sigma);
+  amrex::Real We_g = gpv.rho_fluid * vel_sq * rad_part / sigma_part;
+  amrex::Real Z = mu_part / std::sqrt(rho_part * rad_part * sigma_part);
   amrex::Real T = Z * std::sqrt(We_g);
   bool breakupRT = false;
   // Check of RT breakup occurs
@@ -83,9 +83,9 @@ updateBreakupKHRT(
       3. / 8. * C_D * gpv.rho_fluid * vel_sq / (rho_part * rad_part);
     amrex::Real momdiff = a * (rho_part - gpv.rho_fluid);
     amrex::Real omega_RT = std::sqrt(
-      2. / (3. * std::sqrt(3. * sigma)) * momdiff * std::sqrt(momdiff) /
+      2. / (3. * std::sqrt(3. * sigma_part)) * momdiff * std::sqrt(momdiff) /
       (rho_part + gpv.rho_fluid));
-    amrex::Real KRT = std::sqrt(momdiff / (3. * sigma));
+    amrex::Real KRT = std::sqrt(momdiff / (3. * sigma_part));
     amrex::Real lam_RT = C3 * M_PI / KRT;
     if (rad_part < lam_RT) {
       rt_time = 0.;
@@ -108,7 +108,7 @@ updateBreakupKHRT(
                          std::pow(1. + 0.865 * std::pow(We_g, 1.67), 0.6);
     amrex::Real omega_KH = (0.34 + 0.385 * We_g * std::sqrt(We_g)) /
                            ((1. + Z) * (1. + 1.4 * std::pow(T, 0.6))) *
-                           std::sqrt(sigma / (rho_part * rad_part3));
+                           std::sqrt(sigma_part / (rho_part * rad_part3));
     amrex::Real tau_KH = 3.726 * B1 * rad_part / (lam_KH * omega_KH);
     amrex::Real rs = B0 * lam_KH;
     // KH breakup occurs

--- a/Source/Spray/BreakupSplash/ReitzKHRT.H
+++ b/Source/Spray/BreakupSplash/ReitzKHRT.H
@@ -38,15 +38,12 @@ updateBreakupKHRT(
   amrex::Real T_part = p.rdata(SprayComps::pstateT);
   amrex::Real dia_part = p.rdata(SprayComps::pstateDia);
   amrex::Real num_dens = p.rdata(SprayComps::pstateNumDens);
-  amrex::Real rho_part = 0.;
-  amrex::Real mu_part = 0.;
   amrex::Real Y_part[SPRAY_FUEL_NUM] = {0.0};
   for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-    amrex::Real minT = amrex::min(T_part, cBoilT[spf]);
     Y_part[spf] = p.rdata(SprayComps::pstateY + spf);
-    mu_part += Y_part[spf] * fdat.liqprops.mu_i(minT, spf);
   }
-  rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
+  amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
+  amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
   // Minimum droplet radius for child droplets
   // Should not create child droplets that are near to or less than the minimum
   // allowable mass to avoid unphysical evaporation of mass

--- a/Source/Spray/BreakupSplash/ReitzKHRT.H
+++ b/Source/Spray/BreakupSplash/ReitzKHRT.H
@@ -42,8 +42,8 @@ updateBreakupKHRT(
   for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
     Y_part[spf] = p.rdata(SprayComps::pstateY + spf);
   }
-  amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
-  amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
+  const amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
+  const amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
   // Minimum droplet radius for child droplets
   // Should not create child droplets that are near to or less than the minimum
   // allowable mass to avoid unphysical evaporation of mass
@@ -54,7 +54,7 @@ updateBreakupKHRT(
   // To prolong RT breakup, rt_time is set to -1 on injection. RT breakup can
   // then only occur after KH breakup happens at least once
   amrex::Real rt_time = p.rdata(SprayComps::pstateBM2);
-  amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
+  const amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
   amrex::Real rad_part = 0.5 * dia_part;
   if (rad_part < min_rad) {
     return;

--- a/Source/Spray/BreakupSplash/TABBreakup.H
+++ b/Source/Spray/BreakupSplash/TABBreakup.H
@@ -44,7 +44,8 @@ updateBreakupTAB(
   }
   const amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
   const amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
-  const amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
+  const amrex::Real sigma_part =
+    fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
 
   amrex::Real Utan_total = 0.;
   amrex::Real rad_part = 0.5 * dia_part;

--- a/Source/Spray/BreakupSplash/TABBreakup.H
+++ b/Source/Spray/BreakupSplash/TABBreakup.H
@@ -45,7 +45,7 @@ updateBreakupTAB(
   amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
   amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
   amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
-  
+
   amrex::Real Utan_total = 0.;
   amrex::Real rad_part = 0.5 * dia_part;
   amrex::Real min_rad =

--- a/Source/Spray/BreakupSplash/TABBreakup.H
+++ b/Source/Spray/BreakupSplash/TABBreakup.H
@@ -44,9 +44,9 @@ updateBreakupTAB(
   }
   amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
   amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
+  amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
   
   amrex::Real Utan_total = 0.;
-  amrex::Real sigma = fdat.liqprops.sigma;
   amrex::Real rad_part = 0.5 * dia_part;
   amrex::Real min_rad =
     4. * std::cbrt(SPU.min_mass * 3. / (4. * M_PI * rho_part));
@@ -54,11 +54,11 @@ updateBreakupTAB(
     return 0.;
   }
   amrex::RealVect diff_vel = gpv.vel_fluid - vel_part;
-  amrex::Real We_div_r = gpv.rho_fluid * diff_vel.radSquared() / sigma;
+  amrex::Real We_div_r = gpv.rho_fluid * diff_vel.radSquared() / sigma_part;
   amrex::Real We_crit = C_k * C_b / C_F;
   amrex::Real denom = rho_part * rad_part * rad_part;
   amrex::Real td = 2. * denom / (C_d * mu_part);
-  amrex::Real omega2 = C_k * sigma / (denom * rad_part) - 1. / (td * td);
+  amrex::Real omega2 = C_k * sigma_part / (denom * rad_part) - 1. / (td * td);
   amrex::Real tbconst =
     2. * std::sqrt(3. * rho_part / gpv.rho_fluid) / diff_vel.vectorLength();
   if (omega2 <= 0.) {
@@ -155,7 +155,7 @@ updateBreakupTAB(
         subdt = amrex::min(dt, 0.1 * tb_est);
         denom = rho_part * rad_part * rad_part;
         td = 2. * denom / (C_d * mu_part);
-        omega2 = C_k * sigma / (denom * rad_part) - 1. / (td * td);
+        omega2 = C_k * sigma_part / (denom * rad_part) - 1. / (td * td);
         if (omega2 <= 0.) {
           p.rdata(SprayComps::pstateDia) = 2. * rad_part;
           p.rdata(SprayComps::pstateNumDens) = num_dens;

--- a/Source/Spray/BreakupSplash/TABBreakup.H
+++ b/Source/Spray/BreakupSplash/TABBreakup.H
@@ -38,15 +38,13 @@ updateBreakupTAB(
   amrex::Real T_part = p.rdata(SprayComps::pstateT);
   amrex::Real dia_part = p.rdata(SprayComps::pstateDia);
   amrex::Real num_dens = p.rdata(SprayComps::pstateNumDens);
-  amrex::Real rho_part = 0.;
-  amrex::Real mu_part = 0.;
   amrex::Real Y_part[SPRAY_FUEL_NUM] = {0.0};
   for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-    amrex::Real minT = amrex::min(T_part, cBoilT[spf]);
     Y_part[spf] = p.rdata(SprayComps::pstateY + spf);
-    mu_part += Y_part[spf] * fdat.liqprops.mu_i(minT, spf);
   }
-  rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
+  amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
+  amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
+  
   amrex::Real Utan_total = 0.;
   amrex::Real sigma = fdat.liqprops.sigma;
   amrex::Real rad_part = 0.5 * dia_part;

--- a/Source/Spray/BreakupSplash/TABBreakup.H
+++ b/Source/Spray/BreakupSplash/TABBreakup.H
@@ -42,9 +42,9 @@ updateBreakupTAB(
   for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
     Y_part[spf] = p.rdata(SprayComps::pstateY + spf);
   }
-  amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
-  amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
-  amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
+  const amrex::Real rho_part = fdat.liqprops.rho_mix(Y_part, T_part, cBoilT);
+  const amrex::Real mu_part = fdat.liqprops.mu_mix(Y_part, T_part, cBoilT);
+  const amrex::Real sigma_part = fdat.liqprops.sigma_mix(Y_part, T_part, cBoilT);
 
   amrex::Real Utan_total = 0.;
   amrex::Real rad_part = 0.5 * dia_part;

--- a/Source/Spray/BreakupSplash/WallFilm.H
+++ b/Source/Spray/BreakupSplash/WallFilm.H
@@ -62,7 +62,7 @@ calculateFilmSource(
   }
   amrex::Real T_film = p.rdata(SprayComps::pstateT);
   amrex::Real rho_film = fdat.liqprops.rho_mix(Y_film, T_film, cBoilT);
-  amrex::Real Tcrit = fdat.liqprops.critT_mix(Y_film, T_film);
+  amrex::Real Tcrit = fdat.liqprops.critT_mix(Y_film);
   amrex::Real cp_film = fdat.liqprops.cp_mix(Y_film, T_film, cBoilT);
   amrex::Real lambda_film = fdat.liqprops.lambda_mix(Y_film, T_film, cBoilT);
   amrex::Real mw_film = 0.;

--- a/Source/Spray/BreakupSplash/WallFilm.H
+++ b/Source/Spray/BreakupSplash/WallFilm.H
@@ -65,7 +65,8 @@ calculateFilmSource(
   const amrex::Real rho_film = fdat.liqprops.rho_mix(Y_film, T_film, cBoilT);
   const amrex::Real Tcrit = fdat.liqprops.critT_mix(Y_film);
   const amrex::Real cp_film = fdat.liqprops.cp_mix(Y_film, T_film, cBoilT);
-  const amrex::Real lambda_film = fdat.liqprops.lambda_mix(Y_film, T_film, cBoilT);
+  const amrex::Real lambda_film =
+    fdat.liqprops.lambda_mix(Y_film, T_film, cBoilT);
   amrex::Real mw_film = 0.;
   for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
     mw_film += Y_film[spf] / gpv.mw[fdat.indx[spf]];

--- a/Source/Spray/BreakupSplash/WallFilm.H
+++ b/Source/Spray/BreakupSplash/WallFilm.H
@@ -62,10 +62,10 @@ calculateFilmSource(
     Y_film[spf] = p.rdata(SprayComps::pstateY + spf);
   }
   amrex::Real T_film = p.rdata(SprayComps::pstateT);
-  amrex::Real rho_film = fdat.liqprops.rho_mix(Y_film, T_film, cBoilT);
-  amrex::Real Tcrit = fdat.liqprops.critT_mix(Y_film);
-  amrex::Real cp_film = fdat.liqprops.cp_mix(Y_film, T_film, cBoilT);
-  amrex::Real lambda_film = fdat.liqprops.lambda_mix(Y_film, T_film, cBoilT);
+  const amrex::Real rho_film = fdat.liqprops.rho_mix(Y_film, T_film, cBoilT);
+  const amrex::Real Tcrit = fdat.liqprops.critT_mix(Y_film);
+  const amrex::Real cp_film = fdat.liqprops.cp_mix(Y_film, T_film, cBoilT);
+  const amrex::Real lambda_film = fdat.liqprops.lambda_mix(Y_film, T_film, cBoilT);
   amrex::Real mw_film = 0.;
   for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
     mw_film += Y_film[spf] / gpv.mw[fdat.indx[spf]];

--- a/Source/Spray/BreakupSplash/WallFilm.H
+++ b/Source/Spray/BreakupSplash/WallFilm.H
@@ -55,25 +55,21 @@ calculateFilmSource(
   amrex::GpuArray<amrex::Real, NUM_SPECIES> Ddiag;
   amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> L_fuel = {{0.0}};
   amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> mi_dot = {{0.0}};
-  amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> Y_film; // Liquid mass fractions
+  amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> Y_film = {{0.0}}; // Liquid mass fractions
   amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> X_vapor = {{0.0}};
+  for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
+    Y_film[spf] = p.rdata(SprayComps::pstateY + spf);
+  }
   amrex::Real T_film = p.rdata(SprayComps::pstateT);
-  amrex::Real rho_film = 0.;
-  amrex::Real Tcrit = 0.;
-  amrex::Real cp_film = 0.;
-  amrex::Real lambda_film = 0.;
+  amrex::Real rho_film = fdat.liqprops.rho_mix(Y_film, T_film, cBoilT);
+  amrex::Real Tcrit = fdat.liqprops.critT_mix(Y_film, T_film);
+  amrex::Real cp_film = fdat.liqprops.cp_mix(Y_film, T_film, cBoilT);
+  amrex::Real lambda_film = fdat.liqprops.lambda_mix(Y_film, T_film, cBoilT);
   amrex::Real mw_film = 0.;
   for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-    amrex::Real minT = amrex::min(T_film, cBoilT[spf]);
-    Y_film[spf] = p.rdata(SprayComps::pstateY + spf);
-    rho_film += Y_film[spf] / fdat.liqprops.rho_i(minT, spf);
-    cp_film += Y_film[spf] * fdat.liqprops.cp_i(minT, spf);
-    lambda_film += Y_film[spf] * fdat.liqprops.lambda_i(minT, spf);
-    Tcrit += Y_film[spf] * fdat.liqprops.critT_i(spf);
     mw_film += Y_film[spf] / gpv.mw[fdat.indx[spf]];
   }
   mw_film = 1. / mw_film;
-  rho_film = 1. / rho_film;
   T_film = amrex::min(0.999 * Tcrit, T_film);
   amrex::Real film_height = p.rdata(SprayComps::pstateFilmHght);
   amrex::Real film_dia = p.rdata(SprayComps::pstateDia);

--- a/Source/Spray/BreakupSplash/WallFilm.H
+++ b/Source/Spray/BreakupSplash/WallFilm.H
@@ -55,7 +55,8 @@ calculateFilmSource(
   amrex::GpuArray<amrex::Real, NUM_SPECIES> Ddiag;
   amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> L_fuel = {{0.0}};
   amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> mi_dot = {{0.0}};
-  amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> Y_film = {{0.0}}; // Liquid mass fractions
+  amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> Y_film = {
+    {0.0}}; // Liquid mass fractions
   amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> X_vapor = {{0.0}};
   for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
     Y_film[spf] = p.rdata(SprayComps::pstateY + spf);

--- a/Source/Spray/Drag.H
+++ b/Source/Spray/Drag.H
@@ -223,11 +223,10 @@ calculateSpraySource(
   amrex::Real Reyn;
   amrex::RealVect part_vel_src;
   while (isub <= nsub) {
-    amrex::Real cp_part = 0.; // Cp of the liquid state
+    amrex::Real cp_part = fdat.liqprops.cp_mix(Y_part, T_part);
     amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, T_part, cBoilT);
     amrex::Real mw_part = 0.; // Average molar mass of liquid droplet
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      cp_part += Y_part[spf] * fdat.liqprops.cp_i(T_part, spf);
       mw_part += Y_part[spf] / gpv.mw[fdat.indx[spf]];
     }
     mw_part = 1. / mw_part;

--- a/Source/Spray/Drag.H
+++ b/Source/Spray/Drag.H
@@ -210,7 +210,6 @@ calculateSpraySource(
   amrex::Real T_part = p.rdata(SprayComps::pstateT);
   amrex::Real dia_part = p.rdata(SprayComps::pstateDia);
 
-  // This is inefficient, but we need Y_part for multiple computations below
   for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
     Y_part[spf] = p.rdata(SprayComps::pstateY + spf);
   }
@@ -225,10 +224,9 @@ calculateSpraySource(
   amrex::RealVect part_vel_src;
   while (isub <= nsub) {
     amrex::Real cp_part = 0.; // Cp of the liquid state
-    amrex::Real Tboil = 0.;   // Liquid mixture boiling temperature
+    amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, T_part, cBoilT);
     amrex::Real mw_part = 0.; // Average molar mass of liquid droplet
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      Tboil += Y_part[spf] * cBoilT[spf];
       cp_part += Y_part[spf] * fdat.liqprops.cp_i(T_part, spf);
       mw_part += Y_part[spf] / gpv.mw[fdat.indx[spf]];
     }

--- a/Source/Spray/Drag.H
+++ b/Source/Spray/Drag.H
@@ -223,8 +223,8 @@ calculateSpraySource(
   amrex::Real Reyn;
   amrex::RealVect part_vel_src;
   while (isub <= nsub) {
-    amrex::Real cp_part = fdat.liqprops.cp_mix(Y_part, T_part, cBoilT);
-    amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, cBoilT);
+    const amrex::Real cp_part = fdat.liqprops.cp_mix(Y_part, T_part, cBoilT);
+    const amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, cBoilT);
     amrex::Real mw_part = 0.; // Average molar mass of liquid droplet
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
       mw_part += Y_part[spf] / gpv.mw[fdat.indx[spf]];

--- a/Source/Spray/Drag.H
+++ b/Source/Spray/Drag.H
@@ -224,7 +224,7 @@ calculateSpraySource(
   amrex::RealVect part_vel_src;
   while (isub <= nsub) {
     amrex::Real cp_part = fdat.liqprops.cp_mix(Y_part, T_part, cBoilT);
-    amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, T_part, cBoilT);
+    amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, cBoilT);
     amrex::Real mw_part = 0.; // Average molar mass of liquid droplet
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
       mw_part += Y_part[spf] / gpv.mw[fdat.indx[spf]];

--- a/Source/Spray/Drag.H
+++ b/Source/Spray/Drag.H
@@ -223,7 +223,7 @@ calculateSpraySource(
   amrex::Real Reyn;
   amrex::RealVect part_vel_src;
   while (isub <= nsub) {
-    amrex::Real cp_part = fdat.liqprops.cp_mix(Y_part, T_part);
+    amrex::Real cp_part = fdat.liqprops.cp_mix(Y_part, T_part, cBoilT);
     amrex::Real Tboil = fdat.liqprops.boilT_mix(Y_part, T_part, cBoilT);
     amrex::Real mw_part = 0.; // Average molar mass of liquid droplet
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {

--- a/Source/Spray/SprayDerive.cpp
+++ b/Source/Spray/SprayDerive.cpp
@@ -75,7 +75,7 @@ SprayParticleContainer::computeDerivedVars(
         for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
           Y_part[spf] = p.rdata(SprayComps::pstateY + spf);
         }
-        Real rho_part = fdat->liqprops.rho_mix(Y_part, T_part);
+        const Real rho_part = fdat->liqprops.rho_mix(Y_part, T_part);
         Real surf = M_PI * dia_part * dia_part;
         Real vol = M_PI / 6. * std::pow(dia_part, 3);
         Real pmass = vol * rho_part;

--- a/Source/Spray/SprayProperties.H
+++ b/Source/Spray/SprayProperties.H
@@ -30,14 +30,14 @@ struct MPLiqProps
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real cp_i(const amrex::Real& /*T*/, const int spf) const
+  amrex::Real cp_i(const amrex::Real /*T*/, const int spf) const
   {
     return cp[spf];
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real rho_i(const amrex::Real& T, const int spf) const
+  amrex::Real rho_i(const amrex::Real T, const int spf) const
   {
     amrex::Real a = rho_coef[4 * spf];
     amrex::Real b = rho_coef[4 * spf + 1];
@@ -48,7 +48,7 @@ struct MPLiqProps
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real lambda_i(const amrex::Real& T, const int spf) const
+  amrex::Real lambda_i(const amrex::Real T, const int spf) const
   {
     amrex::Real a = lambda_coef[4 * spf];
     amrex::Real b = lambda_coef[4 * spf + 1];
@@ -59,7 +59,7 @@ struct MPLiqProps
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real mu_i(const amrex::Real& T, const int spf) const
+  amrex::Real mu_i(const amrex::Real T, const int spf) const
   {
     amrex::Real a = mu_coef[4 * spf];
     amrex::Real b = mu_coef[4 * spf + 1];
@@ -70,7 +70,7 @@ struct MPLiqProps
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real psat_i(const amrex::Real& T, const int spf) const
+  amrex::Real psat_i(const amrex::Real T, const int spf) const
   {
     amrex::Real a = psat_coef[4 * spf];
     amrex::Real b = psat_coef[4 * spf + 1];
@@ -81,7 +81,7 @@ struct MPLiqProps
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  amrex::Real latent_i(const amrex::Real& T, const int spf) const
+  amrex::Real latent_i(const amrex::Real T, const int spf) const
   {
     // Since we only know the latent heat at the reference temperature,
     // modify Watsons power law to find latent heat at any temperature
@@ -117,7 +117,7 @@ struct MPLiqProps
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real cp_mix(
     const RealArrayLike& Y,
-    const amrex::Real& T,
+    const amrex::Real T,
     const amrex::Real* cBoilT = nullptr) const
   {
     amrex::Real Cp = 0.;
@@ -132,7 +132,7 @@ struct MPLiqProps
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real rho_mix(
     const RealArrayLike& Y,
-    const amrex::Real& T,
+    const amrex::Real T,
     const amrex::Real* cBoilT = nullptr) const
   {
     amrex::Real rho = 0.;
@@ -148,7 +148,7 @@ struct MPLiqProps
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real lambda_mix(
     const RealArrayLike& Y,
-    const amrex::Real& T,
+    const amrex::Real T,
     const amrex::Real* cBoilT = nullptr) const
   {
     amrex::Real lambda = 0.;
@@ -163,7 +163,7 @@ struct MPLiqProps
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real mu_mix(
     const RealArrayLike& Y,
-    const amrex::Real& T,
+    const amrex::Real T,
     const amrex::Real* cBoilT = nullptr) const
   {
     amrex::Real mu = 0.;
@@ -178,7 +178,7 @@ struct MPLiqProps
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real sigma_mix(
     const RealArrayLike& /*Y*/,
-    const amrex::Real& /*T*/,
+    const amrex::Real /*T*/,
     const amrex::Real* /*cBoilT*/ = nullptr) const
   {
     return sigma;

--- a/Source/Spray/SprayProperties.H
+++ b/Source/Spray/SprayProperties.H
@@ -90,8 +90,7 @@ struct MPLiqProps
   }
 
   // Mixture functions use RealArrayLike to allow for different types of arrays
-  // RealArrayLike can be anything with an [] operator that returns
-  // amrex::Real&
+  // RealArrayLike can be anything with an [] operator that returns amrex::Real&
 
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
@@ -116,115 +115,71 @@ struct MPLiqProps
   }
 
   template <typename RealArrayLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-  cp_mix(const RealArrayLike& Y, const amrex::Real& T) const
-  {
-    amrex::Real Cp = 0.;
-    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      Cp += Y[spf] * cp_i(T, spf);
-    }
-    return Cp;
-  }
-
-  template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real cp_mix(
     const RealArrayLike& Y,
     const amrex::Real& T,
-    const amrex::Real* cBoilT) const
+    const amrex::Real* cBoilT = nullptr) const
   {
     amrex::Real Cp = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      Cp += Y[spf] * cp_i(amrex::min(T, cBoilT[spf]), spf);
+      amrex::Real boil_temp =
+        (cBoilT != nullptr) ? cBoilT[spf] : AMREX_REAL_MAX;
+      Cp += Y[spf] * cp_i(amrex::min(T, boil_temp), spf);
     }
     return Cp;
-  }
-
-  template <typename RealArrayLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-  rho_mix(const RealArrayLike& Y, const amrex::Real& T) const
-  {
-    amrex::Real rho = 0.;
-    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      rho += Y[spf] / rho_i(T, spf);
-    }
-    rho = 1. / rho;
-    return rho;
   }
 
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real rho_mix(
     const RealArrayLike& Y,
     const amrex::Real& T,
-    const amrex::Real* cBoilT) const
+    const amrex::Real* cBoilT = nullptr) const
   {
     amrex::Real rho = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      rho += Y[spf] / rho_i(amrex::min(T, cBoilT[spf]), spf);
+      amrex::Real boil_temp =
+        (cBoilT != nullptr) ? cBoilT[spf] : AMREX_REAL_MAX;
+      rho += Y[spf] / rho_i(amrex::min(T, boil_temp), spf);
     }
     rho = 1. / rho;
     return rho;
   }
 
   template <typename RealArrayLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-  lambda_mix(const RealArrayLike& Y, const amrex::Real& T) const
-  {
-    amrex::Real lambda = 0.;
-    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      lambda += Y[spf] * lambda_i(T, spf);
-    }
-    return lambda;
-  }
-
-  template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real lambda_mix(
     const RealArrayLike& Y,
     const amrex::Real& T,
-    const amrex::Real* cBoilT) const
+    const amrex::Real* cBoilT = nullptr) const
   {
     amrex::Real lambda = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      lambda += Y[spf] * lambda_i(amrex::min(T, cBoilT[spf]), spf);
+      amrex::Real boil_temp =
+        (cBoilT != nullptr) ? cBoilT[spf] : AMREX_REAL_MAX;
+      lambda += Y[spf] * lambda_i(amrex::min(T, boil_temp), spf);
     }
     return lambda;
-  }
-
-  template <typename RealArrayLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-  mu_mix(const RealArrayLike& Y, const amrex::Real& T) const
-  {
-    amrex::Real mu = 0.;
-    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      mu += Y[spf] * mu_i(T, spf);
-    }
-    return mu;
   }
 
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real mu_mix(
     const RealArrayLike& Y,
     const amrex::Real& T,
-    const amrex::Real* cBoilT) const
+    const amrex::Real* cBoilT = nullptr) const
   {
     amrex::Real mu = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      mu += Y[spf] * mu_i(amrex::min(T, cBoilT[spf]), spf);
+      amrex::Real boil_temp =
+        (cBoilT != nullptr) ? cBoilT[spf] : AMREX_REAL_MAX;
+      mu += Y[spf] * mu_i(amrex::min(T, boil_temp), spf);
     }
     return mu;
-  }
-
-  template <typename RealArrayLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-  sigma_mix(const RealArrayLike& /*Y*/, const amrex::Real& /*T*/) const
-  {
-    return sigma;
   }
 
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real sigma_mix(
     const RealArrayLike& /*Y*/,
     const amrex::Real& /*T*/,
-    const amrex::Real* /*cBoilT*/) const
+    const amrex::Real* /*cBoilT*/ = nullptr) const
   {
     return sigma;
   }

--- a/Source/Spray/SprayProperties.H
+++ b/Source/Spray/SprayProperties.H
@@ -94,8 +94,8 @@ struct MPLiqProps
   // amrex::Real&
 
   template <typename RealArrayLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real critT_mix(
-    const RealArrayLike& Y) const
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  critT_mix(const RealArrayLike& Y) const
   {
     amrex::Real Tcrit = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
@@ -105,9 +105,8 @@ struct MPLiqProps
   }
 
   template <typename RealArrayLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real boilT_mix(
-    const RealArrayLike& Y, 
-    const amrex::Real* cBoilT) const
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  boilT_mix(const RealArrayLike& Y, const amrex::Real* cBoilT) const
   {
     amrex::Real Tboil = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
@@ -117,9 +116,8 @@ struct MPLiqProps
   }
 
   template <typename RealArrayLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real cp_mix(
-    const RealArrayLike& Y, 
-    const amrex::Real& T) const
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  cp_mix(const RealArrayLike& Y, const amrex::Real& T) const
   {
     amrex::Real Cp = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
@@ -130,7 +128,7 @@ struct MPLiqProps
 
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real cp_mix(
-    const RealArrayLike& Y, 
+    const RealArrayLike& Y,
     const amrex::Real& T,
     const amrex::Real* cBoilT) const
   {
@@ -214,7 +212,7 @@ struct MPLiqProps
     }
     return mu;
   }
-  
+
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
   sigma_mix(const RealArrayLike& /*Y*/, const amrex::Real& /*T*/) const
@@ -224,13 +222,12 @@ struct MPLiqProps
 
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real sigma_mix(
-    const RealArrayLike& /*Y*/, 
+    const RealArrayLike& /*Y*/,
     const amrex::Real& /*T*/,
     const amrex::Real* /*cBoilT*/) const
   {
     return sigma;
   }
-
 };
 
 // Struct of properties for GCM

--- a/Source/Spray/SprayProperties.H
+++ b/Source/Spray/SprayProperties.H
@@ -91,8 +91,8 @@ struct MPLiqProps
 
   // Mixture functions use RealArrayLike to allow for different types of arrays
   // with an [] operator that returns amrex::Real (or convertible to
-  // amrex::Real). Most mixture functions require amrex::Real* cBoilT parameter.
-  // Only rho_mix has optional cBoilT to allow dual calling patterns.
+  // amrex::Real). cBoilTLike is used in templated functions to allow both
+  // amrex::GpuArray and amrex::Real* types for boiling temperature arrays.
 
   // Helper function to get effective temperature considering boiling point
   template <typename cBoilTLike>

--- a/Source/Spray/SprayProperties.H
+++ b/Source/Spray/SprayProperties.H
@@ -90,8 +90,17 @@ struct MPLiqProps
   }
 
   // Mixture functions use RealArrayLike to allow for different types of arrays
-  // RealArrayLike can be anything with an [] operator that returns amrex::Real&
+  // with an [] operator that returns amrex::Real (or convertible to
+  // amrex::Real). Most mixture functions require amrex::Real* cBoilT parameter.
+  // Only rho_mix has optional cBoilT to allow dual calling patterns.
 
+  // Helper function to get effective temperature considering boiling point
+  template <typename cBoilTLike>
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real effectiveT(
+    const amrex::Real& T, const int spf, const cBoilTLike& cBoilT) const
+  {
+    return amrex::min(T, cBoilT[spf]);
+  }
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
   critT_mix(const RealArrayLike& Y) const
@@ -103,9 +112,9 @@ struct MPLiqProps
     return Tcrit;
   }
 
-  template <typename RealArrayLike>
+  template <typename RealArrayLike, typename cBoilTLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-  boilT_mix(const RealArrayLike& Y, const amrex::Real* cBoilT) const
+  boilT_mix(const RealArrayLike& Y, const cBoilTLike& cBoilT) const
   {
     amrex::Real Tboil = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
@@ -117,29 +126,32 @@ struct MPLiqProps
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real cp_mix(
     const RealArrayLike& Y,
-    const amrex::Real T,
-    const amrex::Real* cBoilT = nullptr) const
+    const amrex::Real& T,
+    const amrex::Real* cBoilT) const
   {
     amrex::Real Cp = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      amrex::Real boil_temp =
-        (cBoilT != nullptr) ? cBoilT[spf] : AMREX_REAL_MAX;
-      Cp += Y[spf] * cp_i(amrex::min(T, boil_temp), spf);
+      Cp += Y[spf] * cp_i(effectiveT(T, spf, cBoilT), spf);
     }
     return Cp;
   }
 
-  template <typename RealArrayLike>
+  // rho_mix can be called as rho_mix(Y,T) or rho_mix(Y,T,cBoilT)
+  template <
+    typename RealArrayLike,
+    typename cBoilTLike = amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM>>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real rho_mix(
     const RealArrayLike& Y,
-    const amrex::Real T,
-    const amrex::Real* cBoilT = nullptr) const
+    const amrex::Real& T,
+    const cBoilTLike& cBoilT = [] {
+      amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> arr;
+      arr.fill(AMREX_REAL_MAX);
+      return arr;
+    }()) const
   {
     amrex::Real rho = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      amrex::Real boil_temp =
-        (cBoilT != nullptr) ? cBoilT[spf] : AMREX_REAL_MAX;
-      rho += Y[spf] / rho_i(amrex::min(T, boil_temp), spf);
+      rho += Y[spf] / rho_i(effectiveT(T, spf, cBoilT), spf);
     }
     rho = 1. / rho;
     return rho;
@@ -148,14 +160,12 @@ struct MPLiqProps
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real lambda_mix(
     const RealArrayLike& Y,
-    const amrex::Real T,
-    const amrex::Real* cBoilT = nullptr) const
+    const amrex::Real& T,
+    const amrex::Real* cBoilT) const
   {
     amrex::Real lambda = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      amrex::Real boil_temp =
-        (cBoilT != nullptr) ? cBoilT[spf] : AMREX_REAL_MAX;
-      lambda += Y[spf] * lambda_i(amrex::min(T, boil_temp), spf);
+      lambda += Y[spf] * lambda_i(effectiveT(T, spf, cBoilT), spf);
     }
     return lambda;
   }
@@ -163,14 +173,12 @@ struct MPLiqProps
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real mu_mix(
     const RealArrayLike& Y,
-    const amrex::Real T,
-    const amrex::Real* cBoilT = nullptr) const
+    const amrex::Real& T,
+    const amrex::Real* cBoilT) const
   {
     amrex::Real mu = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      amrex::Real boil_temp =
-        (cBoilT != nullptr) ? cBoilT[spf] : AMREX_REAL_MAX;
-      mu += Y[spf] * mu_i(amrex::min(T, boil_temp), spf);
+      mu += Y[spf] * mu_i(effectiveT(T, spf, cBoilT), spf);
     }
     return mu;
   }
@@ -178,8 +186,8 @@ struct MPLiqProps
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real sigma_mix(
     const RealArrayLike& /*Y*/,
-    const amrex::Real /*T*/,
-    const amrex::Real* /*cBoilT*/ = nullptr) const
+    const amrex::Real& /*T*/,
+    const amrex::Real* /*cBoilT*/) const
   {
     return sigma;
   }

--- a/Source/Spray/SprayProperties.H
+++ b/Source/Spray/SprayProperties.H
@@ -89,8 +89,60 @@ struct MPLiqProps
            std::pow((critT_i(spf) - ref_T) / (critT_i(spf) - T), -0.38);
   }
 
+  // Mixture functions use RealArrayLike to allow for different types of arrays
   // RealArrayLike can be anything with an [] operator that returns
   // amrex::Real&
+
+  template <typename RealArrayLike>
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real critT_mix(
+    const RealArrayLike& Y, 
+    const amrex::Real& /*T*/) const
+  {
+    amrex::Real Tcrit = 0.;
+    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
+      Tcrit += Y[spf] * critT_i(spf);
+    }
+    return Tcrit;
+  }
+
+  template <typename RealArrayLike>
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real boilT_mix(
+    const RealArrayLike& Y, 
+    const amrex::Real& /*T*/,
+    const amrex::Real* cBoilT) const
+  {
+    amrex::Real Tboil = 0.;
+    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
+      Tboil += Y[spf] * cBoilT[spf];
+    }
+    return Tboil;
+  }
+
+  template <typename RealArrayLike>
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real cp_mix(
+    const RealArrayLike& Y, 
+    const amrex::Real& T) const
+  {
+    amrex::Real Cp = 0.;
+    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
+      Cp += Y[spf] * cp_i(T, spf);
+    }
+    return Cp;
+  }
+
+  template <typename RealArrayLike>
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real cp_mix(
+    const RealArrayLike& Y, 
+    const amrex::Real& T,
+    const amrex::Real* cBoilT) const
+  {
+    amrex::Real Cp = 0.;
+    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
+      Cp += Y[spf] * cp_i(amrex::min(T, cBoilT[spf]), spf);
+    }
+    return Cp;
+  }
+
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
   rho_mix(const RealArrayLike& Y, const amrex::Real& T) const
@@ -118,17 +170,60 @@ struct MPLiqProps
   }
 
   template <typename RealArrayLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real boilT_mix(
-    const RealArrayLike& Y, 
-    const amrex::Real& /*T*/,
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  lambda_mix(const RealArrayLike& Y, const amrex::Real& T) const
+  {
+    amrex::Real lambda = 0.;
+    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
+      lambda += Y[spf] * lambda_i(T, spf);
+    }
+    return lambda;
+  }
+
+  template <typename RealArrayLike>
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real lambda_mix(
+    const RealArrayLike& Y,
+    const amrex::Real& T,
     const amrex::Real* cBoilT) const
   {
-    amrex::Real Tboil = 0.;
+    amrex::Real lambda = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      Tboil += Y[spf] * cBoilT[spf];
+      lambda += Y[spf] * lambda_i(amrex::min(T, cBoilT[spf]), spf);
     }
-    return Tboil;
+    return lambda;
   }
+
+  template <typename RealArrayLike>
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  mu_mix(const RealArrayLike& Y, const amrex::Real& T) const
+  {
+    amrex::Real mu = 0.;
+    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
+      mu += Y[spf] * mu_i(T, spf);
+    }
+    return mu;
+  }
+
+  template <typename RealArrayLike>
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real mu_mix(
+    const RealArrayLike& Y,
+    const amrex::Real& T,
+    const amrex::Real* cBoilT) const
+  {
+    amrex::Real mu = 0.;
+    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
+      mu += Y[spf] * mu_i(amrex::min(T, cBoilT[spf]), spf);
+    }
+    return mu;
+  }
+  
+  template <typename RealArrayLike>
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  sigma_mix(const RealArrayLike& Y, const amrex::Real& T) const
+  {
+    return sigma;
+  }
+
 };
 
 // Struct of properties for GCM

--- a/Source/Spray/SprayProperties.H
+++ b/Source/Spray/SprayProperties.H
@@ -90,17 +90,8 @@ struct MPLiqProps
   }
 
   // Mixture functions use RealArrayLike to allow for different types of arrays
-  // with an [] operator that returns amrex::Real (or convertible to
-  // amrex::Real). cBoilTLike is used in templated functions to allow both
-  // amrex::GpuArray and amrex::Real* types for boiling temperature arrays.
+  // with an [] operator that returns amrex::Real
 
-  // Helper function to get effective temperature considering boiling point
-  template <typename cBoilTLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real effectiveT(
-    const amrex::Real& T, const int spf, const cBoilTLike& cBoilT) const
-  {
-    return amrex::min(T, cBoilT[spf]);
-  }
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
   critT_mix(const RealArrayLike& Y) const
@@ -112,9 +103,9 @@ struct MPLiqProps
     return Tcrit;
   }
 
-  template <typename RealArrayLike, typename cBoilTLike>
+  template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-  boilT_mix(const RealArrayLike& Y, const cBoilTLike& cBoilT) const
+  boilT_mix(const RealArrayLike& Y, const amrex::Real* cBoilT) const
   {
     amrex::Real Tboil = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
@@ -124,14 +115,13 @@ struct MPLiqProps
   }
 
   template <typename RealArrayLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real cp_mix(
-    const RealArrayLike& Y,
-    const amrex::Real& T,
-    const amrex::Real* cBoilT) const
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  cp_mix(const RealArrayLike& Y, const amrex::Real T, const amrex::Real* cBoilT)
+    const
   {
     amrex::Real Cp = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      Cp += Y[spf] * cp_i(effectiveT(T, spf, cBoilT), spf);
+      Cp += Y[spf] * cp_i(amrex::min(T, cBoilT[spf]), spf);
     }
     return Cp;
   }
@@ -139,11 +129,11 @@ struct MPLiqProps
   // rho_mix can be called as rho_mix(Y,T) or rho_mix(Y,T,cBoilT)
   template <
     typename RealArrayLike,
-    typename cBoilTLike = amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM>>
+    typename RealArrayLike2 = amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM>>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real rho_mix(
     const RealArrayLike& Y,
-    const amrex::Real& T,
-    const cBoilTLike& cBoilT = [] {
+    const amrex::Real T,
+    const RealArrayLike2& cBoilT = [] {
       amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> arr;
       arr.fill(AMREX_REAL_MAX);
       return arr;
@@ -151,7 +141,7 @@ struct MPLiqProps
   {
     amrex::Real rho = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      rho += Y[spf] / rho_i(effectiveT(T, spf, cBoilT), spf);
+      rho += Y[spf] / rho_i(amrex::min(T, cBoilT[spf]), spf);
     }
     rho = 1. / rho;
     return rho;
@@ -160,25 +150,24 @@ struct MPLiqProps
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real lambda_mix(
     const RealArrayLike& Y,
-    const amrex::Real& T,
+    const amrex::Real T,
     const amrex::Real* cBoilT) const
   {
     amrex::Real lambda = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      lambda += Y[spf] * lambda_i(effectiveT(T, spf, cBoilT), spf);
+      lambda += Y[spf] * lambda_i(amrex::min(T, cBoilT[spf]), spf);
     }
     return lambda;
   }
 
   template <typename RealArrayLike>
-  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real mu_mix(
-    const RealArrayLike& Y,
-    const amrex::Real& T,
-    const amrex::Real* cBoilT) const
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  mu_mix(const RealArrayLike& Y, const amrex::Real T, const amrex::Real* cBoilT)
+    const
   {
     amrex::Real mu = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
-      mu += Y[spf] * mu_i(effectiveT(T, spf, cBoilT), spf);
+      mu += Y[spf] * mu_i(amrex::min(T, cBoilT[spf]), spf);
     }
     return mu;
   }
@@ -186,7 +175,7 @@ struct MPLiqProps
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real sigma_mix(
     const RealArrayLike& /*Y*/,
-    const amrex::Real& /*T*/,
+    const amrex::Real /*T*/,
     const amrex::Real* /*cBoilT*/) const
   {
     return sigma;

--- a/Source/Spray/SprayProperties.H
+++ b/Source/Spray/SprayProperties.H
@@ -95,8 +95,7 @@ struct MPLiqProps
 
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real critT_mix(
-    const RealArrayLike& Y, 
-    const amrex::Real& /*T*/) const
+    const RealArrayLike& Y) const
   {
     amrex::Real Tcrit = 0.;
     for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
@@ -108,7 +107,6 @@ struct MPLiqProps
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real boilT_mix(
     const RealArrayLike& Y, 
-    const amrex::Real& /*T*/,
     const amrex::Real* cBoilT) const
   {
     amrex::Real Tboil = 0.;

--- a/Source/Spray/SprayProperties.H
+++ b/Source/Spray/SprayProperties.H
@@ -116,6 +116,19 @@ struct MPLiqProps
     rho = 1. / rho;
     return rho;
   }
+
+  template <typename RealArrayLike>
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real boilT_mix(
+    const RealArrayLike& Y, 
+    const amrex::Real& /*T*/,
+    const amrex::Real* cBoilT) const
+  {
+    amrex::Real Tboil = 0.;
+    for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
+      Tboil += Y[spf] * cBoilT[spf];
+    }
+    return Tboil;
+  }
 };
 
 // Struct of properties for GCM

--- a/Source/Spray/SprayProperties.H
+++ b/Source/Spray/SprayProperties.H
@@ -219,7 +219,16 @@ struct MPLiqProps
   
   template <typename RealArrayLike>
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-  sigma_mix(const RealArrayLike& Y, const amrex::Real& T) const
+  sigma_mix(const RealArrayLike& /*Y*/, const amrex::Real& /*T*/) const
+  {
+    return sigma;
+  }
+
+  template <typename RealArrayLike>
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real sigma_mix(
+    const RealArrayLike& /*Y*/, 
+    const amrex::Real& /*T*/,
+    const amrex::Real* /*cBoilT*/) const
   {
     return sigma;
   }


### PR DESCRIPTION
This PR creates mixture property functions within the MPLiqProps struct for the following:

- boiling point `boilT_mix`
- critical temp `critT_mix`
- specific heat `cp_mix`
- thermal conductivity `lambda_mix`
- dynamic viscosity `mu_mix`
- surface tension `sigma_mix`

Note that `rho_mix` was included in #602.  Managing the mixture averaged molecular weight of the spray is still a work in progress and not included here.