### PR TITLE
Add -Y to PMF generator and additional ../ to paths

### DIFF
--- a/Docs/sphinx/Utility.rst
+++ b/Docs/sphinx/Utility.rst
@@ -34,17 +34,17 @@ Generating a PMF file
 
 The script ``cantera_pmf_generator.py`` solves a 1D unstrained premixed flame using `Cantera <https://doi.org/10.5281/zenodo.6387882>`_ and saves it in the appropriate file format for use by the Pele codes. To use this script, first follow the :ref:`CEPTR instructions <sec_ceptr_software>` for setting up ``poetry``. Then return to the ``Utility/PMF/`` directory and run the script: ::
 
-  poetry -C ../../Support/ceptr/ run python cantera_pmf_generator.py -m dodecane_lu -f NC12H26 -d 0.01 -o ./
+  poetry -C ../../../Support/ceptr/ run python cantera_pmf_generator.py -m dodecane_lu -f NC12H26 -d 0.01 -o ./
 
 This example computes a dodecane/air flame using the ``dodecane_lu`` mechanism on a 0.01 m domain, and saves the resulting file to the present directory. You may choose any mechanism included with PelePhysics, as the Cantera ``.yaml`` format is included for all mechanisms. If you choose a reduced mechanism with QSS species, the 1D solution will be obtained using the skeletal version of the mechanism without QSS species being remove, as Cantera does not support QSS by default. In this case, the script will also save a data file with QSS species removed (ending in ``-qssa-removed.dat``) that is suitable for use with the QSS mechanisms in Pele. A range of additional conditions may be specified at the command line. To see the full set of options, use the help feature: ::
 
-  poetry -C ../../Support/ceptr/ run python cantera_pmf_generator.py --help
+  poetry -C ../../../Support/ceptr/ run python cantera_pmf_generator.py --help
 
 Note that when running Cantera, you may need to adjust the domain size to be appropriate for your conditions in order for the solver to converge. At times, you may also need to adjust the solver tolerances and other parameters that are specified within the script.
 
 An additional script is provided to allow plotting of the PMF solutions. This script is used as follows (if no variable index is specified, temperature is plotted by default): ::
 
-  poetry -C ../../Support/ceptr/ run python plotPMF.py <pmf-file> <variable-index>
+  poetry -C ../../../Support/ceptr/ run python plotPMF.py <pmf-file> <variable-index>
 
 .. _sec_turbinflow:
 

--- a/Source/Utility/PMF/cantera_pmf_generator.py
+++ b/Source/Utility/PMF/cantera_pmf_generator.py
@@ -161,11 +161,9 @@ if Y_species is None:
     gas.set_equivalence_ratio(phi, fuel_species, ox_species, basis="mole")
 else:
     gas.TPY = tin, p, Y_species
-    species_names = gas.species_names
-    mass_fractions = gas.Y  
     print("\nMass fractions read into Cantera:")
-    for k in range(len(gas.Y)):
-        print(f"  {species_names[k]}: {mass_fractions[k]}")
+    for spec, massfrac in zip(gas.species_names, gas.Y):
+        print(f"  {spec}: {massfrac}")
 
 # Create the free laminar premixed flame
 f = FreeFlame(gas, initial_grid)

--- a/Source/Utility/PMF/cantera_pmf_generator.py
+++ b/Source/Utility/PMF/cantera_pmf_generator.py
@@ -102,7 +102,11 @@ refine_grid = True  # True to enable refinement
 
 # Print information
 label_pre = "pmf-" + mechanism
-label = fuel_species.split(":")[0] + "_PHI" + str(phi) + "_T" + str(tin) + "_P" + str(p)
+if Y_species is not None:
+    num_input_species = len([item for item in Y_species.split(',') if ':' in item])
+    label = "Y" + str(num_input_species) + "_T" + str(tin) + "_P" + str(p)
+else:
+    label = fuel_species.split(":")[0] + "_PHI" + str(phi) + "_T" + str(tin) + "_P" + str(p)
 
 #################
 # Find mechanism in PelePhysics

--- a/Source/Utility/PMF/cantera_pmf_generator.py
+++ b/Source/Utility/PMF/cantera_pmf_generator.py
@@ -31,7 +31,7 @@ parser.add_argument(
     help="Name of PelePhysics mechanism from Mechanisms",
 )
 parser.add_argument(
-    "-pp", "--pp_home", default="../../", help="Path to PelePhysics directory"
+    "-pp", "--pp_home", default="../../../", help="Path to PelePhysics directory"
 )
 parser.add_argument(
     "-f", "--fuel", default="CH4:1", help="Fuel stream mole-basis Cantera composition"
@@ -41,6 +41,12 @@ parser.add_argument(
     "--oxidizer",
     default="O2:1, N2:3.76",
     help="Oxidizer stream mole-basis Cantera composition",
+)
+parser.add_argument(
+    "-Y",
+    "--massfrac",
+    default=None,
+    help="String of mass fractions (overrides -f and -ox options)",
 )
 parser.add_argument(
     "-T",
@@ -74,6 +80,7 @@ args = parser.parse_args()
 mechanism = args.mechanism
 fuel_species = args.fuel
 ox_species = args.oxidizer
+Y_species = args.massfrac
 
 # General
 p = args.pressure  # pressure [Pa]
@@ -149,8 +156,16 @@ mech_path = os.path.join(pp_path, mech_path)
 
 # Set gas state to that of the unburned gas
 gas = Solution(mech_path, "gas")
-gas.TP = tin, p
-gas.set_equivalence_ratio(phi, fuel_species, ox_species, basis="mole")
+if Y_species is None:
+    gas.TP = tin, p
+    gas.set_equivalence_ratio(phi, fuel_species, ox_species, basis="mole")
+else:
+    gas.TPY = tin, p, Y_species
+    species_names = gas.species_names
+    mass_fractions = gas.Y  
+    print("\nMass fractions read into Cantera:")
+    for k in range(len(gas.Y)):
+        print(f"  {species_names[k]}: {mass_fractions[k]}")
 
 # Create the free laminar premixed flame
 f = FreeFlame(gas, initial_grid)


### PR DESCRIPTION
This PR adds an option to read mass fractions into the PMF generator script. Additionally, the paths must have changed since this file and documentation were created as all paths needed another `../` appended to them.