### PR TITLE
Spray validation updates for Manifold EOS

### DIFF
--- a/Source/Eos/EosParams.H
+++ b/Source/Eos/EosParams.H
@@ -47,6 +47,7 @@ struct EosParm<Manifold>
   int idx_T{0};
   int idx_Wdot[MANIFOLD_DIM];
   int idx_Cp{-1};
+  int idx_Cp_fuel{-1};
   int is_variance_of[MANIFOLD_DIM];
   int verbose{1};
   bool has_mani_src{true};
@@ -121,11 +122,12 @@ struct InitParm<eos::EosParm<eos::Manifold>>
     pp.query("has_mani_src", parm_in->m_h_parm.has_mani_src);
     pp.get("compute_temperature", parm_in->m_h_parm.compute_temperature);
 
+    bool required = false;
 #ifdef PELE_USE_SPRAY
-    parm_in->m_h_parm.idx_Cp = get_var_index("CP", h_manf_data_in);
-#else
-    parm_in->m_h_parm.idx_Cp = get_var_index("CP", h_manf_data_in, false);
+    required = true;
 #endif
+    parm_in->m_h_parm.idx_Cp = get_var_index("CP", h_manf_data_in, required);
+    parm_in->m_h_parm.idx_Cp_fuel = get_var_index("CP_fuel", h_manf_data_in, required);
 
     // Molecular weights and indices of chemical species if requested
     pp.query("has_species_mw", parm_in->m_h_parm.has_species_mw);

--- a/Source/Eos/EosParams.H
+++ b/Source/Eos/EosParams.H
@@ -127,7 +127,8 @@ struct InitParm<eos::EosParm<eos::Manifold>>
     required = true;
 #endif
     parm_in->m_h_parm.idx_Cp = get_var_index("CP", h_manf_data_in, required);
-    parm_in->m_h_parm.idx_Cp_fuel = get_var_index("CP_fuel", h_manf_data_in, required);
+    parm_in->m_h_parm.idx_Cp_fuel =
+      get_var_index("CP_fuel", h_manf_data_in, required);
 
     // Molecular weights and indices of chemical species if requested
     pp.query("has_species_mw", parm_in->m_h_parm.has_species_mw);

--- a/Source/Eos/Manifold.H
+++ b/Source/Eos/Manifold.H
@@ -97,7 +97,7 @@ struct Manifold
   AMREX_FORCE_INLINE
   void Y2GenericManifoldData(
     const amrex::Real* Y, // manifold variables (z,c etc)
-    const int* table_idx,       // Indices of the table columns
+    const int* table_idx, // Indices of the table columns
     amrex::Real* out_vars,
     const int num_of_indices // len of table_idx
   )

--- a/Source/Eos/Manifold.H
+++ b/Source/Eos/Manifold.H
@@ -97,9 +97,9 @@ struct Manifold
   AMREX_FORCE_INLINE
   void Y2GenericManifoldData(
     const amrex::Real* Y, // manifold variables (z,c etc)
-    int* table_idx,       // Indices of the table columns
+    const int* table_idx,       // Indices of the table columns
     amrex::Real* out_vars,
-    int num_of_indices // len of table_idx
+    const int num_of_indices // len of table_idx
   )
   {
     manfunc.get_func()->get_values(num_of_indices, table_idx, Y, out_vars);

--- a/Source/Spray/Drag.H
+++ b/Source/Spray/Drag.H
@@ -386,7 +386,7 @@ calculateSpraySource(
 #ifdef USE_MANIFOLD_EOS
     // Hack: manifold model may inaccurately predict temperature in skin layer
     // to improve predictions, adjust computed transport coefficients to the
-    // skin layer temperature using a simple teperature scaling based on
+    // skin layer temperature using a simple temperature scaling based on
     // Sutherland's law. Rho also needs to be modified (uses ideal gas law)
     amrex::Real T_skin_predicted = 300.0;
     eos.HY2T(0.0, Y_skin.data(), T_skin_predicted);

--- a/Source/Spray/Drag.H
+++ b/Source/Spray/Drag.H
@@ -383,6 +383,25 @@ calculateSpraySource(
 
     mu_skin *= SprayUnits::mu_conv;
     lambda_skin *= SprayUnits::lambda_conv;
+#ifdef USE_MANIFOLD_EOS
+    // Hack: manifold model may inaccurately predict temperature in skin layer
+    // to improve predictions, adjust computed transport coefficients to the
+    // skin layer temperature using a simple teperature scaling based on
+    // Sutherland's law. Rho also needs to be modified (uses ideal gas law)
+    amrex::Real T_skin_predicted = 300.0;
+    eos.HY2T(0.0, Y_skin.data(), T_skin_predicted);
+    const amrex::Real temp_ratio = T_skin / T_skin_predicted;
+    const amrex::Real sutherland_temp = 110.4;
+    const amrex::Real sutherland_ratio = std::sqrt(temp_ratio) * temp_ratio *
+                                         (T_skin_predicted + sutherland_temp) /
+                                         (T_skin + sutherland_temp);
+    mu_skin *= sutherland_ratio;
+    lambda_skin *= sutherland_ratio;
+    for (int spf = 0; spf < NUM_SPECIES; ++spf) {
+      Ddiag[spf] *= sutherland_ratio; // / mw_skin * gpv.mw[spf];
+    }
+    rho_skin /= temp_ratio;
+#endif
     amrex::RealVect diff_vel = gpv.vel_fluid - vel_part;
     amrex::Real diff_vel_mag = diff_vel.vectorLength();
     // Local Reynolds number
@@ -459,7 +478,11 @@ calculateSpraySource(
         eos.TY2Cp(T_skin, Y_fuel_skin.data(), cp_fuel);
 #else
         // Manifold EOS: for now, just taking mixture Cp rather than Fuel Cp
-        eos.TY2Cp(T_skin, Y_skin.data(), cp_fuel);
+        eos.Y2GenericManifoldData(
+          Y_skin.data(), &(fdat.eosparm->idx_Cp_fuel), &cp_fuel, 1);
+        // TODO: account for variation between table temperature and skin
+        // temperature
+        //  cp_fuel = 1e7 + (cp_fuel - 1e7) * T_skin / T_skin_predicted;
 #endif
         cp_fuel *= SprayUnits::eng_conv;
 
@@ -472,7 +495,6 @@ calculateSpraySource(
         amrex::Real ratio = cp_fuel * Sh_num * rhoDtotal / lambda_skin;
 
         Nu_num = calcHeatCoeff(ratio, B_M, B_eps, C_eps, Nu_0);
-
         for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
           // Species index
           const int fspec = fdat.indx[spf];

--- a/Source/Spray/Drag.H
+++ b/Source/Spray/Drag.H
@@ -398,7 +398,7 @@ calculateSpraySource(
     mu_skin *= sutherland_ratio;
     lambda_skin *= sutherland_ratio;
     for (int spf = 0; spf < NUM_SPECIES; ++spf) {
-      Ddiag[spf] *= sutherland_ratio; // / mw_skin * gpv.mw[spf];
+      Ddiag[spf] *= sutherland_ratio;
     }
     rho_skin /= temp_ratio;
 #endif

--- a/Source/Spray/Drag.H
+++ b/Source/Spray/Drag.H
@@ -477,7 +477,6 @@ calculateSpraySource(
         }
         eos.TY2Cp(T_skin, Y_fuel_skin.data(), cp_fuel);
 #else
-        // Manifold EOS: for now, just taking mixture Cp rather than Fuel Cp
         eos.Y2GenericManifoldData(
           Y_skin.data(), &(fdat.eosparm->idx_Cp_fuel), &cp_fuel, 1);
         // TODO: account for variation between table temperature and skin


### PR DESCRIPTION
Supersedes #628

Correct the skin properties using a scaling based on Sutherland's law for Transport properties to better account for actual skin temperature. Use Cp_fuel where needed (rather than previously using Cp_mixture). Ideally we should apply some temperature correction on Cp_fuel as well, but for now the validation is pretty good without it for the Wong-Lin case (which had poor validation before).

Requires https://github.com/NREL/cmlm/pull/23

Here's the Wong-Lin case with these updates (both actually using MP/antoine, the GCM label is using Manifold EOS):
<img width="1272" height="479" alt="Screenshot 2025-10-29 at 3 53 19 PM" src="https://github.com/user-attachments/assets/6d880b7e-8437-4a42-93e8-7a54a2b08b97" />

TODO:
- [ ] Document spray+manifold capability approach and validation
- [x] Corresponding modification to https://github.com/AMReX-Combustion/PeleLMeX/pull/571
- [ ] Fix indexing for diffusion coefficients in `Drag.H`