### PR TITLE
Correct handling of third-body concentration in falloff reactions [issue #579]

### DIFF
--- a/Source/Reactions/ReactorCvode.cpp
+++ b/Source/Reactions/ReactorCvode.cpp
@@ -1560,7 +1560,7 @@ ReactorCvode::react(
   BL_PROFILE_VAR_STOP(AsyncCopy);
 
 #ifdef AMREX_USE_OMP
-  Gpu::Device::streamSynchronize();
+  amrex::Gpu::Device::streamSynchronize();
 #endif
 
   // Setup tolerances with typical values
@@ -1583,7 +1583,7 @@ ReactorCvode::react(
 #endif
 
 #ifdef AMREX_USE_OMP
-  Gpu::Device::streamSynchronize();
+  amrex::Gpu::Device::streamSynchronize();
 #endif
 
   // Get the result back

--- a/Support/ceptr/ceptr/jacobian.py
+++ b/Support/ceptr/ceptr/jacobian.py
@@ -609,7 +609,11 @@ def ajac_reaction_d(
         beta = plog_beta
         ae = (plog_ae * cc.ureg.joule / cc.ureg.kmol).to(aeuc)
     elif third_body and not falloff and plog:
-        # Case 5 third body PLOG
+        # Case 5 TB, PLOG
+        cw.writer(
+            fstream,
+            cw.comment("a third-body, non-pressure-fall-off, and PLOG reaction"),
+        )
         ctuc = cu.prefactor_units(cc.ureg("kmol/m**3"), -dim)
         plog_pef, plog_beta, plog_ae = cu.evaluate_plog(
             reaction.rate.rates, mechanism.P
@@ -677,30 +681,32 @@ def ajac_reaction_d(
     if reaction.third_body:
         if len(reaction.third_body.efficiencies) == 1:
             if isclose(reaction.third_body.default_efficiency, 0.0):
-                all_reactants = dict(
-                    sum(
-                        (
-                            Counter(x)
-                            for x in [
-                                all_reactants,
-                                reaction.third_body.efficiencies,
-                            ]
-                        ),
-                        Counter(),
+                # Do not update third-body falloff reactions
+                if not (reaction.rate.type == "falloff"):
+                    all_reactants = dict(
+                        sum(
+                            (
+                                Counter(x)
+                                for x in [
+                                    all_reactants,
+                                    reaction.third_body.efficiencies,
+                                ]
+                            ),
+                            Counter(),
+                        )
                     )
-                )
-                all_products = dict(
-                    sum(
-                        (
-                            Counter(x)
-                            for x in [
-                                all_products,
-                                reaction.third_body.efficiencies,
-                            ]
-                        ),
-                        Counter(),
+                    all_products = dict(
+                        sum(
+                            (
+                                Counter(x)
+                                for x in [
+                                    all_products,
+                                    reaction.third_body.efficiencies,
+                                ]
+                            ),
+                            Counter(),
+                        )
                     )
-                )
 
     # Build rea_dict containing reaction species
     for symbol, coefficient in all_reactants.items():
@@ -786,6 +792,13 @@ def ajac_reaction_d(
             syms=None,
         )
         cw.writer(fstream, f"alpha = {enhancement_d};")
+        if (
+            falloff
+            and len(reaction.third_body.efficiencies) == 1
+            and isclose(reaction.third_body.default_efficiency, 0.0)
+        ):
+            # Avoid float point exception
+            cw.writer(fstream, "alpha = std::max(alpha, 1e-20);")
 
     # forward
     qss_ps = cu.qss_sorted_phase_space(
@@ -1413,6 +1426,15 @@ def denhancement_d(mechanism, species_info, reaction, kid, cons_p):
             return "0"
     else:
         efficiencies = reaction.third_body.efficiencies
+        if (
+            falloff
+            and len(reaction.third_body.efficiencies) == 1
+            and isclose(reaction.third_body.default_efficiency, 0.0)
+        ):
+            # Revise the efficiencies for Jacobian
+            for symbol in species_info.all_species_list:
+                if symbol not in efficiencies:
+                    efficiencies[symbol] = 0.0
         if cons_p:
             for _, (symbol, efficiency) in enumerate(efficiencies.items()):
                 if species_info.ordered_idx_map[symbol] == kid:

--- a/Support/ceptr/ceptr/production.py
+++ b/Support/ceptr/ceptr/production.py
@@ -229,7 +229,7 @@ def production_rate(
                 beta = plog_beta
                 ae = (plog_ae * cc.ureg.joule / cc.ureg.kmol).to(aeuc)
             elif third_body and not falloff and plog:
-                # Case 5 third body PLOG
+                # Case 5 TB, PLOG
                 ctuc = cu.prefactor_units(cc.ureg("kmol/m**3"), -dim)
                 plog_pef, plog_beta, plog_ae = cu.evaluate_plog(
                     reaction.rate.rates, mechanism.P
@@ -306,14 +306,23 @@ def production_rate(
                 and len(reaction.third_body.efficiencies) == 1
                 and isclose(reaction.third_body.default_efficiency, 0.0)
             ):
+                # TB of A + B + C = AB + C
                 cw.writer(fstream, f"qf[{idx}] *= k_f;")
             elif not falloff:
                 alpha = enhancement_d_with_qss(mechanism, species_info, reaction)
                 cw.writer(fstream, f"Corr  = {alpha};")
                 cw.writer(fstream, f"qf[{idx}] *= Corr * k_f;")
             else:
+                # Falloff, TB
                 alpha = enhancement_d_with_qss(mechanism, species_info, reaction)
                 cw.writer(fstream, f"Corr  = {alpha};")
+                if (
+                    falloff
+                    and len(reaction.third_body.efficiencies) == 1
+                    and isclose(reaction.third_body.default_efficiency, 0.0)
+                ):
+                    # Avoid float point exception?
+                    cw.writer(fstream, f"Corr = std::max(Corr, 1e-20);")
                 cw.writer(
                     fstream,
                     "redP = Corr / k_f *"
@@ -622,7 +631,7 @@ def production_rate(
                 beta = plog_beta
                 ae = (plog_ae * cc.ureg.joule / cc.ureg.kmol).to(aeuc)
             elif third_body and not falloff and plog:
-                # Case 5 third body PLOG
+                # Case 5 TB, PLOG
                 ctuc = cu.prefactor_units(cc.ureg("kmol/m**3"), -dim)
                 plog_pef, plog_beta, plog_ae = cu.evaluate_plog(
                     reaction.rate.rates, mechanism.P
@@ -737,6 +746,13 @@ def production_rate(
                 )
                 cw.writer(fstream, f"amrex::Real Corr = {alpha};")
                 corr_smp = alpha_smp
+                if (
+                    falloff
+                    and len(reaction.third_body.efficiencies) == 1
+                    and isclose(reaction.third_body.default_efficiency, 0.0)
+                ):
+                    # Avoid float point exception?
+                    cw.writer(fstream, f"Corr = std::max(Corr, 1e-20);")
                 cw.writer(
                     fstream,
                     "const amrex::Real redP = Corr / k_f *"
@@ -1584,6 +1600,60 @@ def enhancement_d_with_qss(mechanism, species_info, reaction, syms=None):
             return f"sc[{species_info.ordered_idx_map[species]}]"
 
     efficiencies = reaction.third_body.efficiencies
+
+    if (
+        falloff
+        and len(reaction.third_body.efficiencies) == 1
+        and isclose(reaction.third_body.default_efficiency, 0.0)
+    ):
+        alpha = []
+        if record_symbolic_operations:
+            alpha_smp = []
+        symbol = list(efficiencies.keys())[0]
+        efficiency = efficiencies[symbol]
+        if symbol not in species_info.qssa_species_list:
+            factor = f"({efficiency:.15g})"
+            if record_symbolic_operations:
+                factor_smp = efficiency
+            conc = f"sc[{species_info.ordered_idx_map[symbol]}]"
+            if record_symbolic_operations:
+                conc_smp = syms.sc_smp[species_info.ordered_idx_map[symbol]]
+            if efficiency == 1:
+                alpha.append(f"{conc}")
+                if record_symbolic_operations:
+                    alpha_smp.append(conc_smp)
+            else:
+                alpha.append(f"{factor}*{conc}")
+                if record_symbolic_operations:
+                    alpha_smp.append(factor_smp * conc_smp)
+        else:
+            factor = f"({efficiency:.15g})"
+            if record_symbolic_operations:
+                factor_smp = efficiency
+            if (efficiency) != 0:
+                idx = species_info.ordered_idx_map[symbol] - species_info.n_species
+                conc = f"sc_qss[{idx}]"
+                if record_symbolic_operations:
+                    conc_smp = syms.sc_qss_smp[
+                        species_info.ordered_idx_map[symbol] - species_info.n_species
+                    ]
+                if (efficiency) == 1:
+                    alpha.append(f"{conc}")
+                    if record_symbolic_operations:
+                        alpha_smp.append(conc_smp)
+                else:
+                    alpha.append(f"{factor}*{conc}")
+                    if record_symbolic_operations:
+                        alpha_smp.append(factor_smp * conc_smp)
+    
+        if record_symbolic_operations:
+            alpha_val = alpha_smp[0]
+            enhancement_smp = 0.0 + alpha_val
+            return " + ".join(alpha).replace("+ -", "- "), enhancement_smp
+        else:
+            return " + ".join(alpha).replace("+ -", "- ") 
+        
+
     alpha = ["mixture"]
     if record_symbolic_operations:
         alpha_smp = [syms.mixture_smp]

--- a/Support/ceptr/ceptr/qssa_converter.py
+++ b/Support/ceptr/ceptr/qssa_converter.py
@@ -2830,20 +2830,22 @@ def qssa_return_coeff(mechanism, species_info, reaction, reagents, syms):
     if reaction.third_body:
         if len(reaction.third_body.efficiencies) == 1:
             if isclose(reaction.third_body.default_efficiency, 0.0):
-                reagents = copy.deepcopy(
-                    dict(
-                        sum(
-                            (
-                                Counter(x)
-                                for x in [
-                                    reagents,
-                                    reaction.third_body.efficiencies,
-                                ]
-                            ),
-                            Counter(),
+                if not (reaction.rate.type == "falloff"):
+                    # Skip for third-body falloff reactions with single M
+                    reagents = copy.deepcopy(
+                        dict(
+                            sum(
+                                (
+                                    Counter(x)
+                                    for x in [
+                                        reagents,
+                                        reaction.third_body.efficiencies,
+                                    ]
+                                ),
+                                Counter(),
+                            )
                         )
                     )
-                )
 
     phi = []
     phi_smp = []

--- a/Support/ceptr/ceptr/utilities.py
+++ b/Support/ceptr/ceptr/utilities.py
@@ -35,20 +35,22 @@ def qss_sorted_phase_space(mechanism, species_info, reaction, reagents, syms=Non
     if reaction.third_body:
         if len(reaction.third_body.efficiencies) == 1:
             if isclose(reaction.third_body.default_efficiency, 0.0):
-                reagents = copy.deepcopy(
-                    dict(
-                        sum(
-                            (
-                                Counter(x)
-                                for x in [
-                                    reagents,
-                                    reaction.third_body.efficiencies,
-                                ]
-                            ),
-                            Counter(),
+                if not (reaction.rate.type == "falloff"):
+                    # Skip for third-body falloff reactions with single M
+                    reagents = copy.deepcopy(
+                        dict(
+                            sum(
+                                (
+                                    Counter(x)
+                                    for x in [
+                                        reagents,
+                                        reaction.third_body.efficiencies,
+                                    ]
+                                ),
+                                Counter(),
+                            )
                         )
                     )
-                )
     phi = []
     if record_symbolic_operations:
         phi_smp = []
@@ -416,6 +418,42 @@ def enhancement_d(mechanism, species_info, reaction, syms=None):
             return f"sc[{species_info.ordered_idx_map[species]}]"
 
     efficiencies = reaction.third_body.efficiencies
+
+    if (
+        falloff
+        and len(reaction.third_body.efficiencies) == 1
+        and isclose(reaction.third_body.default_efficiency, 0.0)
+    ):
+        alpha = []
+        if record_symbolic_operations:
+            alpha_smp = []
+        symbol = list(efficiencies.keys())[0]
+        efficiency = efficiencies[symbol]
+        if symbol not in species_info.qssa_species_list:
+            factor = f"( {efficiency:.15g})"
+            if record_symbolic_operations:
+                factor_smp = efficiency
+            if (efficiency) != 0:
+                conc = f"sc[{species_info.ordered_idx_map[symbol]}]"
+                if record_symbolic_operations:
+                    conc_smp = syms.sc_smp[species_info.ordered_idx_map[symbol]]
+                if (efficiency) == 1:
+                    alpha.append(f"{conc}")
+                    if record_symbolic_operations:
+                        alpha_smp.append(conc_smp)
+                else:
+                    alpha.append(f"{factor}*{conc}")
+                    if record_symbolic_operations:
+                        factor_smp = syms.convert_symb_to_int(factor_smp)
+                        alpha_smp.append(factor_smp * conc_smp)
+
+        if record_symbolic_operations:
+            enhancement_smp = 0.0 + alpha_smp[0]
+            enhancement_smp = syms.convert_symb_to_int(enhancement_smp)
+            return " + ".join(alpha).replace("+ -", "- "), enhancement_smp
+        else:
+            return " + ".join(alpha).replace("+ -", "- ")
+
     alpha = ["mixture"]
     if record_symbolic_operations:
         alpha_smp = [syms.mixture_smp]


### PR DESCRIPTION
This pull request aims to resolve the issues reported in #579 in handling of the three-body falloff reactions of type A + B + C <=> AB + C, where C represents a species like N2. 

Specifically, I have made the following updates in my recent two commits:

1. Add an `if not (reaction.rate.type == "falloff"):` in the block to avoid update of the reactant or product for normal three-body Arrhenius reactions.
 
  ```
  if reaction.third_body:        
      if len(reaction.third_body.efficiencies) == 1:
          if isclose(reaction.third_body.default_efficiency, 0.0):
              # Donot update threebody falloff reactions
              if not (reaction.rate.type == "falloff"):
                 all_reactants = ...
                 all_products = ...
                 reagents = copy.deepcopy(...
  ```

2. Update the three-body efficiencies for three-body falloff reactions of type A + B + C <=> AB + C.
```
# three-body-Arrhenius + falloff
efficiencies = reaction.third_body.efficiencies
if (
    falloff 
    and len(reaction.third_body.efficiencies) == 1
    and isclose(reaction.third_body.default_efficiency, 0.0)
):
    for symbol in species_info.all_species_list:
        if symbol not in efficiencies:
            efficiencies[symbol] = 0.0
```

3. Add statements like `cw.writer(fstream, f"alpha = std::max(alpha, 1e-16);")` to avoid float-point exceptions. However, I am not sure whether this will have a big influence on the convergencies.

It is noted that I would like to reuse the existing code as much as possible. Therefore, the generated mechanism.H is not optimized, where a better implementation may be available. For instance, in the present implementation, the generated `Corr` writes like
```
Corr = mixture + (-1) * sc[0] + (-1) * sc[1] + (-1) * sc[2] + (-1) * sc[3] +
         (-1) * sc[4] + (-1) * sc[5] + (-1) * sc[6] + (-1) * sc[8] +
         (-1) * sc[9] + (-1) * sc[10] + (-1) * sc[11] + (-1) * sc[12] +
         (-1) * sc[13] + (-1) * sc[14] + (-1) * sc[15] + (-1) * sc[16] +
         (-1) * sc[17] + (-1) * sc[18] + (-1) * sc[19] + (-1) * sc[20] +
         (-1) * sc[21] + (-1) * sc[22] + (-1) * sc[23] + (-1) * sc[24] +
         (-1) * sc[25] + (-1) * sc[26] + (-1) * sc[27] + (-1) * sc[28] +
         (-1) * sc[29] + (-1) * sc[30] + (-1) * sc[31] + (-1) * sc[32] +
         (-1) * sc[33] + (-1) * sc[34] + (-1) * sc[35] + (-1) * sc[36] +
         (-1) * sc[37] + (-1) * sc[38] + (-1) * sc[39] + (-1) * sc[40] +
         (-1) * sc[41] + (-1) * sc[42] + (-1) * sc[43] + (-1) * sc[44] +
         (-1) * sc[45] + (-1) * sc[46] + (-1) * sc[47] + (-1) * sc[48] +
         (-1) * sc[49] + (-1) * sc[50] + (-1) * sc[51] + (-1) * sc[52] +
         (-1) * sc[53] + (-1) * sc[54] + (-1) * sc[55] + (-1) * sc[56] +
         (-1) * sc[57] + (-1) * sc[58] + (-1) * sc[59] + (-1) * sc[60];

```
which is equivalent to
```
Corr = sc[7];
```
I'm not familiar with parsing simplification, so I just left it as is.