### PR TITLE
Enable compiling Manifold + SYCL

### DIFF
--- a/Source/Eos/EOS.H
+++ b/Source/Eos/EOS.H
@@ -13,9 +13,7 @@
 #include "GammaLaw.H"
 #include "Fuego.H"
 #include "SRK.H"
-#ifndef AMREX_USE_SYCL
 #include "Manifold.H"
-#endif
 
 namespace pele::physics {
 #ifdef USE_GAMMALAW_EOS
@@ -24,7 +22,7 @@ using EosType = eos::GammaLaw;
 using EosType = eos::Fuego;
 #elif USE_SRK_EOS
 using EosType = eos::SRK;
-#elif USE_MANIFOLD_EOS && !defined(AMREX_USE_SYCL)
+#elif USE_MANIFOLD_EOS
 using EosType = eos::Manifold;
 #else
 static_assert(false, "Invalid EOS specified");
@@ -148,7 +146,6 @@ chemSpeciesNames(
   CKSYMS_STR(chemspn);
 }
 
-#ifndef AMREX_USE_SYCL
 template <>
 inline void
 speciesNames<Manifold>(
@@ -207,7 +204,6 @@ chemSpeciesNames<Manifold>(
     chemspn.push_back(amrex::trim(nametmp.substr(2U, std::string::npos)));
   }
 }
-#endif
 
 } // namespace eos
 } // namespace pele::physics

--- a/Source/Eos/EosParams.H
+++ b/Source/Eos/EosParams.H
@@ -34,7 +34,6 @@ struct EosParm<GammaLaw>
 #define MANIFOLD_DIM 1
 #endif
 
-#ifndef AMREX_USE_SYCL
 template <>
 struct EosParm<Manifold>
 {
@@ -56,7 +55,6 @@ struct EosParm<Manifold>
   int* idx_chemspecies;
   int num_chemspecies;
 };
-#endif
 
 } // namespace eos
 
@@ -80,7 +78,6 @@ struct InitParm<eos::EosParm<eos::GammaLaw>>
   }
 };
 
-#ifndef AMREX_USE_SYCL
 template <>
 struct HostOnlyParm<eos::EosParm<eos::Manifold>>
 {
@@ -298,6 +295,9 @@ struct InitParm<eos::EosParm<eos::Manifold>>
         parm_in->m_h_parm.is_variance_of[idim] = -1;
       }
     }
+    if (verbose > 0) {
+      amrex::Print() << "Completed initialization of Manifold EOS\n";
+    }
   }
 
   static void host_deallocate(PeleParams<eos::EosParm<eos::Manifold>>* parm_in)
@@ -310,7 +310,6 @@ struct InitParm<eos::EosParm<eos::Manifold>>
     }
   }
 };
-#endif
 
 } // namespace pele::physics
 #endif

--- a/Source/PelePhysicsConstraints.H
+++ b/Source/PelePhysicsConstraints.H
@@ -50,7 +50,6 @@ struct is_valid_physics_combination<eos::SRK, transport::SutherlandTransport>
 
 // Manifold Transport doesn't apply except with Manifold EOS
 // Manifold EOS requires Manifold or Constant Transport
-#ifndef AMREX_USE_SYCL
 template <typename EosModel>
 struct is_valid_physics_combination<EosModel, transport::ManifoldTransport>
   : public std::false_type
@@ -74,6 +73,5 @@ struct is_valid_physics_combination<eos::Manifold, transport::ConstTransport>
   : public std::true_type
 {
 };
-#endif
 
 } // namespace pele::physics

--- a/Source/Transport/Transport.H
+++ b/Source/Transport/Transport.H
@@ -15,8 +15,6 @@
 #include "Constant.H"
 #include "Simple.H"
 #include "Sutherland.H"
-#ifndef AMREX_USE_SYCL
 #include "Manifold.H"
-#endif
 
 #endif

--- a/Source/Transport/TransportTypes.H
+++ b/Source/Transport/TransportTypes.H
@@ -14,7 +14,7 @@ using TransportType = transport::ConstTransport;
 using TransportType = transport::SimpleTransport;
 #elif USE_SUTHERLAND_TRANSPORT
 using TransportType = transport::SutherlandTransport;
-#elif USE_MANIFOLD_TRANSPORT && !defined(AMREX_USE_SYCL)
+#elif USE_MANIFOLD_TRANSPORT
 using TransportType = transport::ManifoldTransport;
 #else
 static_assert(false, "Invalid Transport specified");

--- a/Source/Utility/BlackBoxFunction/Make.package
+++ b/Source/Utility/BlackBoxFunction/Make.package
@@ -1,6 +1,4 @@
-ifneq ($(USE_SYCL),TRUE)
-  CEXE_sources += BlackBoxFunction.cpp
-endif
+CEXE_sources += BlackBoxFunction.cpp
 
 VPATH_LOCATIONS += $(PELE_PHYSICS_HOME)/Source/Utility/BlackBoxFunction
 INCLUDE_LOCATIONS += $(PELE_PHYSICS_HOME)/Source/Utility/BlackBoxFunction

--- a/Testing/Exec/Make.PelePhysics
+++ b/Testing/Exec/Make.PelePhysics
@@ -61,13 +61,23 @@ endif
 ifeq ($(Eos_Model),$(filter $(Eos_Model),Manifold))
    DEFINES += -DUSE_MANIFOLD_EOS
    DEFINES += -DMANIFOLD_DIM=$(Manifold_Dim)
-   ifeq ($(Manifold_Type),Table)
+   ifeq ($(USE_SYCL),TRUE)
+      # SYCL: Only support Table-only option for now due to virtual function limitations
+      ifneq ($(Manifold_Type),Table)
+         $(warning Compiling with SYCL + Manifold will enforce Manifold_Type = Table)
+      endif
       DEFINES += -DMANIFOLD_EOS_TYPE=1
    else
-      ifeq ($(Manifold_Type),Network)
-         DEFINES += -DMANIFOLD_EOS_TYPE=2
+      # CPU, CUDA, HIP: Can hard code to table or network for performance
+      # default allows either at run time through polymorphism but is less performant
+      ifeq ($(Manifold_Type),Table)
+         DEFINES += -DMANIFOLD_EOS_TYPE=1
       else
-         DEFINES += -DMANIFOLD_EOS_TYPE=0
+         ifeq ($(Manifold_Type),Network)
+            DEFINES += -DMANIFOLD_EOS_TYPE=2
+         else
+            DEFINES += -DMANIFOLD_EOS_TYPE=0
+         endif
       endif
    endif
 endif


### PR DESCRIPTION
The implementation of manifold EOS utilizes virtual functions on device to allow the EOS to use either a table or neural network. At the time of implementation, SYCL did not support virtual functions at all, so `#ifndef AMREX_USE_SYCL` macros were used to prevent compilation of Manifold EOS with SYCL. Since Intel OneAPI 2025.1 there is now support for virtual functions, so the code can now at least compile with SYCL. 

This PR removes the macros and makes some compiling modifications so tests will compile with SYCL. For now, the compilation with SYCL is limited to only using the tabulated version and not the neural network version, which more heavily uses virtual functions. I believe more work will need to be done for the tests to actually run with SYCL and to enable the neural network component. 

More background on virtual functions on device with SYCL: https://www.intel.com/content/www/us/en/developer/articles/technical/sycl-expansion-virtual-functions-and-more.html