### PR TITLE
Add option to loop turbinflow planes in time

### DIFF
--- a/Docs/sphinx/Utility.rst
+++ b/Docs/sphinx/Utility.rst
@@ -88,10 +88,11 @@ provided below. ::
   turbinflow.low.turb_conv_vel  = 5.                      # Velocity to move through the 3rd dimension to simulate time evolution
   turbinflow.low.turb_nplane    = 32                      # Number of planes to read and store at a time
   turbinflow.low.time_offset    = 0.0                     # Offset in time for reading through the 3rd dimension
-  turbinflow.low.verbose        = 0                       # verbosity level
+  turbinflow.low.verbose        = 0                       # Verbosity level
   turbinflow.low.extrap_nonperiodic = 0                   # Allow interpolation near edges of inflow patch where stencil may touch ghost cells
-  turbinflow.low.tile_periodic  = 0                       # cover the entire inflow face by periodically repeating/tiling the inflow patch
-  turbinflow.interp_type        = quadratic               # either quadratic (default) or linear (required if there are nonperiodic directions)
+  turbinflow.low.tile_periodic  = 0                       # Cover the entire inflow face by periodically repeating/tiling the inflow patch
+  turbinflow.low.interp_type    = quadratic               # Either quadratic (default) or linear (required if there are nonperiodic directions)
+  turbinflow.low.time_periodic  = false                   # Specify if the turbinflow data should be repeated in time (default is false)
 
   turbinflow.high.turb_file      = TurbFileHIT/TurbTEST   # All same as above, but for second injection patch
   turbinflow.high.dir            = 1

--- a/Docs/sphinx/Utility.rst
+++ b/Docs/sphinx/Utility.rst
@@ -92,7 +92,7 @@ provided below. ::
   turbinflow.low.extrap_nonperiodic = 0                   # Allow interpolation near edges of inflow patch where stencil may touch ghost cells
   turbinflow.low.tile_periodic  = 0                       # Cover the entire inflow face by periodically repeating/tiling the inflow patch
   turbinflow.low.interp_type    = quadratic               # Either quadratic (default) or linear (required if there are nonperiodic directions)
-  turbinflow.low.time_periodic  = false                   # Specify if the turbinflow data should be repeated in time (default is false)
+  turbinflow.low.time_periodic  = 0                       # Specify if the turbinflow data should be repeated in time, only valid for time varying turbinflow of type "istimeplanes"
 
   turbinflow.high.turb_file      = TurbFileHIT/TurbTEST   # All same as above, but for second injection patch
   turbinflow.high.dir            = 1

--- a/Source/Utility/TurbInflow/turbinflow.H
+++ b/Source/Utility/TurbInflow/turbinflow.H
@@ -45,6 +45,7 @@ struct TurbParm
            // nonperiodic directions
   bool tile_periodic = false; // if true, turbulence is patched over entire face
                               // with a periodic tiled pattern
+  bool time_periodic = true; // if true, turbulence data is looped in time
   TurbInterpType interp_type =
     TurbInterpType::quadratic; // linear required for non-periodic directions
 

--- a/Source/Utility/TurbInflow/turbinflow.H
+++ b/Source/Utility/TurbInflow/turbinflow.H
@@ -38,7 +38,7 @@ struct TurbParm
 
   amrex::IntVect periodicity{AMREX_D_DECL(1, 1, 1)};
   bool istimeplanes = false; // false indicates turb data is periodic normal to
-                            // flow dir, true requires time array in turb data
+                             // flow dir, true requires time array in turb data
 
   bool extrap_nonperiodic =
     false; // if true, allow interpolation where stencil touches ghost cells for

--- a/Source/Utility/TurbInflow/turbinflow.H
+++ b/Source/Utility/TurbInflow/turbinflow.H
@@ -45,7 +45,7 @@ struct TurbParm
            // nonperiodic directions
   bool tile_periodic = false; // if true, turbulence is patched over entire face
                               // with a periodic tiled pattern
-  bool time_periodic = true; // if true, turbulence data is looped in time
+  bool time_periodic = false; // if true, turbulence data is looped in time
   TurbInterpType interp_type =
     TurbInterpType::quadratic; // linear required for non-periodic directions
 

--- a/Source/Utility/TurbInflow/turbinflow.H
+++ b/Source/Utility/TurbInflow/turbinflow.H
@@ -37,7 +37,7 @@ struct TurbParm
   amrex::Real szhi = -1.0e11;        // Position of the current chunk high plane
 
   amrex::IntVect periodicity{AMREX_D_DECL(1, 1, 1)};
-  bool isswirltype = false; // false indicates turb data is periodic normal to
+  bool istimeplanes = false; // false indicates turb data is periodic normal to
                             // flow dir, true requires time array in turb data
 
   bool extrap_nonperiodic =

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -302,7 +302,7 @@ TurbInflow::read_turb_planes(TurbParm& a_tp, amrex::Real z)
     // If time_periodic is enabled, wrap the time value to be within bounds
     if (a_tp.time_periodic) {
       const amrex::Real t_start = a_tp.planeTimes[0];
-      const amrex::Real t_end = a_tp.planeTimes[a_tp.kmax - 1];
+      const amrex::Real t_end = a_tp.planeTimes[a_tp.kmax - 2];
       const amrex::Real period = t_end - t_start;
       if (period > 0.0) {
         // Wrap z to be within [t_start, t_end)
@@ -368,7 +368,7 @@ TurbInflow::fill_turb_plane(
   // If time_periodic is enabled and isswirltype, wrap the time value
   if (a_tp.isswirltype && a_tp.time_periodic && a_tp.kmax > 0) {
     const amrex::Real t_start = a_tp.planeTimes[0];
-    const amrex::Real t_end = a_tp.planeTimes[a_tp.kmax - 1];
+    const amrex::Real t_end = a_tp.planeTimes[a_tp.kmax - 2];
     const amrex::Real period = t_end - t_start;
     if (period > 0.0) {
       // Wrap z to be within [t_start, t_end)

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -47,6 +47,7 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
       pp.query("verbose", tp[n].verbose);
       pp.query("extrap_nonperiodic", tp[n].extrap_nonperiodic);
       pp.query("tile_periodic", tp[n].tile_periodic);
+      pp.query("time_periodic", tp[n].time_periodic);
       pp.query("interp_type", tp[n].interp_type);
       if (tp[n].verbose > 0) {
         amrex::Print() << "Initializing turbInflow " << tp_list[n]
@@ -298,6 +299,19 @@ void
 TurbInflow::read_turb_planes(TurbParm& a_tp, amrex::Real z)
 {
   if (a_tp.isswirltype) {
+    // If time_periodic is enabled, wrap the time value to be within bounds
+    if (a_tp.time_periodic) {
+      const amrex::Real t_start = a_tp.planeTimes[0];
+      const amrex::Real t_end = a_tp.planeTimes[a_tp.kmax - 1];
+      const amrex::Real period = t_end - t_start;
+      if (period > 0.0) {
+        // Wrap z to be within [t_start, t_end)
+        amrex::Real z_wrapped = z - t_start;
+        z_wrapped = z_wrapped - std::floor(z_wrapped / period) * period;
+        z = z_wrapped + t_start;
+      }
+    }
+    
     if (z < a_tp.planeTimes[0] || z >= a_tp.planeTimes[a_tp.kmax - 2]) {
       amrex::Error(
         "TurbInflow::read_turb_planes(): Requested time (" + std::to_string(z) +
@@ -351,6 +365,19 @@ TurbInflow::fill_turb_plane(
   amrex::Real z,
   amrex::FArrayBox& v)
 {
+  // If time_periodic is enabled and isswirltype, wrap the time value
+  if (a_tp.isswirltype && a_tp.time_periodic && a_tp.kmax > 0) {
+    const amrex::Real t_start = a_tp.planeTimes[0];
+    const amrex::Real t_end = a_tp.planeTimes[a_tp.kmax - 1];
+    const amrex::Real period = t_end - t_start;
+    if (period > 0.0) {
+      // Wrap z to be within [t_start, t_end)
+      amrex::Real z_wrapped = z - t_start;
+      z_wrapped = z_wrapped - std::floor(z_wrapped / period) * period;
+      z = z_wrapped + t_start;
+    }
+  }
+  
   const amrex::Real tplanes_lo = a_tp.szlo;
   const amrex::Real tplanes_hi = a_tp.szhi;
 

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -311,7 +311,7 @@ TurbInflow::read_turb_planes(TurbParm& a_tp, amrex::Real z)
         z = z_wrapped + t_start;
       }
     }
-    
+
     if (z < a_tp.planeTimes[0] || z >= a_tp.planeTimes[a_tp.kmax - 2]) {
       amrex::Error(
         "TurbInflow::read_turb_planes(): Requested time (" + std::to_string(z) +
@@ -377,7 +377,7 @@ TurbInflow::fill_turb_plane(
       z = z_wrapped + t_start;
     }
   }
-  
+
   const amrex::Real tplanes_lo = a_tp.szlo;
   const amrex::Real tplanes_hi = a_tp.szhi;
 

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -90,7 +90,7 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
         >> tp[n].periodicity[2]); // Will use zperiodicity to single whether
                                   // using periodic or time per plane mode
 
-      tp[n].isswirltype = AMREX_D_PICK(, false, tp[n].periodicity[2] == 0);
+      tp[n].istimeplanes = AMREX_D_PICK(, false, tp[n].periodicity[2] == 0);
       if (tp[n].periodicity[0] == 0 || tp[n].periodicity[1] == 0) {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
           tp[n].interp_type == TurbInterpType::linear,
@@ -124,7 +124,7 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
         , tp[n].pboxlo[2] = 0.0;)
 
       // Swirl type: we can't load more planes than are available
-      if (tp[n].isswirltype) {
+      if (tp[n].istimeplanes) {
         tp[n].nplane = AMREX_D_PICK(
           tp[n].nplane, tp[n].nplane, amrex::min<int>(tp[n].nplane, npts[2]));
       }
@@ -144,7 +144,7 @@ TurbInflow::init(amrex::Geometry const& /*geom*/)
         is >> off;
       }
 
-      if (tp[n].isswirltype) {
+      if (tp[n].istimeplanes) {
         tp[n].planeTimes.resize(tp[n].kmax);
         for (int i = 0; i < tp[n].kmax; i++) {
           is >> tp[n].planeTimes[i]; // Time for each plane
@@ -211,7 +211,7 @@ TurbInflow::add_turb(
       // Get the turbulence
       amrex::Real z =
         (time + tpn.time_shift) *
-        (tpn.isswirltype ? 1 : tpn.turb_conv_vel * tpn.turb_scale_loc);
+        (tpn.istimeplanes ? 1 : tpn.turb_conv_vel * tpn.turb_scale_loc);
       fill_turb_plane(tpn, x, y, z, v);
     }
   }
@@ -298,7 +298,7 @@ TurbInflow::read_one_turb_plane(TurbParm& a_tp, int iplane, int k)
 void
 TurbInflow::read_turb_planes(TurbParm& a_tp, amrex::Real z)
 {
-  if (a_tp.isswirltype) {
+  if (a_tp.istimeplanes) {
     // If time_periodic is enabled, wrap the time value to be within bounds
     if (a_tp.time_periodic) {
       const amrex::Real t_start = a_tp.planeTimes[0];
@@ -339,7 +339,7 @@ TurbInflow::read_turb_planes(TurbParm& a_tp, amrex::Real z)
                 a_tp.dx[2]; // need one plane forward in time for interpolating
   }
   if (a_tp.verbose > 1) {
-    std::string varname = a_tp.isswirltype ? "t" : "z";
+    std::string varname = a_tp.istimeplanes ? "t" : "z";
     amrex::Print() << "read_turb_planes filling " << a_tp.izlo << " to "
                    << a_tp.izhi << std::endl
                    << " --> now have interp data for range [" << a_tp.szlo
@@ -349,7 +349,7 @@ TurbInflow::read_turb_planes(TurbParm& a_tp, amrex::Real z)
 
   for (int iplane = 0; iplane < a_tp.nplane; ++iplane) {
     int k = a_tp.izlo + iplane;
-    if (!a_tp.isswirltype) {
+    if (!a_tp.istimeplanes) {
       k = (a_tp.npboxcells[2] + k) %
           a_tp.npboxcells[2]; // "wrap" planes if data is periodic
     }
@@ -365,8 +365,8 @@ TurbInflow::fill_turb_plane(
   amrex::Real z,
   amrex::FArrayBox& v)
 {
-  // If time_periodic is enabled and isswirltype, wrap the time value
-  if (a_tp.isswirltype && a_tp.time_periodic && a_tp.kmax > 0) {
+  // If time_periodic is enabled and istimeplanes, wrap the time value
+  if (a_tp.istimeplanes && a_tp.time_periodic && a_tp.kmax > 0) {
     const amrex::Real t_start = a_tp.planeTimes[0];
     const amrex::Real t_end = a_tp.planeTimes[a_tp.kmax - 2];
     const amrex::Real period = t_end - t_start;
@@ -383,7 +383,7 @@ TurbInflow::fill_turb_plane(
 
   if ((z < tplanes_lo) || (z >= tplanes_hi)) {
     if (a_tp.verbose > 1) {
-      std::string varname = a_tp.isswirltype ? "t" : "z";
+      std::string varname = a_tp.istimeplanes ? "t" : "z";
       amrex::Print() << "Reading new data because " << varname << " = " << z
                      << " is outside the range [" << tplanes_lo << ", "
                      << tplanes_hi << ")" << std::endl;
@@ -419,7 +419,7 @@ TurbInflow::fill_turb_plane(
   const bool lininterp = a_tp.interp_type == TurbInterpType::linear;
   amrex::Real cz[3];
   int k0 = -1;
-  if (a_tp.isswirltype) {
+  if (a_tp.istimeplanes) {
     AMREX_ALWAYS_ASSERT(
       z >= a_tp.planeTimes[a_tp.izlo] && z <= a_tp.planeTimes[a_tp.izhi]);
     for (k0 = 1; k0 < a_tp.nplane - 2 && a_tp.planeTimes[a_tp.izlo + k0] <= z;


### PR DESCRIPTION
This PR adds a flag `turbinflow.__.time_periodic`, which enables users to loop turbinflow planes periodically in time. 