### PR TITLE
Fix volume used  in 2D spray_density calculation  

### DIFF
--- a/Source/Spray/SprayDerive.cpp
+++ b/Source/Spray/SprayDerive.cpp
@@ -18,7 +18,11 @@ SprayParticleContainer::computeDerivedVars(
   const RealVect dxi(AMREX_D_DECL(dxiarr[0], dxiarr[1], dxiarr[2]));
   const RealVect dx(AMREX_D_DECL(dxarr[0], dxarr[1], dxarr[2]));
   const RealVect plo(AMREX_D_DECL(ploarr[0], ploarr[1], ploarr[2]));
-  const Real cell_vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
+  Real cell_vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
+#if AMREX_SPACEDIM == 2
+  // Spray model in 2D assumes narrow domain in z-direction (Lz = dx)
+  cell_vol *= dx[0];
+#endif
 #ifdef AMREX_USE_EB
   const auto& factory =
     dynamic_cast<EBFArrayBoxFactory const&>(mf_var.Factory());

--- a/Source/Spray/SprayDerive.cpp
+++ b/Source/Spray/SprayDerive.cpp
@@ -18,11 +18,7 @@ SprayParticleContainer::computeDerivedVars(
   const RealVect dxi(AMREX_D_DECL(dxiarr[0], dxiarr[1], dxiarr[2]));
   const RealVect dx(AMREX_D_DECL(dxarr[0], dxarr[1], dxarr[2]));
   const RealVect plo(AMREX_D_DECL(ploarr[0], ploarr[1], ploarr[2]));
-  Real cell_vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
-#if AMREX_SPACEDIM == 2
-  // Spray model in 2D assumes narrow domain in z-direction (Lz = dx)
-  cell_vol *= dx[0];
-#endif
+  const Real cell_vol = AMREX_D_PICK(dx[0]*dx[0]*dx[0], dx[0]*dx[1]*dx[0], dx[0]*dx[1]*dx[2]);
 #ifdef AMREX_USE_EB
   const auto& factory =
     dynamic_cast<EBFArrayBoxFactory const&>(mf_var.Factory());

--- a/Source/Spray/SprayDerive.cpp
+++ b/Source/Spray/SprayDerive.cpp
@@ -18,7 +18,8 @@ SprayParticleContainer::computeDerivedVars(
   const RealVect dxi(AMREX_D_DECL(dxiarr[0], dxiarr[1], dxiarr[2]));
   const RealVect dx(AMREX_D_DECL(dxarr[0], dxarr[1], dxarr[2]));
   const RealVect plo(AMREX_D_DECL(ploarr[0], ploarr[1], ploarr[2]));
-  const Real cell_vol = AMREX_D_PICK(dx[0]*dx[0]*dx[0], dx[0]*dx[1]*dx[0], dx[0]*dx[1]*dx[2]);
+  const Real cell_vol = AMREX_D_PICK(
+    dx[0] * dx[0] * dx[0], dx[0] * dx[1] * dx[0], dx[0] * dx[1] * dx[2]);
 #ifdef AMREX_USE_EB
   const auto& factory =
     dynamic_cast<EBFArrayBoxFactory const&>(mf_var.Factory());

--- a/Source/Spray/SprayParticles.cpp
+++ b/Source/Spray/SprayParticles.cpp
@@ -219,7 +219,8 @@ SprayParticleContainer::updateParticles(
     }
   }
   // Spray model in 2D assumes narrow domain in z-direction (Lz = dx)
-  const Real vol = AMREX_D_PICK(dx[0]*dx[0]*dx[0], dx[0]*dx[1]*dx[0], dx[0]*dx[1]*dx[2]);
+  const Real vol = AMREX_D_PICK(
+    dx[0] * dx[0] * dx[0], dx[0] * dx[1] * dx[0], dx[0] * dx[1] * dx[2]);
   const Real inv_vol = 1. / vol;
   // If particle subcycling is being done, determine the number of subcycles
   // Note: this is different than the AMR subcycling

--- a/Source/Spray/SprayParticles.cpp
+++ b/Source/Spray/SprayParticles.cpp
@@ -218,11 +218,8 @@ SprayParticleContainer::updateParticles(
       bndry_hi[dir] = 0;
     }
   }
-  Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
-#if AMREX_SPACEDIM == 2
   // Spray model in 2D assumes narrow domain in z-direction (Lz = dx)
-  vol *= dx[0];
-#endif
+  const Real vol = AMREX_D_PICK(dx[0]*dx[0]*dx[0], dx[0]*dx[1]*dx[0], dx[0]*dx[1]*dx[2]);
   const Real inv_vol = 1. / vol;
   // If particle subcycling is being done, determine the number of subcycles
   // Note: this is different than the AMR subcycling


### PR DESCRIPTION
In 2D, the spray source-term coupling in `SprayParticles.cpp` treats the domain as a thin slab with `Lz = dx[0]`, using `V_slab = dx[0] * dx[0] * dx[1]`. The `computeDerivedVars` computation in `SprayDerive.cpp` was using only the 2D cell area `dx[0] * dx[1]`, causing `spray_density` and `spray_vol_frac` to be overestimated by a factor of `dx[0]` in plotfiles. This applies the same correction to cell volume in `computeDerivedVars` so diagnostic fields are consistent with the source-term coupling.