### PR TITLE
Make CEPTR code generation fully deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11']
         poetry-version: ['1.4.2']
+    env:
+      PYTHONHASHSEED: 0
     defaults:
       run:
         working-directory: ${{github.workspace}}/Support/ceptr

--- a/Support/ceptr/ceptr/qssa_reduction.py
+++ b/Support/ceptr/ceptr/qssa_reduction.py
@@ -166,7 +166,7 @@ def identify_qssa_coupling(mechanism, qssa_species):
             if sum_coeff > 1:
                 qssa_problematic += qssa_species_involved
 
-    return list(set(qssa_problematic))
+    return sorted(set(qssa_problematic))
 
 
 def visualize_qssa(mechanism, reaction_info, qssa_species):

--- a/Support/ceptr/ceptr/species_info.py
+++ b/Support/ceptr/ceptr/species_info.py
@@ -89,7 +89,9 @@ class SpeciesInfo:
         self.dict_qssdepend_kr = {}
         self.sc_qss_chain_stop = []
         for symbol in self.dict_qss_species:
-            free_symb = syms.sc_qss_smp[self.dict_qss_species[symbol]].free_symbols
+            free_symb = sorted(
+                syms.sc_qss_smp[self.dict_qss_species[symbol]].free_symbols, key=str
+            )
             qss_symb = []
             sc_symb = []
             g_rt_qss_symb = []
@@ -129,7 +131,9 @@ class SpeciesInfo:
         self.dict_nonqssdepend_kf = {}
         self.dict_nonqssdepend_kr = {}
         for symbol in self.dict_nonqss_species:
-            free_symb = syms.sc_smp[self.dict_nonqss_species[symbol]].free_symbols
+            free_symb = sorted(
+                syms.sc_smp[self.dict_nonqss_species[symbol]].free_symbols, key=str
+            )
             qss_symb = []
             sc_symb = []
             g_rt_qss_symb = []
@@ -167,7 +171,7 @@ class SpeciesInfo:
             if isinstance(symbolic_wdot, float):
                 free_symb = []
             else:
-                free_symb = symbolic_wdot.free_symbols
+                free_symb = sorted(symbolic_wdot.free_symbols, key=str)
 
             qss_symb = []
             sc_symb = []

--- a/Support/ceptr/ceptr/symbolic_math.py
+++ b/Support/ceptr/ceptr/symbolic_math.py
@@ -1192,7 +1192,7 @@ class SymbolicMath:
 
     def compute_spec_dependencies(self, sym_smp):
         """Routine to compute the sc and sc_qss dependencies."""
-        free_symb = sym_smp.free_symbols
+        free_symb = sorted(sym_smp.free_symbols, key=str)
         sc_depend = []
         scqss_depend = []
         for symbol in free_symb:

--- a/Support/ceptr/ceptr/utilities.py
+++ b/Support/ceptr/ceptr/utilities.py
@@ -9,7 +9,7 @@ import ceptr.constants as cc
 
 def intersection(lst1, lst2):
     """Return intersection of two lists."""
-    return list(set(lst1).intersection(lst2))
+    return sorted(set(lst1).intersection(lst2))
 
 
 def sc_cutoff(exponent):


### PR DESCRIPTION
## Summary

CEPTR code generation can produce trivially different (but equivalent) output
across runs when `PYTHONHASHSEED` varies, causing the CI diff-check to flag
spurious changes, as mentioned in #659 . This PR aims to fix the sources of non-determinism in the generator:

- `intersection()` in `utilities.py`: replace `list(set(...))` with `sorted(...)`
- `identify_qssa_coupling()` in `qssa_reduction.py`: same fix for the deduplication step
- `free_symbols` iterations in `species_info.py` and `symbolic_math.py`: sort by `str` before iterating
- CI `CEPTR` job: set `PYTHONHASHSEED: 0` to fix SymEngine CSE variable numbering,
  which otherwise varies with Python's hash randomization

All four existing tests pass.

---

Co-authored by: Claude Sonnet 4.6 <noreply@anthropic.com>