### PR TITLE
Compute convected_distance as time-integrated inlet velocity

### DIFF
--- a/Source/Utility/TurbInflow/turbinflow.H
+++ b/Source/Utility/TurbInflow/turbinflow.H
@@ -55,6 +55,11 @@ struct TurbParm
   amrex::Real turb_conv_vel =
     1.; // Mean inlet velocity, used to move through data planes
 
+  amrex::Real convected_distance =
+    -1.; // If >= 0, used directly as the through-plane sampling position
+         // (physical convected distance, e.g. the time integral of the inlet
+         // velocity), bypassing turb_conv_vel * time. Negative => disabled.
+
   amrex::Vector<amrex::Real> planeTimes;
 
   amrex::Vector<long> offset;
@@ -80,6 +85,17 @@ public:
     const amrex::Orientation::Side& side);
 
   bool is_initialized() const { return turbinflow_initialized; }
+
+  // Override the through-plane sampling position with a supplied physical
+  // convected distance (e.g. the time-integrated inlet velocity). Applies to
+  // all loaded turb planes. Pass a negative value to revert to the default
+  // turb_conv_vel * time behavior.
+  void set_convected_distance(amrex::Real dist)
+  {
+    for (auto& t : tp) {
+      t.convected_distance = dist;
+    }
+  }
 
   static void read_turb_planes(TurbParm& a_tp, amrex::Real z);
 

--- a/Source/Utility/TurbInflow/turbinflow.cpp
+++ b/Source/Utility/TurbInflow/turbinflow.cpp
@@ -209,9 +209,16 @@ TurbInflow::add_turb(
       }
 
       // Get the turbulence
-      amrex::Real z =
-        (time + tpn.time_shift) *
-        (tpn.istimeplanes ? 1 : tpn.turb_conv_vel * tpn.turb_scale_loc);
+      amrex::Real z;
+      if (tpn.istimeplanes) {
+        z = time + tpn.time_shift;
+      } else if (tpn.convected_distance >= 0.0) {
+        // Through-plane position supplied as a physical convected distance
+        // (e.g. the time-integrated inlet velocity); turb_conv_vel is bypassed.
+        z = tpn.convected_distance * tpn.turb_scale_loc;
+      } else {
+        z = (time + tpn.time_shift) * tpn.turb_conv_vel * tpn.turb_scale_loc;
+      }
       fill_turb_plane(tpn, x, y, z, v);
     }
   }


### PR DESCRIPTION
Generalize the available methods to compute the location in the turbulence file from which to interpolate boundary data.  The former, turb_conv_vel * time, assumes turb_conv_vel has been constant from the start of the run.  This mod uses the history of turb_conv_vel, adjusted for example over time by the flow controller, to compute the proper integral and make it available for the users at the time of BC setting.